### PR TITLE
Calibration: golden fixtures + labeled corpus + accuracy runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
       - run: npm ci
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
+      - name: Golden detection fixtures (clean vs slop)
+        run: RUN_GOLDEN=1 node --test packages/cli/test/golden.test.js
       - name: Scan a known-clean page (HN)
         run: |
           cd packages/cli

--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -1,0 +1,48 @@
+# Calibrating the detector
+
+The slop score is only credible if we can show it agrees with human judgement.
+This is the harness for that — and the honest answer to "what's your accuracy?".
+
+## What's here
+
+- **Deterministic golden fixtures** — `packages/cli/test/fixtures/*.html`, scanned
+  in a real headless browser by `packages/cli/test/golden.test.js`. These pin
+  detector behavior on a hand-built clean page and a maximal-slop page so a
+  refactor or threshold tweak can't silently break detection. They run in CI's
+  "Smoke test CLI" job (`RUN_GOLDEN=1`), which has Chromium.
+- **A labeled corpus** — `packages/cli/calibration/corpus.json`. Each row has a
+  URL, a human-confirmed expected tier (`label`), and provenance. `label: null`
+  means "candidate, awaiting review."
+- **A runner** — `packages/cli/calibration/run.mjs` (`npm run calibrate`). Scans
+  the corpus, prints predicted-vs-expected + a confusion matrix + accuracy over
+  *confirmed* rows, and lists unlabeled predictions for a human to promote.
+
+## How to use it
+
+```bash
+npm run calibrate                 # scan via the public API (no browser needed)
+npm run calibrate -- --local      # scan locally (needs Playwright)
+npm run calibrate -- --json cal.json
+npm run calibrate -- --check      # CI/regression: exit 1 on a confirmed-label miss
+```
+
+## The honest status
+
+This is a **seed**: ~5 confidently-labeled clean pages, 2 sourced "Mild" AI-builder
+sites, and a handful of candidates. That is enough to catch gross regressions —
+**not** enough to claim a headline accuracy number.
+
+To state a defensible figure (the deep-review gap #8):
+
+1. Grow `corpus.json` to **50–100 URLs** spanning Clean/Mild/Heavy and builders
+   (v0, Lovable, Bolt, Framer) plus genuinely-custom premium sites.
+2. Label each **by eye**, recording who labeled it and when (inter-rater
+   agreement matters — get a second opinion on the boundary cases).
+3. Run `npm run calibrate`, read the confusion matrix, and **tune thresholds**
+   where the engine and humans disagree — especially the patterns that fire on a
+   single occurrence (glassmorphism / colored-glows / gradient-text), which are
+   the likeliest false-positive sources.
+4. Re-run until accuracy is stable, then publish the number *with* the corpus and
+   the definitions version, so it's reproducible.
+
+Until then, describe the score as "a deterministic fingerprint" — not "N% accurate."

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -41,11 +41,13 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
 - ✅ Version drift fixed (all 0.6.0, lockfile synced).
 - ✅ Security headers + CSP (scoped to Google Fonts + Turnstile). ⏳ Graduate CSP
   from `'unsafe-inline'` to nonces once index.html inline scripts are audited.
-- ⏳ **Calibrate detection.** No labeled corpus exists; thresholds are hand-tuned
-  and several fire on a single occurrence (glassmorphism/glows/gradient-text →
-  false-positive risk). Build a 50–100 page labeled set, add Playwright golden
-  tests scanning `file://` fixtures, then tune. This is what lets you state an
-  accuracy number you can defend.
+- 🟡 **Calibrate detection — harness shipped, data pending.** Added deterministic
+  golden fixtures (`packages/cli/test/golden.test.js`, run in CI with Chromium), a
+  seed labeled corpus (`packages/cli/calibration/corpus.json`), and a runner
+  (`npm run calibrate`) that reports accuracy + a confusion matrix. 🔧 Grow the
+  corpus to 50–100 human-labeled URLs and tune the single-occurrence thresholds
+  (glassmorphism/glows/gradient-text) before quoting an accuracy number. See
+  `CALIBRATION.md`.
 - ⏳ Dev-dep advisory: `ws`←`miniflare`←`wrangler` (build-time only). `npm audit
   fix` when convenient.
 - ⏳ Directory `listAllSites` is unbounded — cap/paginate before the catalogue

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "demo": "npm run --workspace slop-detect demo",
     "web:dev": "npm run --workspace slop-detect-web dev",
     "web:deploy": "npm run --workspace slop-detect-web deploy",
+    "calibrate": "node packages/cli/calibration/run.mjs",
     "test": "node --test packages/core/test/*.test.js packages/web/test/*.test.js packages/cli/test/*.test.js packages/mcp/test/*.test.js",
     "lint": "node --check packages/core/src/*.js packages/cli/src/*.js packages/cli/bin/*.js packages/mcp/src/*.js packages/mcp/bin/*.js packages/web/functions/api/*.js packages/web/functions/*.js"
   },

--- a/packages/cli/calibration/corpus.json
+++ b/packages/cli/calibration/corpus.json
@@ -1,0 +1,18 @@
+{
+  "_about": "Seed calibration corpus. `label` is the human-confirmed expected design tier (Clean|Mild|Heavy); null means a candidate awaiting human review. The runner (run.mjs) scores accuracy only over confirmed labels and prints unlabeled predictions for a human to confirm. Grow this to 50-100 rows to state a defensible accuracy number — see CALIBRATION.md.",
+  "definitionsVersion": "2026.08",
+  "entries": [
+    { "url": "https://news.ycombinator.com", "label": "Clean", "builtWith": "custom", "source": "README baseline (canonical clean)", "notes": "Plain, dense, system fonts." },
+    { "url": "https://example.com", "label": "Clean", "builtWith": "static", "source": "IANA example page", "notes": "Minimal by construction." },
+    { "url": "https://motherfuckingwebsite.com", "label": "Clean", "builtWith": "static", "source": "manual", "notes": "Deliberately unstyled." },
+    { "url": "https://berkshirehathaway.com", "label": "Clean", "builtWith": "static", "source": "manual", "notes": "Famously plain corporate site." },
+    { "url": "https://www.gnu.org", "label": "Clean", "builtWith": "static", "source": "manual", "notes": "Old-web, no slop tells." },
+    { "url": "https://bolt.new", "label": "Mild", "builtWith": "bolt", "source": "README example scan (24/100)", "notes": "AI-builder marketing site." },
+    { "url": "https://www.aura.build", "label": "Mild", "builtWith": "aura", "source": "README example scan (20/100)", "notes": "Gradient avatars, Inter." },
+    { "url": "https://lovable.dev", "label": null, "builtWith": "lovable", "source": "candidate", "notes": "Likely Mild/Heavy — confirm by eye." },
+    { "url": "https://v0.dev", "label": null, "builtWith": "v0", "source": "candidate", "notes": "Vercel/v0 surface — confirm." },
+    { "url": "https://vercel.com", "label": null, "builtWith": "next", "source": "candidate", "notes": "Premium but modern-default; confirm Clean vs Mild." },
+    { "url": "https://stripe.com", "label": null, "builtWith": "custom", "source": "candidate", "notes": "Premium custom; expected Clean — confirm." },
+    { "url": "https://linear.app", "label": null, "builtWith": "custom", "source": "candidate", "notes": "Dark, gradient-forward but bespoke; confirm." }
+  ]
+}

--- a/packages/cli/calibration/run.mjs
+++ b/packages/cli/calibration/run.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Calibration runner. Scans the labeled corpus and reports how well the detector
+// agrees with human labels — the thing you need to state a defensible accuracy
+// number (the deep-review gap #8).
+//
+//   node packages/cli/calibration/run.mjs            # scan via the public API (no browser)
+//   node packages/cli/calibration/run.mjs --local    # scan locally (needs Playwright)
+//   node packages/cli/calibration/run.mjs --check     # exit 1 if any CONFIRMED label mismatches
+//   node packages/cli/calibration/run.mjs --json out.json
+//
+// Accuracy is computed ONLY over rows with a confirmed `label`. Rows with
+// label:null are printed as predictions for a human to confirm and promote.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { scanRemote, scanUrl } from '../src/detector.js';
+
+const args = process.argv.slice(2);
+const local = args.includes('--local');
+const check = args.includes('--check');
+const jsonIdx = args.indexOf('--json');
+const jsonOut = jsonIdx >= 0 ? args[jsonIdx + 1] : null;
+
+const corpus = JSON.parse(readFileSync(new URL('./corpus.json', import.meta.url)));
+const entries = corpus.entries || [];
+
+const scan = (url) => (local ? scanUrl(url, { axes: ['design'] }) : scanRemote(url, { axes: ['design'] }));
+
+const TIERS = ['Clean', 'Mild', 'Heavy'];
+const pad = (s, n) => String(s).padEnd(n);
+
+const rows = [];
+let labeled = 0, correct = 0;
+const confusion = {}; // expected -> predicted -> count
+for (const t of TIERS) confusion[t] = { Clean: 0, Mild: 0, Heavy: 0 };
+
+console.log(`\nCalibration · defs ${corpus.definitionsVersion} · ${local ? 'local' : 'remote'} · ${entries.length} urls\n`);
+console.log(`${pad('url', 38)} ${pad('expect', 7)} ${pad('predict', 7)} ${pad('score', 6)} ok`);
+console.log('-'.repeat(70));
+
+for (const e of entries) {
+  let predicted = 'ERROR', score = '-', ok = '';
+  try {
+    const r = await scan(e.url);
+    predicted = r.tier;
+    score = r.score;
+    if (e.label) {
+      labeled++;
+      const hit = predicted === e.label;
+      if (hit) correct++;
+      confusion[e.label][predicted] = (confusion[e.label][predicted] || 0) + 1;
+      ok = hit ? '✓' : '✗ MISS';
+    } else {
+      ok = '· (unlabeled)';
+    }
+  } catch (err) {
+    ok = `! ${err.message?.slice(0, 30)}`;
+  }
+  rows.push({ url: e.url, expected: e.label, predicted, score, builtWith: e.builtWith });
+  console.log(`${pad(e.url.replace(/^https?:\/\//, ''), 38)} ${pad(e.label || '—', 7)} ${pad(predicted, 7)} ${pad(score, 6)} ${ok}`);
+}
+
+const accuracy = labeled ? (correct / labeled) : 0;
+console.log('-'.repeat(70));
+console.log(`\nLabeled: ${labeled}  ·  Correct: ${correct}  ·  Accuracy: ${(accuracy * 100).toFixed(1)}%`);
+console.log('\nConfusion (rows = expected, cols = predicted):');
+console.log(`${pad('', 8)}${TIERS.map((t) => pad(t, 7)).join('')}`);
+for (const exp of TIERS) {
+  console.log(`${pad(exp, 8)}${TIERS.map((p) => pad(confusion[exp][p] || 0, 7)).join('')}`);
+}
+
+const unlabeled = rows.filter((r) => !r.expected && r.predicted !== 'ERROR');
+if (unlabeled.length) {
+  console.log('\nPredictions awaiting a human label (promote into corpus.json):');
+  for (const r of unlabeled) console.log(`  ${r.predicted.padEnd(6)} ${r.score}\t${r.url}`);
+}
+
+const report = { definitionsVersion: corpus.definitionsVersion, mode: local ? 'local' : 'remote', labeled, correct, accuracy, rows, confusion };
+if (jsonOut) { writeFileSync(jsonOut, JSON.stringify(report, null, 2)); console.log(`\nWrote ${jsonOut}`); }
+
+// In --check mode, a confirmed-label miss is a regression → fail.
+if (check) {
+  const misses = rows.filter((r) => r.expected && r.predicted !== 'ERROR' && r.predicted !== r.expected);
+  if (misses.length) {
+    console.error(`\n✗ ${misses.length} confirmed-label mismatch(es).`);
+    process.exit(1);
+  }
+}
+console.log('');

--- a/packages/cli/test/fixtures/clean-artisan.html
+++ b/packages/cli/test/fixtures/clean-artisan.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hand Tools Co. — Forged in Sheffield since 1947</title>
+  <style>
+    /* Deliberately anti-slop: a real system/serif stack, ink-on-paper, no
+       gradients, no purple, no glass, generous hierarchy. Should score Clean. */
+    :root { --ink:#1a1a1a; --paper:#fbfaf7; }
+    * { margin:0; padding:0; box-sizing:border-box; }
+    body { font-family: Georgia, 'Times New Roman', serif; color:var(--ink);
+           background:var(--paper); line-height:1.55; }
+    .wrap { max-width:680px; margin:0 auto; padding:64px 24px; }
+    h1 { font-size:44px; font-weight:700; letter-spacing:-0.01em; margin-bottom:16px; }
+    h2 { font-size:24px; margin:40px 0 12px; }
+    p { font-size:18px; margin-bottom:16px; max-width:60ch; }
+    a.cta { display:inline-block; margin-top:8px; padding:12px 22px;
+            background:#1a1a1a; color:#fbfaf7; text-decoration:none; border-radius:4px; }
+    table { border-collapse:collapse; margin:20px 0; }
+    td, th { border:1px solid #ddd; padding:8px 14px; text-align:left; font-size:16px; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Forged in Sheffield since 1947.</h1>
+    <p>We make chisels, planes, and marking gauges the slow way: drop-forged
+      high-carbon steel, hand-ground bevels, and beech handles turned in our own
+      workshop. No subscriptions. No app. Just tools that outlive their owner.</p>
+    <a class="cta" href="/catalogue">See the catalogue</a>
+
+    <h2>What we still do by hand</h2>
+    <p>Every blade is hardened, tempered, and tested against a brass rod before it
+      leaves the bench. If it chips in normal use within ten years, we re-grind it
+      for free.</p>
+
+    <h2>Prices</h2>
+    <table>
+      <tr><th>Tool</th><th>Steel</th><th>Price</th></tr>
+      <tr><td>Bench chisel, 25mm</td><td>O1 carbon</td><td>£38</td></tr>
+      <tr><td>Block plane</td><td>Ductile iron</td><td>£96</td></tr>
+      <tr><td>Marking gauge</td><td>Beech + brass</td><td>£44</td></tr>
+    </table>
+
+    <p>Ships from Sheffield. Order by post, phone, or the form on our orders page.</p>
+  </main>
+</body>
+</html>

--- a/packages/cli/test/fixtures/slop-vibecode.html
+++ b/packages/cli/test/fixtures/slop-vibecode.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FlowSync — Ship faster with AI</title>
+  <style>
+    /* Deliberately maximal AI-design-slop: Inter everywhere, indigo/violet
+       gradients, gradient-clip H1, eyebrow pill, glass cards, colored glows,
+       identical icon cards. Should score well out of Clean and trigger the
+       canonical font / purple / gradient-text tells. */
+    * { margin:0; padding:0; box-sizing:border-box; }
+    body { font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+           background:#0b0b12; color:#a1a1aa; text-align:center; }
+    .hero { padding:96px 20px 64px; }
+    .pill { display:inline-block; padding:6px 16px; border-radius:9999px;
+            background:rgba(124,58,237,0.15); color:#c4b5fd; font-size:13px;
+            letter-spacing:0.04em; text-transform:uppercase; margin-bottom:24px; }
+    h1 { font-size:76px; font-weight:800; letter-spacing:-0.04em; line-height:1.02;
+         background:linear-gradient(90deg,#818cf8,#c084fc 50%,#f0abfc);
+         -webkit-background-clip:text; background-clip:text;
+         -webkit-text-fill-color:transparent; color:transparent; margin:0 auto 20px; max-width:14ch; }
+    .sub { font-size:20px; color:#9ca3af; max-width:60ch; margin:0 auto 32px; }
+    .cta { display:inline-block; padding:14px 28px; border-radius:12px;
+           background:#7c3aed; color:#fff; text-decoration:none; font-weight:600;
+           box-shadow:0 20px 60px -10px rgba(124,58,237,0.7); }
+    .grid { display:grid; grid-template-columns:repeat(3,1fr); gap:20px;
+            max-width:1040px; margin:64px auto; padding:0 20px; }
+    .card { padding:28px; border-radius:16px;
+            background:linear-gradient(180deg,rgba(129,140,248,0.08),rgba(192,132,252,0.05));
+            backdrop-filter:blur(12px); -webkit-backdrop-filter:blur(12px);
+            border:1px solid rgba(255,255,255,0.06);
+            box-shadow:0 30px 80px -20px rgba(129,140,248,0.45); }
+    .card .ico { width:44px; height:44px; border-radius:12px; margin:0 auto 16px;
+                 background:linear-gradient(135deg,#818cf8,#c084fc); }
+    .card h3 { color:#e5e7eb; font-size:18px; font-weight:600; margin-bottom:8px; }
+    .card p { color:#9ca3af; font-size:14px; }
+    .aurora { position:fixed; inset:0; z-index:-1;
+              background:radial-gradient(60% 50% at 50% 0%, rgba(124,58,237,0.35), transparent),
+                         radial-gradient(40% 40% at 80% 20%, rgba(236,72,153,0.25), transparent); }
+  </style>
+</head>
+<body>
+  <div class="aurora"></div>
+  <section class="hero">
+    <span class="pill">Now in beta</span>
+    <h1>Ship faster with AI</h1>
+    <p class="sub">FlowSync is the all-in-one platform to build, ship, and scale.
+      Leverage AI to streamline your workflow and unlock your team's potential.</p>
+    <a class="cta" href="/signup">Get started free</a>
+  </section>
+
+  <section class="grid">
+    <div class="card"><div class="ico"></div><h3>Lightning fast</h3><p>Blazing-fast performance out of the box, so you can focus on what matters.</p></div>
+    <div class="card"><div class="ico"></div><h3>Secure by default</h3><p>Enterprise-grade security and compliance, baked in from day one.</p></div>
+    <div class="card"><div class="ico"></div><h3>Built to scale</h3><p>From your first user to your millionth, FlowSync grows seamlessly with you.</p></div>
+  </section>
+</body>
+</html>

--- a/packages/cli/test/golden.test.js
+++ b/packages/cli/test/golden.test.js
@@ -1,0 +1,45 @@
+// Golden detection tests — scan self-contained HTML fixtures in a REAL headless
+// browser and pin the detector's behavior on known-clean vs. known-slop pages.
+// This is the only coverage that exercises the 27 design-pattern `extract`
+// functions end to end (they need layout + computed styles, so jsdom won't do).
+//
+// Gated behind RUN_GOLDEN=1 because it needs Playwright + a Chromium binary. The
+// default `npm test` (and the browser-free CI "Unit tests" job) skip it; the
+// CI "Smoke test CLI" job installs Chromium and runs it with RUN_GOLDEN=1.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { scanUrl } from '../src/detector.js';
+
+const RUN = process.env.RUN_GOLDEN === '1';
+const fixture = (name) => new URL(`./fixtures/${name}`, import.meta.url).href;
+const triggered = (r, id) => r.patterns.find((p) => p.id === id)?.triggered === true;
+
+test('clean artisan page scores Clean and trips no font/purple tells', { skip: !RUN }, async () => {
+  const r = await scanUrl(fixture('clean-artisan.html'), { axes: ['design'] });
+  assert.equal(r.tier, 'Clean', `expected Clean, got ${r.tier} (score ${r.score})`);
+  assert.ok(r.score < 10, `Clean must be < 10, got ${r.score}`);
+  assert.equal(triggered(r, 'slop_fonts'), false, 'serif/system stack is not a slop font');
+  assert.equal(triggered(r, 'purple_accent'), false, 'no VibeCode purple here');
+  assert.equal(triggered(r, 'gradient_text'), false, 'no gradient-clip headline');
+});
+
+test('maximal VibeCode page scores out of Clean with the canonical tells', { skip: !RUN }, async () => {
+  const r = await scanUrl(fixture('slop-vibecode.html'), { axes: ['design'] });
+  // Coarse-but-robust: a page wearing Inter + indigo gradients + a gradient-clip
+  // H1 must not read as Clean, and the three dead-giveaways must fire.
+  assert.notEqual(r.tier, 'Clean', `slop page must not be Clean (score ${r.score})`);
+  assert.ok(r.score >= 10, `expected Mild+ (>=10), got ${r.score}`);
+  assert.equal(triggered(r, 'slop_fonts'), true, 'Inter stack should trip slop_fonts');
+  assert.equal(triggered(r, 'gradient_text'), true, 'gradient-clip H1 should trip gradient_text');
+  assert.equal(triggered(r, 'purple_accent'), true, 'violet filled CTA should trip purple_accent');
+});
+
+test('the two fixtures are clearly separated (slop scores well above clean)', { skip: !RUN }, async () => {
+  const [clean, slop] = await Promise.all([
+    scanUrl(fixture('clean-artisan.html'), { axes: ['design'] }),
+    scanUrl(fixture('slop-vibecode.html'), { axes: ['design'] })
+  ]);
+  assert.ok(slop.score - clean.score >= 15,
+    `expected a clear gap; clean=${clean.score} slop=${slop.score}`);
+});


### PR DESCRIPTION
Closes the last open item from the production review (#8): **detection was unmeasured.** This adds the harness to pin it and to make accuracy reportable.

## What's in it

- **Deterministic golden fixtures** — a hand-built clean page (`clean-artisan.html`) and a maximal-slop page (`slop-vibecode.html`: Inter + indigo gradients + gradient-clip H1 + glass cards + colored glows). `golden.test.js` scans them in a **real headless browser** and pins `clean → Clean` and `slop → not-Clean` + the canonical `slop_fonts` / `purple_accent` / `gradient_text` tells. This is the only coverage that exercises the 27 design-pattern `extract` functions end to end.
  - Gated on `RUN_GOLDEN=1`: the browser-free **Unit tests** job skips them (stays fast); the **Smoke test CLI** job (which installs Chromium) runs them.
- **Labeled corpus** (`packages/cli/calibration/corpus.json`) — a seed of confirmed-clean + sourced-Mild rows plus review candidates (`label: null`), honest about what's confirmed.
- **Calibration runner** (`npm run calibrate`) — predicted-vs-expected, a confusion matrix, accuracy over confirmed rows, and a list of unlabeled predictions to promote. `--local` / `--check` / `--json` modes.
- **`CALIBRATION.md`** — how to grow the corpus to 50–100 labeled URLs and tune the single-occurrence thresholds (glassmorphism/glows/gradient-text) to a number you can defend.

## Honest notes

- The corpus is a **seed** — enough to catch gross regressions, not to quote a headline accuracy %. `CALIBRATION.md` + `PRODUCTION.md` say exactly that and lay out the path.
- I can't run the golden tests in this sandbox (no Playwright/Chromium here), so the fixture assertions are deliberately **coarse** (tier-level + the three dead-giveaway patterns) and will be executed for real by the CI Smoke job. If an assertion is off, CI will say so.

## Tests
96 total: 93 pass, **3 golden skipped** (browser-free), lint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test, tooling, and documentation only; no changes to production scan or scoring paths beyond new optional CI and calibrate steps.
> 
> **Overview**
> Adds a **calibration and regression harness** so slop detection can be measured and pinned, without changing scoring logic.
> 
> **Golden browser tests** scan hand-built `clean-artisan.html` and `slop-vibecode.html` fixtures via Playwright, asserting tier separation and key patterns (`slop_fonts`, `purple_accent`, `gradient_text`). They run only when `RUN_GOLDEN=1`; CI’s **Smoke test CLI** job now installs Chromium and runs them before the existing HN smoke scan.
> 
> **Corpus + runner**: seed `corpus.json` (confirmed Clean/Mild rows plus `label: null` candidates), `npm run calibrate` (`run.mjs`) for predicted vs expected, confusion matrix, accuracy on labeled rows, and `--local` / `--json` / `--check` (fail on confirmed-label misses).
> 
> **Docs**: new `CALIBRATION.md` and `PRODUCTION.md` updated to reflect harness shipped vs corpus growth still pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4238366b765554d25ceea0a9d930b95a39159f9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->