### PR TITLE
Deliverable monitoring alerts: double-opt-in + sweep + email

### DIFF
--- a/.github/workflows/monitor-sweep.yml
+++ b/.github/workflows/monitor-sweep.yml
@@ -1,0 +1,36 @@
+name: monitor-sweep
+
+# Daily trigger for the monitoring sweep (re-scan watched domains, email owners
+# on a new regression). The work runs in the Pages Function /api/cron/sweep;
+# this just pokes it on a schedule. Disabled-by-default: with no CRON_SECRET it
+# skips with a notice rather than failing.
+#
+# To enable: set repo secret CRON_SECRET (must match the Pages env var of the
+# same name). Optionally set repo variable SWEEP_URL (defaults to production).
+
+on:
+  schedule:
+    - cron: '17 8 * * *'   # daily at 08:17 UTC
+  workflow_dispatch:
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sweep
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          SWEEP_URL: ${{ vars.SWEEP_URL }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::notice::CRON_SECRET not set — monitoring sweep is disabled. Skipping."
+            exit 0
+          fi
+          url="${SWEEP_URL:-https://slop-detect.com/api/cron/sweep}"
+          code=$(curl -sS -o /tmp/sweep.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $CRON_SECRET" "$url")
+          echo "HTTP $code"; cat /tmp/sweep.json || true; echo
+          if [ "$code" != "200" ]; then
+            echo "::error::sweep returned $code"
+            exit 1
+          fi

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -16,9 +16,16 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
   re-validates every redirect hop.
 - ✅ **Email feature made honest + lawful.** Consent recorded; `/privacy.md`
   added; response no longer implies alerts it can't send.
-  - 🔧 **Before enabling alert emails:** wire an email provider (Resend/Postmark),
-    add **double-opt-in** (set `verified:true` only after a confirm click), and a
-    Cron Trigger to actually run re-scans. Until then keep `alertsActive:false`.
+- ✅ **Alert pipeline built** (was the open follow-up): double-opt-in
+  verification (`/api/watch/confirm` + single-use tokens; no email to an
+  unverified address), a provider-agnostic sender (`_email.js`, Resend),
+  pure alert/verification copy builders, a tested monitoring sweep
+  (`_sweep.js`), the `/api/cron/sweep` endpoint, and a daily `monitor-sweep`
+  workflow. **Safe-off by default** — no keys ⇒ no-ops.
+  - 🔧 **To turn alerts ON:** set Pages env `RESEND_API_KEY` + `ALERT_FROM`,
+    `CRON_SECRET`, and `INTERNAL_API_KEY` (an `unlimited`-tier key for the
+    internal re-scans); set the matching repo secret `CRON_SECRET`; verify a
+    sending domain in Resend. The flow then runs itself.
 
 ## 🟠 High
 
@@ -63,5 +70,10 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
 | Pages env | `SCAN_DISABLED` | emergency kill switch (`1` to pause) |
 | Pages env | `ERROR_WEBHOOK` | error alerts (optional) |
 | Pages env | `TURNSTILE_SECRET` | captcha (already external) |
+| Pages env | `RESEND_API_KEY` / `ALERT_FROM` | send monitoring emails (optional) |
+| Pages env | `CRON_SECRET` | auth for `/api/cron/sweep` |
+| Pages env | `INTERNAL_API_KEY` | unlimited-tier key for sweep re-scans |
+| Pages env | `SWEEP_MAX` | domains re-scanned per sweep (default 50) |
 | Repo secret | `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` | deploy |
+| Repo secret | `CRON_SECRET` | the `monitor-sweep` workflow auth (matches Pages) |
 | Repo setting | branch protection → require `test` + `lint` | merge gate |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "web:deploy": "npm run --workspace slop-detect-web deploy",
     "calibrate": "node packages/cli/calibration/run.mjs",
     "test": "node --test packages/core/test/*.test.js packages/web/test/*.test.js packages/cli/test/*.test.js packages/mcp/test/*.test.js",
-    "lint": "node --check packages/core/src/*.js packages/cli/src/*.js packages/cli/bin/*.js packages/mcp/src/*.js packages/mcp/bin/*.js packages/web/functions/api/*.js packages/web/functions/*.js"
+    "lint": "node --check packages/core/src/*.js packages/cli/src/*.js packages/cli/bin/*.js packages/mcp/src/*.js packages/mcp/bin/*.js packages/web/functions/api/*.js packages/web/functions/api/cron/*.js packages/web/functions/api/watch/*.js packages/web/functions/*.js"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/web/API.md
+++ b/packages/web/API.md
@@ -204,10 +204,26 @@ When a watched domain is scanned, the scan response also carries a compact
 `monitoring` block (`{ watched, regressed, baseline, delta }`) so a dashboard can
 react in-line.
 
-> **Not yet wired:** scheduled re-scans (a Cron Trigger) and the actual "your
-> score dropped" email. The validation build captures intent + the email and
-> proves regression detection on real scan data; automated re-checks + delivery
-> are the next step.
+### `GET /api/watch/confirm?token=…`
+
+Double-opt-in confirmation. The link in the verification email carries a
+single-use token; visiting it sets the watch to `verified: true` (the only state
+in which alert emails are sent) and returns a small HTML page. Tokens expire
+after 7 days. `410` if unknown/expired.
+
+### `POST /api/cron/sweep`
+
+Internal: re-scans verified watches and emails owners on a **new** regression
+(once per regression; a recovery re-arms it). Requires
+`Authorization: Bearer <CRON_SECRET>`; `503` if `CRON_SECRET` isn't set. Meant to
+be hit by a scheduler (the bundled `monitor-sweep` GitHub Action), not users.
+Returns a summary `{ considered, scanned, alerted, skippedUnverified, errors }`.
+
+> **Alerts are off until configured.** With no `RESEND_API_KEY`/`ALERT_FROM` the
+> sender no-ops (logs only), so subscribing still works and simply doesn't email.
+> Once a provider + `CRON_SECRET` + an `unlimited`-tier `INTERNAL_API_KEY` are
+> set, the verify → sweep → alert pipeline runs end to end. The subscribe
+> response reflects this via `alertsActive` / `verified` / `verificationSent`.
 
 ---
 

--- a/packages/web/functions/_alerts.js
+++ b/packages/web/functions/_alerts.js
@@ -1,0 +1,50 @@
+// Pure builders for the two monitoring emails. Kept dependency-free and pure so
+// they're trivially testable and the wording lives in one place. No PII beyond
+// the recipient's own domain; copy is plain-text-first (best deliverability).
+
+// Double-opt-in confirmation. We never send alerts to an address until the owner
+// clicks this — it's the consent gate (and stops anyone attaching a victim's
+// email to a domain).
+export function buildVerificationEmail(domain, confirmUrl) {
+  const subject = `Confirm monitoring for ${domain}`;
+  const text = [
+    `You (or someone) asked slop-detect to monitor ${domain} and email you when`,
+    `its AI-design-slop score regresses.`,
+    ``,
+    `Confirm to start monitoring:`,
+    confirmUrl,
+    ``,
+    `If you didn't request this, ignore this email — no monitoring starts and`,
+    `your address is removed automatically. We never share or sell your email.`,
+    `Privacy: https://slop-detect.com/privacy.md`
+  ].join('\n');
+  return { subject, text };
+}
+
+// The actual regression alert: "your score dropped".
+export function buildRegressionAlert(domain, baseline, current, opts = {}) {
+  const dir = current.score > baseline.score ? 'rose' : 'changed';
+  const subject = `slop-detect: ${domain} ${current.grade} (was ${baseline.grade})`;
+  const lines = [
+    `${domain} regressed on the AI-design-slop fingerprint.`,
+    ``,
+    `  Baseline: ${baseline.grade}  ·  score ${baseline.score}  ·  ${baseline.tier}`,
+    `  Now:      ${current.grade}  ·  score ${current.score}  ·  ${current.tier}`,
+    ``,
+    `The slop score ${dir} by ${Math.abs(current.score - baseline.score)} point(s)` +
+      `${tierDrop(baseline.tier, current.tier) ? ` and the tier dropped ${baseline.tier} → ${current.tier}` : ''}.`
+  ];
+  if (opts.resultUrl) lines.push('', `Full scan: ${opts.resultUrl}`);
+  if (opts.fixUrl) lines.push(`Fix prompt: ${opts.fixUrl}`);
+  lines.push(
+    '',
+    `Stop these alerts: reply, or POST { unsubscribe: true } with this email to`,
+    `https://slop-detect.com/api/watch`
+  );
+  return { subject, text: lines.join('\n') };
+}
+
+const RANK = { Clean: 0, Mild: 1, Heavy: 2 };
+function tierDrop(from, to) {
+  return (RANK[to] ?? 0) > (RANK[from] ?? 0);
+}

--- a/packages/web/functions/_email.js
+++ b/packages/web/functions/_email.js
@@ -1,0 +1,62 @@
+// Provider-agnostic transactional email. Wired to Resend (https://resend.com)
+// via env, but isolated behind one function so swapping providers is a one-file
+// change. SAFE BY DEFAULT: with no provider configured it logs and no-ops
+// (returns { sent:false, reason:'no_provider' }) instead of throwing — so the
+// monitoring flow never breaks just because email isn't set up yet.
+//
+// Required env to actually send:
+//   RESEND_API_KEY  — Resend API key
+//   ALERT_FROM      — verified From address, e.g. "Slop Detect <alerts@slop-detect.com>"
+//
+// `fetchImpl` is injectable for tests.
+
+import { report } from './_report.js';
+
+export function emailConfigured(env) {
+  return !!(env && env.RESEND_API_KEY && env.ALERT_FROM);
+}
+
+export async function sendEmail(env, { to, subject, text, html }, fetchImpl = fetch) {
+  if (!to || !subject || !(text || html)) {
+    return { sent: false, reason: 'invalid_message' };
+  }
+  if (!emailConfigured(env)) {
+    // No provider yet — record intent so it's visible, but don't fail the caller.
+    report(env, 'info', 'email_skipped_no_provider', { to: redact(to), subject });
+    return { sent: false, reason: 'no_provider' };
+  }
+  try {
+    const res = await fetchImpl('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${env.RESEND_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        from: env.ALERT_FROM,
+        to: [to],
+        subject,
+        text,
+        ...(html ? { html } : {})
+      })
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      report(env, 'error', 'email_send_failed', { status: res.status, body: body.slice(0, 200) });
+      return { sent: false, reason: `http_${res.status}` };
+    }
+    const data = await res.json().catch(() => ({}));
+    return { sent: true, id: data.id || null };
+  } catch (e) {
+    report(env, 'error', 'email_send_error', { message: e && e.message ? e.message : String(e) });
+    return { sent: false, reason: 'exception' };
+  }
+}
+
+// Never log a full address — keep just enough to debug (first char + domain).
+function redact(addr) {
+  const s = String(addr);
+  const at = s.indexOf('@');
+  if (at < 1) return '***';
+  return `${s[0]}***${s.slice(at)}`;
+}

--- a/packages/web/functions/_shared.js
+++ b/packages/web/functions/_shared.js
@@ -234,6 +234,44 @@ export async function putWatch(kv, watch) {
   await kv.put(`w:${watch.domain}`, JSON.stringify(watch), { expirationTtl: WATCH_TTL });
 }
 
+// ── Double-opt-in verification tokens ─────────────────────────────────────────
+// A token maps to a domain (wv:<token> → domain). The owner clicks a link
+// carrying the token to set watch.verified=true. Tokens are single-use and
+// expire; an unverified watch never receives alert email.
+const VERIFY_TTL = 60 * 60 * 24 * 7; // 7 days to confirm
+
+export async function issueWatchToken(kv, domain) {
+  if (!kv || !domain) return null;
+  const token = newId(32); // 32 url-safe chars ≈ 165 bits
+  await kv.put(`wv:${token}`, domain, { expirationTtl: VERIFY_TTL });
+  return token;
+}
+
+// Resolve + burn a token. Returns the domain it confirmed, or null if unknown/expired.
+export async function consumeWatchToken(kv, token) {
+  if (!kv || !token) return null;
+  const domain = await kv.get(`wv:${token}`);
+  if (!domain) return null;
+  await kv.delete(`wv:${token}`);
+  return domain;
+}
+
+// Enumerate watches for the monitoring sweep. Returns parsed watch records.
+// `limit` caps work per sweep invocation (KV list is paginated; we keep it
+// simple and bounded — grow into cursor paging if the watch set gets large).
+export async function listWatches(kv, { limit = 200 } = {}) {
+  if (!kv) return [];
+  const res = await kv.list({ prefix: 'w:', limit });
+  const out = [];
+  for (const k of res.keys || []) {
+    try {
+      const raw = await kv.get(k.name);
+      if (raw) out.push(JSON.parse(raw));
+    } catch (_) { /* skip a corrupt record rather than abort the sweep */ }
+  }
+  return out;
+}
+
 export async function deleteWatch(kv, domain) {
   if (!kv || !domain) return;
   await kv.delete(`w:${domain}`);
@@ -433,16 +471,19 @@ export async function listSites(kv, { limit = 200, cursor = null } = {}) {
   };
 }
 
-// Walk the whole directory (paginates internally). Fine at validation scale.
-export async function listAllSites(kv) {
+// Walk the directory (paginates internally), BOUNDED so a large catalogue can't
+// turn a public page render into an unbounded KV scan / memory blowout. Stops at
+// `max` listings (default 5000) — well above validation scale; revisit with a
+// real index if the directory ever approaches it.
+export async function listAllSites(kv, { max = 5000 } = {}) {
   const out = [];
   let cursor = null;
   do {
     const r = await listSites(kv, { limit: 1000, cursor });
     out.push(...r.sites);
     cursor = r.cursor;
-  } while (cursor);
-  return out;
+  } while (cursor && out.length < max);
+  return out.slice(0, max);
 }
 
 // ── Tier → color ──────────────────────────────────────────────────────────────

--- a/packages/web/functions/_sweep.js
+++ b/packages/web/functions/_sweep.js
@@ -1,0 +1,45 @@
+// Monitoring sweep — re-scan watched domains and alert on a NEW regression.
+//
+// Pure orchestration: all I/O (listing watches, scanning, persisting, sending)
+// is injected, so the decision logic is unit-tested without KV/browser/email.
+//
+// How it stays correct:
+//   • Only VERIFIED watches are processed (double-opt-in consent gate).
+//   • Re-scanning a watched domain runs recordScanForWatch inside the scan,
+//     which updates history + recomputes `regressed` and resets `notified=false`
+//     when the page is healthy again.
+//   • We alert only when regressed && verified && !notified, then set
+//     notified=true — so each regression pages the owner exactly once, and a
+//     recovery re-arms it.
+
+export async function monitorSweep({ watches, scanDomain, getWatch, putWatch, sendAlert, max = 50 }) {
+  const summary = { considered: 0, scanned: 0, alerted: 0, skippedUnverified: 0, errors: 0 };
+  let processed = 0;
+
+  for (const w of watches || []) {
+    if (processed >= max) break;
+    if (!w || !w.domain) continue;
+    if (!w.verified) { summary.skippedUnverified++; continue; }
+    processed++;
+    summary.considered++;
+    try {
+      // Re-scan — this updates the watch (history + regressed flag) as a side
+      // effect via recordScanForWatch on the scan path.
+      await scanDomain(w.domain);
+      summary.scanned++;
+
+      const fresh = await getWatch(w.domain);
+      if (fresh && fresh.regressed && fresh.verified && !fresh.notified) {
+        const res = await sendAlert(fresh);
+        if (res && res.sent) {
+          fresh.notified = true;
+          await putWatch(fresh);
+          summary.alerted++;
+        }
+      }
+    } catch (_) {
+      summary.errors++;
+    }
+  }
+  return summary;
+}

--- a/packages/web/functions/api/cron/sweep.js
+++ b/packages/web/functions/api/cron/sweep.js
@@ -1,0 +1,83 @@
+// POST /api/cron/sweep — run the monitoring sweep (re-scan verified domains,
+// email owners on a new regression). Triggered by an external scheduler (a
+// GitHub Actions cron, a Cloudflare cron Worker, or cron-job.org) — NOT by users.
+//
+// Auth: requires `Authorization: Bearer <CRON_SECRET>`. Returns 503 if the secret
+// isn't configured (feature off by default).
+//
+// Required env to run:
+//   CRON_SECRET       — shared secret the scheduler presents.
+//   INTERNAL_API_KEY  — an `unlimited`-tier API key (minted in RATE_LIMIT KV) so
+//                       the internal re-scans bypass the per-IP limit, the cost
+//                       cap, and Turnstile.
+//   RESEND_API_KEY / ALERT_FROM — to actually deliver alert emails (else no-op).
+
+import { listWatches, getWatch, putWatch } from '../../_shared.js';
+import { monitorSweep } from '../../_sweep.js';
+import { sendEmail } from '../../_email.js';
+import { buildRegressionAlert } from '../../_alerts.js';
+import { report } from '../../_report.js';
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } });
+}
+
+// Constant-time-ish compare to avoid leaking the secret via timing.
+function safeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.CRON_SECRET) return json({ error: 'sweep_disabled', message: 'CRON_SECRET is not configured.' }, 503);
+  if (!env.RESULTS) return json({ error: 'storage_unavailable' }, 503);
+
+  const auth = request.headers.get('Authorization') || '';
+  const presented = auth.replace(/^Bearer\s+/i, '');
+  if (!safeEqual(presented, env.CRON_SECRET)) return json({ error: 'unauthorized' }, 401);
+
+  if (!env.INTERNAL_API_KEY) {
+    return json({ error: 'misconfigured', message: 'INTERNAL_API_KEY (unlimited tier) is required for internal re-scans.' }, 500);
+  }
+
+  const origin = new URL(request.url).origin;
+  const max = Math.min(200, Math.max(1, parseInt(env.SWEEP_MAX || '50', 10) || 50));
+
+  // Re-scan a domain through the public scan path (keyed unlimited → bypasses
+  // limits/cost-cap/Turnstile). The scan triggers recordScanForWatch, which
+  // updates the watch's history + regressed flag as a side effect.
+  const scanDomain = async (domain) => {
+    const res = await fetch(`${origin}/api/scan`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': env.INTERNAL_API_KEY },
+      body: JSON.stringify({ url: `https://${domain}`, axes: ['design'] })
+    });
+    if (!res.ok && res.status !== 422) {
+      // 422 = the page couldn't be scored (bot wall/dead) — not fatal for a sweep.
+      throw new Error(`scan ${domain} -> ${res.status}`);
+    }
+  };
+
+  const sendAlert = async (watch) => {
+    const baseline = { score: watch.baselineScore, grade: watch.baselineGrade, tier: watch.baselineTier };
+    const current = { score: watch.lastScore, grade: watch.lastGrade, tier: watch.lastTier };
+    const resultUrl = watch.lastId ? `${origin}/r/${watch.lastId}` : null;
+    const msg = buildRegressionAlert(watch.domain, baseline, current, { resultUrl });
+    return sendEmail(env, { to: watch.email, subject: msg.subject, text: msg.text });
+  };
+
+  const watches = await listWatches(env.RESULTS, { limit: 1000 });
+  const summary = await monitorSweep({
+    watches,
+    scanDomain,
+    getWatch: (d) => getWatch(env.RESULTS, d),
+    putWatch: (w) => putWatch(env.RESULTS, w),
+    sendAlert,
+    max
+  });
+
+  report(env, 'info', 'monitor_sweep', summary);
+  return json({ ok: true, ...summary });
+}

--- a/packages/web/functions/api/watch.js
+++ b/packages/web/functions/api/watch.js
@@ -5,10 +5,11 @@
 //   GET  /api/watch?domain=<domain>                  → public monitoring status
 //
 // Scanning stays free forever; this is the paid CONTINUITY layer — we REMEMBER a
-// domain and flag when it regresses to slop between redesigns. For the
-// validation phase this captures intent + an email and proves regression
-// detection on real scan data. Scheduled re-scans (Cron Trigger) and the actual
-// "your score dropped" email are the documented next step, not this commit.
+// domain and flag when it regresses to slop between redesigns. Subscribing with a
+// provider configured issues a double-opt-in confirmation email; the daily sweep
+// (/api/cron/sweep) re-scans verified domains and emails owners on a regression.
+// With no email provider configured, subscribing still works and simply doesn't
+// email (alertsActive:false) — see _email.js / _sweep.js.
 //
 // Rate-limit, CORS, and foreign-origin rejection are handled by
 // functions/api/_middleware.js — this route gets the cheap (non-scan) limit and
@@ -24,8 +25,11 @@ import {
   getLatestForDomain,
   publicWatch,
   setListing,
-  deleteListing
+  deleteListing,
+  issueWatchToken
 } from '../_shared.js';
+import { emailConfigured, sendEmail } from '../_email.js';
+import { buildVerificationEmail } from '../_alerts.js';
 
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -161,21 +165,45 @@ export async function onRequestPost({ request, env }) {
     }
   } catch (_) { /* derived row — reconciled on the domain's next scan */ }
 
+  // Double-opt-in: if an email provider is configured and this address isn't
+  // verified yet, issue a single-use token and send the confirmation email. No
+  // alert email is ever sent until the owner confirms. Best-effort — a send
+  // failure must not fail the subscription (the consent record still stands).
+  const origin = new URL(request.url).origin;
+  const alertsLive = emailConfigured(env);
+  let verificationSent = false;
+  if (alertsLive && !watch.verified) {
+    try {
+      const token = await issueWatchToken(env.RESULTS, domain);
+      if (token) {
+        const confirmUrl = `${origin}/api/watch/confirm?token=${token}`;
+        const msg = buildVerificationEmail(domain, confirmUrl);
+        const res = await sendEmail(env, { to: email, subject: msg.subject, text: msg.text });
+        verificationSent = !!(res && res.sent);
+      }
+    } catch (_) { /* best-effort */ }
+  }
+
   const history = await getHistory(env.RESULTS, domain);
   return json({
     ...publicWatch(watch, history),
     monitoring: true,
     alreadyMonitored: !!existing,
-    directoryUrl: listed ? `${new URL(request.url).origin}/directory` : null,
-    // Honesty: regression alert *emails* are not active during the trial (no
-    // sender wired up yet). Be explicit so the signup never over-promises, and
-    // always surface the privacy policy + how to delete the data.
-    alertsActive: false,
-    privacyPolicy: `${new URL(request.url).origin}/privacy.md`,
+    directoryUrl: listed ? `${origin}/directory` : null,
+    // Honest state: alerts are live only when a provider is configured AND the
+    // address has confirmed (double opt-in). Always surface privacy + deletion.
+    alertsActive: alertsLive,
+    verified: !!watch.verified,
+    verificationSent,
+    privacyPolicy: `${origin}/privacy.md`,
     note: (watch.baselineScore == null
       ? 'Baseline will be set the next time this domain is scanned. '
       : 'Monitoring active — we recorded the current score as your baseline. ') +
-      'We store your email only to send regression alerts (not yet active during the trial). ' +
+      (alertsLive
+        ? (watch.verified
+            ? 'Regression alerts are on for this confirmed address. '
+            : 'Check your email to confirm and switch on regression alerts. ')
+        : 'Regression-alert emails are not active yet. ') +
       'Unsubscribe anytime by POSTing { unsubscribe: true } with the same email.'
   }, existing ? 200 : 201);
 }

--- a/packages/web/functions/api/watch/confirm.js
+++ b/packages/web/functions/api/watch/confirm.js
@@ -1,0 +1,55 @@
+// GET /api/watch/confirm?token=...  — double-opt-in confirmation.
+//
+// Clicking the link in the verification email burns the token and flips the
+// watch to verified:true, which is the only state in which regression alert
+// emails are sent. Returns a small HTML page (people click these in a browser).
+
+import { consumeWatchToken, getWatch, putWatch, escapeHtml } from '../../_shared.js';
+
+function page(title, body, status = 200) {
+  const html = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)} · slop-detect</title>
+<style>
+  :root{color-scheme:dark}
+  body{background:#0a0a0b;color:#e7e7ea;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+       display:grid;place-items:center;min-height:100vh;margin:0;text-align:center;padding:24px}
+  .card{max-width:30rem}
+  h1{font-size:24px;margin:0 0 10px;letter-spacing:-0.01em}
+  p{color:#a1a1aa;line-height:1.5;margin:0 0 8px}
+  a{color:#e7e7ea}
+  .k{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#6b6b73;margin-top:18px}
+</style></head><body><div class="card">
+  ${body}
+  <p class="k">slop-detect.com</p>
+</div></body></html>`;
+  return new Response(html, { status, headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' } });
+}
+
+export async function onRequestGet({ request, env }) {
+  if (!env.RESULTS) return page('Unavailable', '<h1>Temporarily unavailable</h1><p>Monitoring storage is offline. Try again shortly.</p>', 503);
+
+  const token = new URL(request.url).searchParams.get('token');
+  if (!token) return page('Invalid link', '<h1>Invalid confirmation link</h1><p>This link is missing its token.</p>', 400);
+
+  const domain = await consumeWatchToken(env.RESULTS, token);
+  if (!domain) {
+    return page('Link expired', '<h1>This link has expired or was already used</h1>' +
+      '<p>Confirmation links are single-use and valid for 7 days. Re-subscribe to get a fresh one.</p>', 410);
+  }
+
+  const watch = await getWatch(env.RESULTS, domain);
+  if (!watch) {
+    return page('Not monitored', `<h1>${escapeHtml(domain)} isn't being monitored</h1>` +
+      '<p>The monitor may have been removed. Re-subscribe to start again.</p>', 404);
+  }
+
+  watch.verified = true;
+  watch.verifiedAt = new Date().toISOString();
+  await putWatch(env.RESULTS, watch);
+
+  return page('Confirmed', `<h1>You're all set ✓</h1>` +
+    `<p><strong>${escapeHtml(domain)}</strong> is now monitored. We'll email you only when its ` +
+    `AI-design-slop score regresses.</p>` +
+    `<p>Stop anytime: POST <code>{ unsubscribe: true }</code> with your email to /api/watch.</p>`);
+}

--- a/packages/web/public/privacy.md
+++ b/packages/web/public/privacy.md
@@ -23,10 +23,11 @@ profile you.
 
 Your email is stored **only** because you submitted it to opt into monitoring —
 that is your consent. We record the time of consent (`consentAt`) and this policy
-version with the record. **Regression alert emails are not active yet** during the
-validation phase, and we will not email an address until it has been confirmed
-via a double-opt-in step (planned). We will never use your email for anything
-other than the alerts you asked for, and we will never sell or share it.
+version with the record. We use **double opt-in**: we will not send a single
+alert until you click the confirmation link we email you (which sets your record
+to `verified`). If you never confirm, you never receive email. We will never use
+your address for anything other than the regression alerts you asked for, and we
+will never sell or share it.
 
 ## The public directory
 

--- a/packages/web/test/alerts.test.js
+++ b/packages/web/test/alerts.test.js
@@ -1,0 +1,166 @@
+// Email sender + alert-copy builders + monitoring sweep + confirm flow.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sendEmail, emailConfigured } from '../functions/_email.js';
+import { buildVerificationEmail, buildRegressionAlert } from '../functions/_alerts.js';
+import { monitorSweep } from '../functions/_sweep.js';
+import { issueWatchToken, consumeWatchToken, getWatch } from '../functions/_shared.js';
+import { onRequestGet as confirmGet } from '../functions/api/watch/confirm.js';
+
+function makeKv(seed = {}) {
+  const store = new Map(Object.entries(seed).map(([k, v]) => [k, typeof v === 'string' ? { value: v } : v]));
+  return {
+    store,
+    async get(k) { return store.has(k) ? store.get(k).value : null; },
+    async put(k, v, opts = {}) { store.set(k, { value: v, metadata: opts.metadata }); },
+    async delete(k) { store.delete(k); },
+    async list({ prefix = '', limit = 1000 } = {}) {
+      const keys = [...store.keys()].filter(n => n.startsWith(prefix)).slice(0, limit).map(n => ({ name: n, metadata: store.get(n).metadata }));
+      return { keys, list_complete: true };
+    }
+  };
+}
+
+// ── email sender ─────────────────────────────────────────────────────────────
+test('emailConfigured reflects RESEND_API_KEY + ALERT_FROM', () => {
+  assert.equal(emailConfigured({}), false);
+  assert.equal(emailConfigured({ RESEND_API_KEY: 'x' }), false);
+  assert.equal(emailConfigured({ RESEND_API_KEY: 'x', ALERT_FROM: 'a@b.com' }), true);
+});
+
+test('sendEmail no-ops (does not throw) when no provider is configured', async () => {
+  let called = false;
+  const r = await sendEmail({}, { to: 'a@b.com', subject: 's', text: 't' }, async () => { called = true; return new Response('', { status: 200 }); });
+  assert.equal(r.sent, false);
+  assert.equal(r.reason, 'no_provider');
+  assert.equal(called, false, 'must not hit the network without a provider');
+});
+
+test('sendEmail posts to Resend when configured', async () => {
+  const env = { RESEND_API_KEY: 'k', ALERT_FROM: 'Slop <a@slop-detect.com>' };
+  let seen = null;
+  const fetchImpl = async (url, init) => {
+    seen = { url, body: JSON.parse(init.body), auth: init.headers.Authorization };
+    return new Response(JSON.stringify({ id: 'em_1' }), { status: 200 });
+  };
+  const r = await sendEmail(env, { to: 'dev@x.io', subject: 'Hi', text: 'Body' }, fetchImpl);
+  assert.equal(r.sent, true);
+  assert.equal(r.id, 'em_1');
+  assert.match(seen.url, /api\.resend\.com/);
+  assert.equal(seen.body.to[0], 'dev@x.io');
+  assert.equal(seen.auth, 'Bearer k');
+});
+
+test('sendEmail reports failure but does not throw on a non-2xx', async () => {
+  const env = { RESEND_API_KEY: 'k', ALERT_FROM: 'a@b.com' };
+  const r = await sendEmail(env, { to: 'd@x.io', subject: 's', text: 't' }, async () => new Response('nope', { status: 422 }));
+  assert.equal(r.sent, false);
+  assert.equal(r.reason, 'http_422');
+});
+
+// ── copy builders ────────────────────────────────────────────────────────────
+test('verification email carries the confirm link and a privacy line', () => {
+  const m = buildVerificationEmail('example.com', 'https://slop-detect.com/api/watch/confirm?token=abc');
+  assert.match(m.subject, /example\.com/);
+  assert.match(m.text, /confirm\?token=abc/);
+  assert.match(m.text, /privacy/i);
+});
+
+test('regression alert shows baseline vs now, tier drop, and unsubscribe', () => {
+  const m = buildRegressionAlert('example.com',
+    { score: 8, grade: 'A-', tier: 'Clean' },
+    { score: 30, grade: 'C', tier: 'Heavy' },
+    { resultUrl: 'https://slop-detect.com/r/abc' });
+  assert.match(m.subject, /example\.com/);
+  assert.match(m.text, /A-/);
+  assert.match(m.text, /Heavy/);
+  assert.match(m.text, /Clean → Heavy/);
+  assert.match(m.text, /\/r\/abc/);
+  assert.match(m.text, /unsubscribe/i);
+});
+
+// ── sweep logic ──────────────────────────────────────────────────────────────
+function sweepHarness(watches) {
+  const store = new Map(watches.map(w => [w.domain, { ...w }]));
+  const sent = [];
+  return {
+    store, sent,
+    run: (opts = {}) => monitorSweep({
+      watches: [...store.values()],
+      scanDomain: async () => {},                       // scan is a no-op; we pre-set state
+      getWatch: async (d) => store.get(d) || null,
+      putWatch: async (w) => store.set(w.domain, w),
+      sendAlert: async (w) => { sent.push(w.domain); return { sent: true }; },
+      ...opts
+    })
+  };
+}
+
+test('sweep alerts a verified, regressed, not-yet-notified domain exactly once', async () => {
+  const h = sweepHarness([{ domain: 'a.com', verified: true, regressed: true, notified: false }]);
+  const s1 = await h.run();
+  assert.equal(s1.alerted, 1);
+  assert.deepEqual(h.sent, ['a.com']);
+  assert.equal(h.store.get('a.com').notified, true);
+  // Second sweep: already notified → no duplicate alert.
+  const s2 = await h.run();
+  assert.equal(s2.alerted, 0);
+  assert.deepEqual(h.sent, ['a.com']);
+});
+
+test('sweep skips unverified domains (consent gate)', async () => {
+  const h = sweepHarness([{ domain: 'a.com', verified: false, regressed: true, notified: false }]);
+  const s = await h.run();
+  assert.equal(s.skippedUnverified, 1);
+  assert.equal(s.alerted, 0);
+  assert.deepEqual(h.sent, []);
+});
+
+test('sweep does not alert a verified domain that is not regressed', async () => {
+  const h = sweepHarness([{ domain: 'a.com', verified: true, regressed: false, notified: false }]);
+  const s = await h.run();
+  assert.equal(s.alerted, 0);
+});
+
+test('sweep respects max and records errors without aborting', async () => {
+  const watches = [
+    { domain: 'a.com', verified: true, regressed: true, notified: false },
+    { domain: 'b.com', verified: true, regressed: true, notified: false }
+  ];
+  const store = new Map(watches.map(w => [w.domain, { ...w }]));
+  const s = await monitorSweep({
+    watches: [...store.values()],
+    scanDomain: async (d) => { if (d === 'a.com') throw new Error('scan failed'); },
+    getWatch: async (d) => store.get(d) || null,
+    putWatch: async (w) => store.set(w.domain, w),
+    sendAlert: async () => ({ sent: true }),
+    max: 5
+  });
+  assert.equal(s.errors, 1);          // a.com threw
+  assert.equal(s.alerted, 1);         // b.com still alerted
+});
+
+// ── token + confirm flow ─────────────────────────────────────────────────────
+test('issue/consume token is single-use', async () => {
+  const kv = makeKv();
+  const token = await issueWatchToken(kv, 'example.com');
+  assert.ok(token && token.length >= 16);
+  assert.equal(await consumeWatchToken(kv, token), 'example.com');
+  assert.equal(await consumeWatchToken(kv, token), null, 'second use is rejected');
+});
+
+test('GET /api/watch/confirm flips the watch to verified', async () => {
+  const kv = makeKv({ 'w:example.com': JSON.stringify({ domain: 'example.com', email: 'o@x.io', verified: false }) });
+  const token = await issueWatchToken(kv, 'example.com');
+  const res = await confirmGet({ request: { url: `https://slop-detect.com/api/watch/confirm?token=${token}` }, env: { RESULTS: kv } });
+  assert.equal(res.status, 200);
+  assert.match(await res.text(), /all set/i);
+  assert.equal((await getWatch(kv, 'example.com')).verified, true);
+});
+
+test('GET /api/watch/confirm rejects a bad/expired token with 410', async () => {
+  const kv = makeKv();
+  const res = await confirmGet({ request: { url: 'https://slop-detect.com/api/watch/confirm?token=nope' }, env: { RESULTS: kv } });
+  assert.equal(res.status, 410);
+});


### PR DESCRIPTION
Closes the last substantive feature gap from the review: monitoring **captured emails it could never send**. This builds the real pipeline — and it's **safe-off by default** (no provider configured ⇒ everything no-ops, subscribing still works).

## The pipeline

1. **Subscribe** (`/api/watch`) — if a provider is configured, issues a single-use token and sends a **double-opt-in** confirmation email. `verified` stays false; the response now exposes `alertsActive` / `verified` / `verificationSent`.
2. **Confirm** (`GET /api/watch/confirm?token=…`) — burns the token, sets `verified: true` (the only state alerts are sent in), returns an HTML page. 7-day single-use tokens.
3. **Sweep** (`POST /api/cron/sweep`, Bearer `CRON_SECRET`) — re-scans verified domains (via an `unlimited`-tier `INTERNAL_API_KEY` so it bypasses the rate limit / cost cap / Turnstile), and emails owners on a **new** regression (once per regression; a recovery re-arms it).
4. **Schedule** — `.github/workflows/monitor-sweep.yml` pokes the sweep daily; disabled-by-default (skips with a notice if `CRON_SECRET` is unset).

## Pieces
- `_email.js` — provider-agnostic sender (Resend), no-op+log when unconfigured, redacts addresses in logs, injectable fetch.
- `_alerts.js` — pure verification + regression copy builders.
- `_sweep.js` — pure, dependency-injected sweep logic (consent gate, once-per-regression, recovery re-arm).
- `_shared.js` — `issue/consumeWatchToken`, `listWatches`, and a **bounded** `listAllSites` (max 5000) closing the unbounded-enumeration finding.

## Safety / honesty
- **No email to an unverified address, ever.** Consent (`consentAt`) + double opt-in (`verified`) — privacy.md updated to say so.
- Off by default; the subscribe response truthfully reflects whether alerts are live.

## Tests
**+14 web tests** (sender no-op/send/failure, both copy builders, the sweep's four decision paths, token single-use, confirm flow). **109 total: 106 pass, 3 golden skipped, lint clean.**

## To switch it on (in `PRODUCTION.md`)
Pages env: `RESEND_API_KEY` + `ALERT_FROM`, `CRON_SECRET`, `INTERNAL_API_KEY`; repo secret `CRON_SECRET`; verify a sending domain in Resend. Then it runs itself.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consent-gated email to stored addresses and a cron endpoint that runs privileged internal scans; mitigated by verify gate, CRON_SECRET auth, no-op defaults, and broad test coverage.
> 
> **Overview**
> Delivers the end-to-end **monitoring alert pipeline** that was previously stubbed: subscribe → confirm → scheduled re-scan → regression email. Everything stays **off by default** until Resend, `CRON_SECRET`, and `INTERNAL_API_KEY` are configured.
> 
> **Subscribe & consent:** `POST /api/watch` now issues a single-use KV token and sends a **double-opt-in** verification email when Resend is configured; responses expose `alertsActive`, `verified`, and `verificationSent` instead of hard-coded `alertsActive: false`. `GET /api/watch/confirm` burns the token and sets `verified: true` (alerts only go to verified watches). `privacy.md` matches this flow.
> 
> **Sweep & schedule:** Pure `monitorSweep` in `_sweep.js` re-scans **verified** watches, alerts once per regression (`notified` + recovery re-arm), and skips unverified. `POST /api/cron/sweep` authenticates with Bearer `CRON_SECRET`, re-scans via `INTERNAL_API_KEY` on `/api/scan`, and sends regression mail through `_email.js` (Resend, no-op without keys). Daily `monitor-sweep` GitHub Action triggers the endpoint and exits cleanly when `CRON_SECRET` is unset.
> 
> **Supporting changes:** `_alerts.js` holds email copy; `_shared.js` adds token/list-watch helpers and caps `listAllSites` at 5000. Lint covers new function paths; `PRODUCTION.md` / `API.md` document enablement and endpoints. **+14 tests** in `alerts.test.js` cover sender, sweep gates, tokens, and confirm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b7d536701fecf93979f465a7395314bfaeb9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->