### PR TITLE
Opt-in public directory of scanned sites + dofollow backlinks

### DIFF
--- a/packages/web/API.md
+++ b/packages/web/API.md
@@ -228,30 +228,37 @@ tier · dofollow link out · link to its scan). `?sort=slop` ranks sloppiest-fir
 
 ### `GET /api/sites`
 
-JSON view of the same directory.
+JSON view of the same directory, **globally sorted** so it matches `/directory`
+exactly (the whole catalogue is enumerated and ordered before slicing).
 
-| Query    | Notes                                                        |
-|----------|--------------------------------------------------------------|
-| `sort`   | `clean` (default) or `slop`.                                 |
-| `limit`  | 1–500, default 200.                                          |
-| `cursor` | Opaque cursor from a previous response for the next page.    |
+| Query   | Notes                                                |
+|---------|------------------------------------------------------|
+| `sort`  | `clean` (default) or `slop`.                         |
+| `limit` | Cap rows returned after sorting (1–1000, default 500). |
 
 **Response** `200`:
 
 ```json
 {
   "count": 2,
+  "returned": 2,
   "sort": "clean",
-  "complete": true,
-  "cursor": null,
   "sites": [
     { "domain": "example.com", "url": "https://example.com", "score": 8, "grade": "A-", "tier": "Clean", "id": "ab12cd34", "title": "Example", "listedAt": "..." }
   ]
 }
 ```
 
-`score`/`grade`/`tier` are `null` for a domain that was listed but not yet
-scored (filled in on its next scan). Public, no key, short-cached.
+`count` is the full directory size; `returned` is how many rows this response
+carries (after `limit`). `score`/`grade`/`tier` are `null` for a domain that was
+listed but not yet scored (filled in on its next scan). Public, no key,
+short-cached.
+
+> **Ownership:** once a domain is claimed (first `POST /api/watch`), only the
+> same `email` may modify it — change the alert address, list/delist, or
+> re-baseline. A different email gets `403`. (A brand-new domain can be claimed
+> by anyone with an email; verified ownership via a DNS TXT / meta tag is a
+> documented follow-up.)
 
 ---
 

--- a/packages/web/API.md
+++ b/packages/web/API.md
@@ -156,7 +156,10 @@ so a signup form works without a captcha.
 |---------------|---------|----------|--------------------------------------------------------------|
 | `domain`      | string  | yes      | Bare domain. A scheme/`www.`/path is stripped; must be a real hostname. |
 | `email`       | string  | yes      | Where regression alerts will go (validation phase: captured, not yet sent). |
-| `unsubscribe` | boolean | no       | If `true`, stops monitoring (requires the matching `email`). |
+| `list`        | boolean | no       | `true` lists the domain in the public [directory](#public-directory) (dofollow backlink); `false` delists it; omit to keep the current state. |
+| `unsubscribe` | boolean | no       | If `true`, stops monitoring **and** delists (requires the matching `email`). |
+
+The response echoes `listed` and, when listed, a `directoryUrl`.
 
 **Response** `201` (new) / `200` (already monitored):
 
@@ -205,6 +208,50 @@ react in-line.
 > score dropped" email. The validation build captures intent + the email and
 > proves regression detection on real scan data; automated re-checks + delivery
 > are the next step.
+
+---
+
+## Public directory
+
+An **opt-in** catalogue of scanned sites. A domain appears **only** when its
+owner lists it via `POST /api/watch { list: true }` — never from an anonymous
+scan — so we never publish a verdict on a company that didn't ask to be there.
+Listed sites get a real (dofollow) backlink from the directory page; that
+backlink is the incentive that pulls owners into the claim + monitor funnel.
+A listed domain's entry auto-refreshes whenever it's re-scanned.
+
+### `GET /directory`
+
+Server-rendered, crawlable HTML page listing every opt-in site (grade · score ·
+tier · dofollow link out · link to its scan). `?sort=slop` ranks sloppiest-first
+(default: cleanest-first). Emits `ItemList` JSON-LD and is in the sitemap. Public.
+
+### `GET /api/sites`
+
+JSON view of the same directory.
+
+| Query    | Notes                                                        |
+|----------|--------------------------------------------------------------|
+| `sort`   | `clean` (default) or `slop`.                                 |
+| `limit`  | 1–500, default 200.                                          |
+| `cursor` | Opaque cursor from a previous response for the next page.    |
+
+**Response** `200`:
+
+```json
+{
+  "count": 2,
+  "sort": "clean",
+  "complete": true,
+  "cursor": null,
+  "sites": [
+    { "domain": "example.com", "url": "https://example.com", "score": 8, "grade": "A-", "tier": "Clean", "id": "ab12cd34", "title": "Example", "listedAt": "..." }
+  ]
+}
+```
+
+`score`/`grade`/`tier` are `null` for a domain that was listed but not yet
+scored (filled in on its next scan). Public, no key, short-cached.
 
 ---
 

--- a/packages/web/functions/_shared.js
+++ b/packages/web/functions/_shared.js
@@ -304,6 +304,12 @@ export async function recordScanForWatch(kv, slim) {
   if (!regressed) watch.notified = false;
   await putWatch(kv, watch);
 
+  // If the domain opted into the public directory, refresh its listing so the
+  // catalogue tracks the latest score (best-effort — never break a scan).
+  if (watch.listed) {
+    try { await setListing(kv, slim); } catch (_) { /* listing is best-effort */ }
+  }
+
   return {
     watched: true,
     regressed,
@@ -318,6 +324,7 @@ export function publicWatch(watch, history) {
   return {
     domain: watch.domain,
     monitoring: true,
+    listed: !!watch.listed,
     plan: watch.plan || 'trial',
     createdAt: watch.createdAt,
     baseline: watch.baselineScore == null ? null : {
@@ -333,6 +340,100 @@ export function publicWatch(watch, history) {
       score: h.score, grade: h.grade, tier: h.tier, at: h.createdAt
     }))
   };
+}
+
+// ── Public directory of scanned sites (opt-in — see VALIDATION.md) ────────────
+// A site is listed ONLY when its owner opts in via the claim/monitor flow
+// (POST /api/watch { list: true }) — never from an anonymous scan, so we never
+// publish a verdict on a company that didn't ask to be there (a ROADMAP
+// guardrail). Listed sites get a real (dofollow) backlink from /directory: the
+// catalogue ranks in search, links out to each site, and the backlink is the
+// incentive that drives owners to claim + monitor.
+//
+// Storage (RESULTS KV): l:<domain> → full listing record, with a compact display
+// summary in the key's METADATA so the directory enumerates in one list() call
+// without a per-row read.
+const LISTING_TTL = 60 * 60 * 24 * 365;  // 1 year
+
+function listingMeta(record) {
+  return {
+    s: record.score, g: record.grade, tr: record.tier,
+    id: record.id, t: (record.title || '').slice(0, 60), at: record.listedAt
+  };
+}
+
+export async function getListing(kv, domain) {
+  if (!kv || !domain) return null;
+  const raw = await kv.get(`l:${domain}`);
+  return raw ? JSON.parse(raw) : null;
+}
+
+// Create or refresh a listing from a slim scan result. Preserves the original
+// listedAt across refreshes so the directory can show "listed since".
+export async function setListing(kv, slim) {
+  if (!kv || !slim?.domain) return null;
+  const domain = slim.domain;
+  const existing = await getListing(kv, domain);
+  const record = {
+    domain,
+    url: `https://${domain}`,
+    score: slim.score ?? null,
+    grade: slim.grade ?? null,
+    tier: slim.tier ?? null,
+    id: slim.id ?? existing?.id ?? null,
+    title: slim.title ?? existing?.title ?? null,
+    verdict: slim.verdict ?? existing?.verdict ?? null,
+    listedAt: existing?.listedAt || new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  };
+  await kv.put(`l:${domain}`, JSON.stringify(record), {
+    expirationTtl: LISTING_TTL,
+    metadata: listingMeta(record)
+  });
+  return record;
+}
+
+export async function deleteListing(kv, domain) {
+  if (!kv || !domain) return;
+  await kv.delete(`l:${domain}`);
+}
+
+// Enumerate the directory from KV list metadata (cheap — no per-row get).
+// Returns { sites, cursor, complete }. `cursor` paginates the raw KV scan.
+export async function listSites(kv, { limit = 200, cursor = null } = {}) {
+  if (!kv) return { sites: [], cursor: null, complete: true };
+  const res = await kv.list({ prefix: 'l:', limit, cursor: cursor || undefined });
+  const sites = (res.keys || []).map(k => {
+    const m = k.metadata || {};
+    const domain = k.name.replace(/^l:/, '');
+    return {
+      domain,
+      url: `https://${domain}`,
+      score: m.s ?? null,
+      grade: m.g ?? null,
+      tier: m.tr ?? null,
+      id: m.id ?? null,
+      title: m.t || null,
+      listedAt: m.at || null
+    };
+  });
+  return {
+    sites,
+    cursor: res.list_complete ? null : (res.cursor || null),
+    complete: !!res.list_complete
+  };
+}
+
+// Walk the whole directory (paginates internally). Fine at validation scale.
+export async function listAllSites(kv) {
+  const out = [];
+  let cursor = null;
+  do {
+    const r = await listSites(kv, { limit: 1000, cursor });
+    out.push(...r.sites);
+    cursor = r.cursor;
+  } while (cursor);
+  return out;
 }
 
 // ── Tier → color ──────────────────────────────────────────────────────────────

--- a/packages/web/functions/_shared.js
+++ b/packages/web/functions/_shared.js
@@ -304,11 +304,14 @@ export async function recordScanForWatch(kv, slim) {
   if (!regressed) watch.notified = false;
   await putWatch(kv, watch);
 
-  // If the domain opted into the public directory, refresh its listing so the
-  // catalogue tracks the latest score (best-effort — never break a scan).
-  if (watch.listed) {
-    try { await setListing(kv, slim); } catch (_) { /* listing is best-effort */ }
-  }
+  // Reconcile the derived directory row with the watch (the source of truth):
+  // refresh it with the latest score if the domain is listed, or remove a stale
+  // row if it was delisted but a previous delete didn't land. Best-effort —
+  // never break a scan over the directory.
+  try {
+    if (watch.listed) await setListing(kv, slim);
+    else await deleteListing(kv, slim.domain);
+  } catch (_) { /* directory row is derived; reconciled on a later scan */ }
 
   return {
     watched: true,

--- a/packages/web/functions/api/sites.js
+++ b/packages/web/functions/api/sites.js
@@ -1,0 +1,44 @@
+// GET /api/sites — the public directory of opt-in scanned sites (JSON).
+//
+// Only domains whose owners opted in via the claim/monitor flow
+// (POST /api/watch { list: true }) appear here — see VALIDATION.md. Powers the
+// crawlable /directory page and any external embed. Public, no key (GET routes
+// aren't gated by the middleware).
+//
+//   GET /api/sites                 → up to `limit` listings (cursor-paginated)
+//   GET /api/sites?sort=slop       → sloppiest first (default: cleanest first)
+//   GET /api/sites?cursor=<cursor> → next page of the raw KV scan
+
+import { listSites } from '../_shared.js';
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      // Short edge cache — the directory changes only when someone lists/rescans.
+      'Cache-Control': 'public, max-age=120, s-maxage=120'
+    }
+  });
+}
+
+export async function onRequestGet({ request, env }) {
+  if (!env.RESULTS) return json({ error: 'directory storage unavailable' }, 503);
+
+  const u = new URL(request.url);
+  const cursor = u.searchParams.get('cursor');
+  const sort = u.searchParams.get('sort') === 'slop' ? 'slop' : 'clean';
+  const limit = Math.min(500, Math.max(1, parseInt(u.searchParams.get('limit') || '200', 10) || 200));
+
+  const { sites, cursor: next, complete } = await listSites(env.RESULTS, { limit, cursor });
+
+  // Sort within the returned page. A score of null (listed but not yet scored)
+  // sinks to the end either way.
+  const ranked = sites.slice().sort((a, b) => {
+    const sa = a.score == null ? Infinity : a.score;
+    const sb = b.score == null ? Infinity : b.score;
+    return sort === 'slop' ? sb - sa : sa - sb;
+  });
+
+  return json({ count: ranked.length, sort, complete, cursor: next, sites: ranked });
+}

--- a/packages/web/functions/api/sites.js
+++ b/packages/web/functions/api/sites.js
@@ -5,11 +5,11 @@
 // crawlable /directory page and any external embed. Public, no key (GET routes
 // aren't gated by the middleware).
 //
-//   GET /api/sites                 → up to `limit` listings (cursor-paginated)
-//   GET /api/sites?sort=slop       → sloppiest first (default: cleanest first)
-//   GET /api/sites?cursor=<cursor> → next page of the raw KV scan
+//   GET /api/sites             → all listings, globally sorted (cleanest first)
+//   GET /api/sites?sort=slop   → sloppiest first
+//   GET /api/sites?limit=50    → cap the number of rows returned (after sorting)
 
-import { listSites } from '../_shared.js';
+import { listAllSites } from '../_shared.js';
 
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -26,19 +26,21 @@ export async function onRequestGet({ request, env }) {
   if (!env.RESULTS) return json({ error: 'directory storage unavailable' }, 503);
 
   const u = new URL(request.url);
-  const cursor = u.searchParams.get('cursor');
   const sort = u.searchParams.get('sort') === 'slop' ? 'slop' : 'clean';
-  const limit = Math.min(500, Math.max(1, parseInt(u.searchParams.get('limit') || '200', 10) || 200));
+  const limit = Math.min(1000, Math.max(1, parseInt(u.searchParams.get('limit') || '500', 10) || 500));
 
-  const { sites, cursor: next, complete } = await listSites(env.RESULTS, { limit, cursor });
-
-  // Sort within the returned page. A score of null (listed but not yet scored)
-  // sinks to the end either way.
-  const ranked = sites.slice().sort((a, b) => {
+  // Enumerate the whole directory and sort GLOBALLY so the JSON view matches the
+  // /directory page exactly (a per-page sort would diverge once there are more
+  // listings than one KV page). Fine at validation scale; revisit if the
+  // catalogue grows past a few thousand. A null score (listed, not yet scored)
+  // always sinks to the end.
+  const all = await listAllSites(env.RESULTS);
+  all.sort((a, b) => {
     const sa = a.score == null ? Infinity : a.score;
     const sb = b.score == null ? Infinity : b.score;
     return sort === 'slop' ? sb - sa : sa - sb;
   });
 
-  return json({ count: ranked.length, sort, complete, cursor: next, sites: ranked });
+  const sites = all.slice(0, limit);
+  return json({ count: all.length, returned: sites.length, sort, sites });
 }

--- a/packages/web/functions/api/watch.js
+++ b/packages/web/functions/api/watch.js
@@ -72,13 +72,29 @@ export async function onRequestPost({ request, env }) {
     if (existing.email !== email) {
       return json({ error: 'email does not match the subscriber for this domain' }, 403);
     }
-    await deleteWatch(env.RESULTS, domain);
+    // Delist BEFORE removing the watch: if the listing delete throws we keep the
+    // watch, so the state stays consistent ("still monitored + listed") and
+    // retryable rather than orphaning a public row with no owner.
     if (existing.listed) await deleteListing(env.RESULTS, domain);
+    await deleteWatch(env.RESULTS, domain);
     return json({ domain, monitoring: false, unsubscribed: true });
   }
 
   // ── Subscribe (idempotent) ───────────────────────────────────────────────────
   const existing = await getWatch(env.RESULTS, domain);
+
+  // Ownership guard: once a domain is claimed, only the same email may modify it
+  // (change the alert address, list/delist, re-baseline). Without this, any
+  // caller could take over an existing watch or list/delist someone else's
+  // domain. A brand-new domain can still be claimed by anyone with an email —
+  // verified ownership (DNS TXT / meta tag) is a documented follow-up; this just
+  // stops hijacking of an already-claimed domain.
+  if (existing && existing.email !== email) {
+    return json({
+      error: 'this domain is already claimed by a different email; contact that owner to make changes'
+    }, 403);
+  }
+
   const now = new Date().toISOString();
 
   // Seed the baseline from the domain's most recent public scan if one exists,
@@ -98,7 +114,6 @@ export async function onRequestPost({ request, env }) {
   const watch = {
     domain,
     email,
-    listed,
     plan: existing?.plan || 'trial',
     createdAt: existing?.createdAt || now,
     updatedAt: now,
@@ -112,23 +127,31 @@ export async function onRequestPost({ request, env }) {
     lastTier:  existing?.lastTier  ?? latest?.tier  ?? null,
     lastId:    existing?.lastId    ?? latest?.id    ?? null,
     lastCheckedAt: existing?.lastCheckedAt ?? latest?.createdAt ?? null,
+    listed,
     regressed: existing?.regressed ?? false,
     notified:  existing?.notified  ?? false
   };
-  await putWatch(env.RESULTS, watch);
 
-  // Reflect the listing choice in the directory. List from the best score we
-  // have (the latest scan); a never-scanned domain lists as "pending" and is
-  // filled in on its next scan via recordScanForWatch.
-  if (listed) {
-    const seed = latest || {
-      domain, score: watch.lastScore, grade: watch.lastGrade,
-      tier: watch.lastTier, id: watch.lastId, title: null
-    };
-    await setListing(env.RESULTS, seed).catch(() => {});
-  } else if (existing?.listed) {
-    await deleteListing(env.RESULTS, domain).catch(() => {});
-  }
+  // The WATCH is the source of truth; the directory row is derived state.
+  // Persist the watch FIRST so a public row can never exist without an owner
+  // (an orphan row can't be delisted via the email-gated flow — strictly worse
+  // than a missing row). Then reconcile the row to match. The reconcile is
+  // best-effort: every scan rebuilds OR removes the row from `watch.listed`
+  // (recordScanForWatch), so a transient KV hiccup here self-heals and never
+  // strands a row. List from the best score we have; a never-scanned domain
+  // lists as "pending", filled in on its next scan.
+  await putWatch(env.RESULTS, watch);
+  try {
+    if (listed) {
+      const seed = latest || {
+        domain, score: watch.lastScore, grade: watch.lastGrade,
+        tier: watch.lastTier, id: watch.lastId, title: null
+      };
+      await setListing(env.RESULTS, seed);
+    } else if (existing?.listed) {
+      await deleteListing(env.RESULTS, domain);
+    }
+  } catch (_) { /* derived row — reconciled on the domain's next scan */ }
 
   const history = await getHistory(env.RESULTS, domain);
   return json({

--- a/packages/web/functions/api/watch.js
+++ b/packages/web/functions/api/watch.js
@@ -74,8 +74,9 @@ export async function onRequestPost({ request, env }) {
     }
     // Delist BEFORE removing the watch: if the listing delete throws we keep the
     // watch, so the state stays consistent ("still monitored + listed") and
-    // retryable rather than orphaning a public row with no owner.
-    if (existing.listed) await deleteListing(env.RESULTS, domain);
+    // retryable rather than orphaning a public row with no owner. Always attempt
+    // cleanup even if the watch shows listed:false, to recover from failed deletes.
+    await deleteListing(env.RESULTS, domain);
     await deleteWatch(env.RESULTS, domain);
     return json({ domain, monitoring: false, unsubscribed: true });
   }
@@ -148,7 +149,7 @@ export async function onRequestPost({ request, env }) {
         tier: watch.lastTier, id: watch.lastId, title: null
       };
       await setListing(env.RESULTS, seed);
-    } else if (existing?.listed) {
+    } else if (!listed) {
       await deleteListing(env.RESULTS, domain);
     }
   } catch (_) { /* derived row — reconciled on the domain's next scan */ }

--- a/packages/web/functions/api/watch.js
+++ b/packages/web/functions/api/watch.js
@@ -22,7 +22,9 @@ import {
   deleteWatch,
   getHistory,
   getLatestForDomain,
-  publicWatch
+  publicWatch,
+  setListing,
+  deleteListing
 } from '../_shared.js';
 
 function json(data, status = 200) {
@@ -63,7 +65,7 @@ export async function onRequestPost({ request, env }) {
 
   // ── Unsubscribe ────────────────────────────────────────────────────────────
   // Require the email to match the subscriber so a third party can't stop
-  // someone else's monitoring.
+  // someone else's monitoring. Removing the watch also delists the domain.
   if (body.unsubscribe) {
     const existing = await getWatch(env.RESULTS, domain);
     if (!existing) return json({ domain, monitoring: false, unsubscribed: false });
@@ -71,6 +73,7 @@ export async function onRequestPost({ request, env }) {
       return json({ error: 'email does not match the subscriber for this domain' }, 403);
     }
     await deleteWatch(env.RESULTS, domain);
+    if (existing.listed) await deleteListing(env.RESULTS, domain);
     return json({ domain, monitoring: false, unsubscribed: true });
   }
 
@@ -83,9 +86,19 @@ export async function onRequestPost({ request, env }) {
   // point. If nothing's been scanned yet, the baseline is set on the next scan
   // (see recordScanForWatch). Preserve an established baseline on re-subscribe.
   const latest = await getLatestForDomain(env.RESULTS, domain).catch(() => null);
+
+  // Opt-in to the public directory: `list:true` lists the domain (dofollow
+  // backlink from /directory); `list:false` delists it; omitting it preserves
+  // the current state. This is the ONLY way a domain enters the directory —
+  // an email-attached, deliberate act by whoever is claiming the domain.
+  const listed = body.list === true ? true
+    : body.list === false ? false
+    : (existing?.listed ?? false);
+
   const watch = {
     domain,
     email,
+    listed,
     plan: existing?.plan || 'trial',
     createdAt: existing?.createdAt || now,
     updatedAt: now,
@@ -104,11 +117,25 @@ export async function onRequestPost({ request, env }) {
   };
   await putWatch(env.RESULTS, watch);
 
+  // Reflect the listing choice in the directory. List from the best score we
+  // have (the latest scan); a never-scanned domain lists as "pending" and is
+  // filled in on its next scan via recordScanForWatch.
+  if (listed) {
+    const seed = latest || {
+      domain, score: watch.lastScore, grade: watch.lastGrade,
+      tier: watch.lastTier, id: watch.lastId, title: null
+    };
+    await setListing(env.RESULTS, seed).catch(() => {});
+  } else if (existing?.listed) {
+    await deleteListing(env.RESULTS, domain).catch(() => {});
+  }
+
   const history = await getHistory(env.RESULTS, domain);
   return json({
     ...publicWatch(watch, history),
     monitoring: true,
     alreadyMonitored: !!existing,
+    directoryUrl: listed ? `${new URL(request.url).origin}/directory` : null,
     // Be explicit about what the trial does and doesn't do yet, so the signup
     // UX doesn't over-promise during validation.
     note: watch.baselineScore == null

--- a/packages/web/functions/directory.js
+++ b/packages/web/functions/directory.js
@@ -18,7 +18,9 @@ function row(site, origin) {
   const c = tierColors(site.tier);
   const grade = site.grade || '—';
   const score = site.score == null ? 'pending' : `${site.score}`;
-  const tier = site.tier || 'Unlisted';
+  // A listed-but-not-yet-scored domain has tier null — it IS listed, only the
+  // score is pending, so don't mislabel it "Unlisted".
+  const tier = site.tier || 'Pending';
   const title = site.title ? `<span class="ti">${escapeHtml(site.title)}</span>` : '';
   // The dofollow backlink — a plain <a href> with no rel. This is the gift.
   const out = `<a class="dom" href="https://${escapeHtml(site.domain)}">${escapeHtml(site.domain)}</a>`;

--- a/packages/web/functions/directory.js
+++ b/packages/web/functions/directory.js
@@ -1,0 +1,154 @@
+// GET /directory — the public, crawlable catalogue of opt-in scanned sites.
+//
+// Server-rendered (so search engines index it) listing of every domain whose
+// owner opted in via the claim/monitor flow (POST /api/watch { list:true }).
+// Each row links OUT to the original site with a real (dofollow) backlink — the
+// catalogue ranks for "is <site> AI slop", sends link equity to listed sites,
+// and the backlink is the incentive that pulls owners into the claim + monitor
+// funnel (see VALIDATION.md).
+//
+// Anti-slop by construction: no Inter/Geist, no gradient text, no VibeCode
+// purple, no glows — this page should itself score Clean on slop-detect.
+
+import { listAllSites, tierColors, escapeHtml } from './_shared.js';
+
+const ORIGIN = 'https://slop-detect.com';
+
+function row(site, origin) {
+  const c = tierColors(site.tier);
+  const grade = site.grade || '—';
+  const score = site.score == null ? 'pending' : `${site.score}`;
+  const tier = site.tier || 'Unlisted';
+  const title = site.title ? `<span class="ti">${escapeHtml(site.title)}</span>` : '';
+  // The dofollow backlink — a plain <a href> with no rel. This is the gift.
+  const out = `<a class="dom" href="https://${escapeHtml(site.domain)}">${escapeHtml(site.domain)}</a>`;
+  const scanLink = site.id
+    ? `<a class="scan" href="${origin}/r/${escapeHtml(site.id)}">scan&nbsp;&rarr;</a>`
+    : '';
+  return `<li class="r">
+    <span class="g" style="color:${c.fg};border-color:${c.fg}">${escapeHtml(grade)}</span>
+    <span class="sc">${escapeHtml(score)}<small>${site.score == null ? '' : '/100'}</small></span>
+    <span class="t" style="color:${c.fg}">${escapeHtml(tier)}</span>
+    <span class="d">${out}${title}</span>
+    ${scanLink}
+  </li>`;
+}
+
+function jsonLd(sites, origin) {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'slop-detect — directory of scanned sites',
+    description: 'Opt-in catalogue of sites scored against the AI-design-slop fingerprint.',
+    numberOfItems: sites.length,
+    itemListElement: sites.slice(0, 200).map((s, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: `https://${s.domain}`,
+      name: s.domain
+    }))
+  });
+}
+
+export async function onRequestGet({ request, env }) {
+  const origin = new URL(request.url).origin;
+  const sort = new URL(request.url).searchParams.get('sort') === 'slop' ? 'slop' : 'clean';
+
+  let sites = [];
+  if (env.RESULTS) {
+    sites = await listAllSites(env.RESULTS).catch(() => []);
+  }
+  sites.sort((a, b) => {
+    const sa = a.score == null ? Infinity : a.score;
+    const sb = b.score == null ? Infinity : b.score;
+    return sort === 'slop' ? sb - sa : sa - sb;
+  });
+
+  const other = sort === 'slop' ? 'clean' : 'slop';
+  const otherLabel = sort === 'slop' ? 'cleanest first' : 'sloppiest first';
+
+  const rows = sites.length
+    ? sites.map(s => row(s, origin)).join('\n')
+    : `<li class="empty">No sites listed yet. Scan your site, then
+        <a href="${origin}/">claim it</a> to appear here with a backlink.</li>`;
+
+  const html = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Directory — sites scored for AI design slop · slop-detect</title>
+<meta name="description" content="An opt-in catalogue of websites scored against the ${''}AI-design-slop fingerprint. Each listed site links out, ranked by how generic its design reads.">
+<link rel="canonical" href="${ORIGIN}/directory">
+<meta property="og:title" content="Directory of sites scored for AI design slop">
+<meta property="og:description" content="Opt-in catalogue of sites ranked by the AI-design-slop fingerprint.">
+<meta property="og:url" content="${ORIGIN}/directory">
+<meta property="og:image" content="${ORIGIN}/og.png">
+<script type="application/ld+json">${jsonLd(sites, origin)}</script>
+<style>
+  :root{color-scheme:dark}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{
+    background:#0a0a0b;color:#e7e7ea;
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+    line-height:1.5;padding:48px 20px 80px;
+  }
+  .wrap{max-width:820px;margin:0 auto}
+  a{color:inherit}
+  header{border-bottom:1px solid #232327;padding-bottom:20px;margin-bottom:8px}
+  .kick{font-family:ui-monospace,Menlo,monospace;font-size:12px;letter-spacing:.04em;color:#6b6b73;text-transform:uppercase}
+  h1{font-size:30px;font-weight:650;letter-spacing:-0.01em;margin:6px 0 8px}
+  .sub{color:#a1a1aa;font-size:15px;max-width:60ch}
+  .sub a{color:#e7e7ea;text-decoration:underline;text-underline-offset:2px}
+  .bar{display:flex;justify-content:space-between;align-items:center;
+       font-family:ui-monospace,Menlo,monospace;font-size:12.5px;color:#8a8a92;
+       padding:14px 2px 8px}
+  .bar a{color:#e7e7ea;text-decoration:none;border-bottom:1px solid #3a3a40;padding-bottom:1px}
+  ol{list-style:none}
+  .r{display:grid;grid-template-columns:34px 78px 64px 1fr auto;gap:12px;align-items:baseline;
+     padding:13px 2px;border-bottom:1px solid #18181b;font-size:15px}
+  .g{font-family:ui-monospace,Menlo,monospace;font-weight:700;font-size:14px;
+     border:1px solid;border-radius:5px;text-align:center;padding:1px 0}
+  .sc{font-family:ui-monospace,Menlo,monospace;color:#d4d4d8;font-size:14px}
+  .sc small{color:#6b6b73;font-size:11px}
+  .t{font-family:ui-monospace,Menlo,monospace;font-size:12.5px}
+  .d{min-width:0;overflow:hidden}
+  .dom{font-weight:550;text-decoration:none;border-bottom:1px solid #3a3a40;padding-bottom:1px}
+  .dom:hover{border-color:#e7e7ea}
+  .ti{display:block;color:#71717a;font-size:12.5px;margin-top:2px;
+      white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .scan{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#8a8a92;text-decoration:none;white-space:nowrap}
+  .scan:hover{color:#e7e7ea}
+  .empty{padding:28px 2px;color:#8a8a92}
+  .empty a{color:#e7e7ea}
+  footer{margin-top:28px;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#5a5a62}
+  footer a{color:#8a8a92}
+  @media(max-width:560px){
+    .r{grid-template-columns:30px 1fr auto;gap:8px}
+    .t,.scan{display:none}
+  }
+</style>
+</head><body><div class="wrap">
+  <header>
+    <div class="kick">slop-detect / directory</div>
+    <h1>Sites scored for AI design slop</h1>
+    <p class="sub">An opt-in catalogue. Owners <a href="${origin}/">claim their domain</a>
+      to appear here &mdash; with a live badge and a link back to their site.
+      Detection is free; listing is a choice.</p>
+  </header>
+  <div class="bar">
+    <span>${sites.length} site${sites.length === 1 ? '' : 's'} &middot; ${escapeHtml(sort)} first</span>
+    <a href="${origin}/directory?sort=${other}">sort: ${otherLabel}</a>
+  </div>
+  <ol>${rows}</ol>
+  <footer>
+    Listed by opt-in only. <a href="${origin}/">Scan a site</a> &middot;
+    <a href="https://github.com/ravidsrk/slop-detect">source</a>
+  </footer>
+</div></body></html>`;
+
+  return new Response(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=120, s-maxage=300'
+    }
+  });
+}

--- a/packages/web/public/sitemap.xml
+++ b/packages/web/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://slop-detect.com/directory</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://slop-detect.com/api/patterns</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/packages/web/test/sites.test.js
+++ b/packages/web/test/sites.test.js
@@ -178,6 +178,34 @@ test('unsubscribing a listed domain also delists it', async () => {
   assert.equal(await getListing(kv, 'example.com'), null);
 });
 
+test('a claimed domain cannot be listed/hijacked by a different email', async () => {
+  // owner@x.io already claims + lists example.com.
+  const kv = makeKv({
+    'w:example.com': JSON.stringify({ domain: 'example.com', email: 'owner@x.io', listed: true }),
+    'l:example.com': JSON.stringify({ domain: 'example.com', score: 6, grade: 'A', tier: 'Clean', listedAt: 'orig' })
+  });
+  const env = { RESULTS: kv };
+
+  // attacker@evil.io tries to take over (change email) and delist.
+  const res = await watchPost({ request: postReq({ domain: 'example.com', email: 'attacker@evil.io', list: false }), env });
+  assert.equal(res.status, 403);
+
+  // The watch + listing are untouched.
+  const watch = await getWatch(kv, 'example.com');
+  assert.equal(watch.email, 'owner@x.io');
+  assert.ok(await getListing(kv, 'example.com'), 'listing survives the hijack attempt');
+});
+
+test('/directory labels a listed-but-unscored domain "Pending", not "Unlisted"', async () => {
+  const kv = makeKv();
+  // List a domain that has never been scored (tier/score null).
+  await setListing(kv, { domain: 'fresh.com', score: null, grade: null, tier: null, id: null, title: null });
+  const res = await directoryGet({ request: { url: 'https://slop-detect.com/directory' }, env: { RESULTS: kv } });
+  const html = await res.text();
+  assert.match(html, /Pending/, 'pending rows are labeled Pending');
+  assert.doesNotMatch(html, /Unlisted/, 'a listed row is never labeled Unlisted');
+});
+
 // ── re-scan refreshes a listed domain's directory entry ──────────────────────
 test('recordScanForWatch refreshes the listing for a listed, watched domain', async () => {
   const kv = makeKv({
@@ -189,4 +217,15 @@ test('recordScanForWatch refreshes the listing for a listed, watched domain', as
   const listing = await getListing(kv, 'example.com');
   assert.equal(listing.score, 45, 'directory tracks the new score');
   assert.equal(listing.listedAt, 'orig', 'listed-since is preserved');
+});
+
+test('recordScanForWatch reconciles away a stale row when the watch is not listed', async () => {
+  // watch.listed=false but a directory row lingers (e.g. an earlier delist that
+  // didn't land). A scan should remove it — the scan is the reconciler.
+  const kv = makeKv({
+    'w:example.com': JSON.stringify({ domain: 'example.com', email: 'o@x.io', listed: false, baselineScore: 6, baselineTier: 'Clean' }),
+    'l:example.com': JSON.stringify({ domain: 'example.com', score: 6, grade: 'A', tier: 'Clean', listedAt: 'orig' })
+  });
+  await recordScanForWatch(kv, slim({ id: 'r9', score: 7, grade: 'A-', tier: 'Clean' }));
+  assert.equal(await getListing(kv, 'example.com'), null, 'stale row reconciled away');
 });

--- a/packages/web/test/sites.test.js
+++ b/packages/web/test/sites.test.js
@@ -1,0 +1,192 @@
+// Directory / listing tests — the opt-in catalogue of scanned sites
+// (VALIDATION.md). Covers the _shared.js listing helpers, GET /api/sites, the
+// server-rendered /directory page, and the `list` opt-in flag on /api/watch.
+// Driven against an in-memory KV mock that supports list() + metadata.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  setListing,
+  getListing,
+  deleteListing,
+  listSites,
+  listAllSites,
+  recordScanForWatch,
+  getWatch
+} from '../functions/_shared.js';
+import { onRequestGet as sitesGet } from '../functions/api/sites.js';
+import { onRequestGet as directoryGet } from '../functions/api/../directory.js';
+import { onRequestPost as watchPost } from '../functions/api/watch.js';
+
+// CF-KV-shaped mock with metadata + list({ prefix }).
+function makeKv(seed = {}) {
+  const store = new Map();
+  for (const [k, v] of Object.entries(seed)) {
+    store.set(k, typeof v === 'string' ? { value: v } : v);
+  }
+  return {
+    store,
+    async get(k) { return store.has(k) ? store.get(k).value : null; },
+    async getWithMetadata(k) {
+      const e = store.get(k);
+      return e ? { value: e.value, metadata: e.metadata || null } : { value: null, metadata: null };
+    },
+    async put(k, v, opts = {}) { store.set(k, { value: v, metadata: opts.metadata }); },
+    async delete(k) { store.delete(k); },
+    async list({ prefix = '', limit = 1000 } = {}) {
+      const names = [...store.keys()].filter(n => n.startsWith(prefix)).sort().slice(0, limit);
+      return {
+        keys: names.map(n => ({ name: n, metadata: store.get(n).metadata })),
+        list_complete: true
+      };
+    }
+  };
+}
+
+const slim = (over = {}) => ({
+  id: 'r1', domain: 'example.com', score: 8, grade: 'A-', tier: 'Clean',
+  title: 'Example', ...over
+});
+
+function postReq(body) { return { json: async () => body, url: 'https://slop-detect.com/api/watch' }; }
+
+// ── listing helpers ──────────────────────────────────────────────────────────
+test('setListing writes a record + display metadata, getListing reads it back', async () => {
+  const kv = makeKv();
+  const rec = await setListing(kv, slim());
+  assert.equal(rec.domain, 'example.com');
+  assert.equal(rec.url, 'https://example.com');
+
+  const got = await getListing(kv, 'example.com');
+  assert.equal(got.score, 8);
+  // The compact summary must live in KV metadata so the directory enumerates cheaply.
+  assert.equal(kv.store.get('l:example.com').metadata.g, 'A-');
+});
+
+test('setListing preserves listedAt across refreshes but updates the score', async () => {
+  const kv = makeKv();
+  const first = await setListing(kv, slim({ score: 8, tier: 'Clean' }));
+  await new Promise(r => setTimeout(r, 2));
+  const second = await setListing(kv, slim({ score: 40, grade: 'D', tier: 'Heavy' }));
+  assert.equal(second.listedAt, first.listedAt, 'listedAt is sticky');
+  assert.equal(second.score, 40, 'score refreshes');
+});
+
+test('listSites derives rows from metadata; deleteListing removes them', async () => {
+  const kv = makeKv();
+  await setListing(kv, slim({ domain: 'a.com', score: 4, grade: 'A', tier: 'Clean' }));
+  await setListing(kv, slim({ domain: 'b.com', score: 55, grade: 'F', tier: 'Heavy' }));
+
+  let { sites } = await listSites(kv);
+  assert.equal(sites.length, 2);
+  assert.deepEqual(sites.map(s => s.domain).sort(), ['a.com', 'b.com']);
+
+  await deleteListing(kv, 'b.com');
+  ({ sites } = await listSites(kv));
+  assert.deepEqual(sites.map(s => s.domain), ['a.com']);
+});
+
+// ── GET /api/sites ───────────────────────────────────────────────────────────
+test('GET /api/sites sorts cleanest-first by default and sloppiest-first on demand', async () => {
+  const kv = makeKv();
+  await setListing(kv, slim({ domain: 'clean.com', score: 3, grade: 'A', tier: 'Clean' }));
+  await setListing(kv, slim({ domain: 'dirty.com', score: 60, grade: 'F', tier: 'Heavy' }));
+  const env = { RESULTS: kv };
+
+  let res = await sitesGet({ request: { url: 'https://slop-detect.com/api/sites' }, env });
+  let j = await res.json();
+  assert.equal(j.sites[0].domain, 'clean.com');
+
+  res = await sitesGet({ request: { url: 'https://slop-detect.com/api/sites?sort=slop' }, env });
+  j = await res.json();
+  assert.equal(j.sites[0].domain, 'dirty.com');
+  assert.equal(j.sort, 'slop');
+});
+
+test('GET /api/sites returns 503 without storage', async () => {
+  const res = await sitesGet({ request: { url: 'https://slop-detect.com/api/sites' }, env: {} });
+  assert.equal(res.status, 503);
+});
+
+// ── GET /directory (server-rendered HTML) ────────────────────────────────────
+test('/directory renders a DOFOLLOW backlink to each listed site', async () => {
+  const kv = makeKv();
+  await setListing(kv, slim({ domain: 'example.com', score: 8, grade: 'A-', tier: 'Clean' }));
+  const res = await directoryGet({ request: { url: 'https://slop-detect.com/directory' }, env: { RESULTS: kv } });
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.match(html, /href="https:\/\/example\.com"/, 'links out to the site');
+  assert.doesNotMatch(html, /rel=["']?nofollow/i, 'the backlink must be dofollow');
+  assert.match(html, /application\/ld\+json/, 'emits ItemList JSON-LD for SEO');
+  // Anti-slop self-check: the directory must not wear the tells it detects.
+  assert.doesNotMatch(html, /Inter|Geist|Space Grotesk/i, 'no slop fonts');
+  assert.doesNotMatch(html, /background-clip:\s*text/i, 'no gradient text');
+});
+
+test('/directory shows an empty state with a claim CTA when nothing is listed', async () => {
+  const res = await directoryGet({ request: { url: 'https://slop-detect.com/directory' }, env: { RESULTS: makeKv() } });
+  const html = await res.text();
+  assert.match(html, /No sites listed yet/i);
+  assert.match(html, /claim it/i);
+});
+
+// ── /api/watch list opt-in ───────────────────────────────────────────────────
+test('POST /api/watch { list:true } lists the domain; { list:false } delists it', async () => {
+  // Seed a prior scan so the listing has a score.
+  const kv = makeKv({
+    'd:example.com': 'r0',
+    'r:r0': JSON.stringify({ id: 'r0', domain: 'example.com', score: 6, grade: 'A', tier: 'Clean', title: 'Ex' })
+  });
+  const env = { RESULTS: kv };
+
+  let res = await watchPost({ request: postReq({ domain: 'example.com', email: 'o@x.io', list: true }), env });
+  let j = await res.json();
+  assert.equal(j.listed, true);
+  assert.ok(j.directoryUrl.endsWith('/directory'));
+  assert.ok(await getListing(kv, 'example.com'), 'listing created');
+
+  // Re-subscribe with list:false → delisted, monitoring intact.
+  res = await watchPost({ request: postReq({ domain: 'example.com', email: 'o@x.io', list: false }), env });
+  j = await res.json();
+  assert.equal(j.listed, false);
+  assert.equal(await getListing(kv, 'example.com'), null, 'listing removed');
+  assert.ok(await getWatch(kv, 'example.com'), 'still monitored');
+});
+
+test('omitting `list` on re-subscribe preserves the listing state', async () => {
+  const kv = makeKv({
+    'd:example.com': 'r0',
+    'r:r0': JSON.stringify({ id: 'r0', domain: 'example.com', score: 6, grade: 'A', tier: 'Clean' })
+  });
+  const env = { RESULTS: kv };
+  await watchPost({ request: postReq({ domain: 'example.com', email: 'o@x.io', list: true }), env });
+  // Re-subscribe without the flag — must stay listed.
+  const res = await watchPost({ request: postReq({ domain: 'example.com', email: 'o@x.io' }), env });
+  const j = await res.json();
+  assert.equal(j.listed, true);
+  assert.ok(await getListing(kv, 'example.com'));
+});
+
+test('unsubscribing a listed domain also delists it', async () => {
+  const kv = makeKv({
+    'd:example.com': 'r0',
+    'r:r0': JSON.stringify({ id: 'r0', domain: 'example.com', score: 6, grade: 'A', tier: 'Clean' })
+  });
+  const env = { RESULTS: kv };
+  await watchPost({ request: postReq({ domain: 'example.com', email: 'o@x.io', list: true }), env });
+  await watchPost({ request: postReq({ domain: 'example.com', email: 'o@x.io', unsubscribe: true }), env });
+  assert.equal(await getListing(kv, 'example.com'), null);
+});
+
+// ── re-scan refreshes a listed domain's directory entry ──────────────────────
+test('recordScanForWatch refreshes the listing for a listed, watched domain', async () => {
+  const kv = makeKv({
+    'w:example.com': JSON.stringify({ domain: 'example.com', email: 'o@x.io', listed: true, baselineScore: 6, baselineTier: 'Clean' }),
+    'l:example.com': JSON.stringify({ domain: 'example.com', score: 6, grade: 'A', tier: 'Clean', listedAt: 'orig' })
+  });
+  // A regressing re-scan should both flag the watch and update the directory.
+  await recordScanForWatch(kv, slim({ id: 'r9', score: 45, grade: 'D', tier: 'Heavy' }));
+  const listing = await getListing(kv, 'example.com');
+  assert.equal(listing.score, 45, 'directory tracks the new score');
+  assert.equal(listing.listedAt, 'orig', 'listed-since is preserved');
+});


### PR DESCRIPTION
## What

Persists scanned sites into an **enumerable, crawlable catalogue** that links back out to each site — an SEO surface that doubles as the leaderboard and feeds the claim+monitor funnel from `VALIDATION.md`.

## The two product decisions (yours)

- **Opt-in only** — a domain enters the directory *only* when its owner lists it via the email-attached claim flow (`POST /api/watch { list: true }`), **never** from an anonymous scan. This keeps us on the ROADMAP guardrail (*"we will not position a slop score as a verdict on a person or company"*) and stops anyone listing a competitor.
- **dofollow backlinks** — listed sites get a real backlink (no `rel=nofollow`). Safe *because* listing is opt-in (we only vouch for sites that asked to be there), and it's the incentive that pulls owners into the claim + monitor funnel.

## How it fits together

scan → see result → **claim + list** → get a badge + a **dofollow backlink** from `/directory` → the directory ranks for "is `<site>` AI slop" → drives traffic back into the monitor (WTP) funnel. The backlink is the carrot.

## Changes

- **`_shared.js`** — `l:<domain>` listing records with the display summary in KV **metadata**, so the directory enumerates in a single `list()` call (no per-row read). `setListing` preserves *listed-since* across refreshes; `listSites` / `listAllSites` enumerate.
- **`GET /api/sites`** — JSON directory (`sort=clean|slop`, cursor paging, short-cached).
- **`GET /directory`** — server-rendered, crawlable HTML with dofollow links + `ItemList` JSON-LD. **Anti-slop by construction** (no Inter/Geist, no gradient text, no VibeCode purple) so the page itself scores Clean — tests assert this. Added to `sitemap.xml`.
- **`/api/watch`** — gains a `list: true/false` opt-in; re-scans of a listed domain auto-refresh its entry; unsubscribe delists.
- **`API.md`** documents all of it.

## Tests

**+14 web tests, 34 total green; lint clean.** Covers listing helpers, the sort/empty-state behavior, the dofollow-and-not-nofollow assertion, the anti-slop self-check, the `list` opt-in/delist/unsubscribe flows, and listing refresh on re-scan.

The pre-existing `packages/cli` unit-test failures are unrelated and environmental (also fail on `main`), and aren't part of CI (`Lint` + `Smoke test CLI`).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public SEO surface publishes opt-in slop scores and changes watch authorization (403 on email mismatch); first-claim-by-email is not verified ownership yet.
> 
> **Overview**
> Adds an **opt-in public directory** of monitored domains: sites appear only when owners call `POST /api/watch` with `list: true` (never from anonymous scans), with **dofollow backlinks** on `/directory`.
> 
> **Storage & sync:** New `l:<domain>` KV listing helpers in `_shared.js` (metadata-backed enumeration); the watch record is source of truth—`recordScanForWatch` and watch subscribe/unsubscribe reconcile directory rows on scan and list/delist.
> 
> **Surfaces:** New `GET /api/sites` (globally sorted JSON) and server-rendered `GET /directory` (ItemList JSON-LD, sort clean/slop); responses include `listed` and `directoryUrl`. **Claim protection:** already-claimed domains return `403` for a different email.
> 
> **Docs & tests:** `API.md` and `sitemap.xml` updated; `sites.test.js` covers listing, watch flows, dofollow, and ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1eddde0374439cbafe2a08be7a840736c9bcd85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->