### PR TITLE
docs: refresh README + wrangler env for v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ By April 2026, AI-generated landing pages had collapsed onto a measurable visual
 - 🟢 **`slop-detect.com`** — drop-in web UI, scan any URL in 8 seconds
 - 🟢 **`slop-detect-core`** — pure detection engine, embed it in your own pipeline
 
-All three share the **same 19-rule scoring engine** so a Heavy from the CLI is a Heavy from the web is a Heavy from the API.
+All three share the **same 27-rule scoring engine** so a Heavy from the CLI is a Heavy from the web is a Heavy from the API.
 
 ## Try it now
 
@@ -61,6 +61,9 @@ curl -s -X POST -H 'Content-Type: application/json' \
 
 # CLI — for CI, batch scans, or air-gapped work
 npx slop-detect https://your-site.com
+
+# CLI without a local browser — scan via the API (zero Playwright install)
+npx slop-detect https://your-site.com --remote
 
 # Agent Skill — drop into Claude Code / Cursor / Copilot / Codex / Junie
 git clone --depth 1 https://github.com/ravidsrk/slop-detect /tmp/sd \
@@ -118,6 +121,25 @@ when slop creeps above your threshold.
 grade (fail if the grade is worse). Leave it empty for report-only mode.
 
 The repo also ships an [Agent Skill](skills/slop-detect/SKILL.md) following the [agentskills.io](https://agentskills.io) open spec — any compatible agent (Claude Code, Cursor, GitHub Copilot, Gemini CLI, Codex, Roo Code, Junie, and 20+ others) will autonomously invoke the scanner when you ask it to audit a landing page.
+
+## Monitor a domain + the directory
+
+Detection is free and stateless. The optional **continuity** layer remembers a
+domain and emails you when it regresses to slop between redesigns:
+
+```bash
+# Start monitoring (double opt-in: you confirm via an emailed link)
+curl -s -X POST -H 'Content-Type: application/json' \
+  https://slop-detect.com/api/watch \
+  -d '{"url":"https://your-site.com","email":"you@example.com","list":true}'
+```
+
+`list: true` also opts the domain into the public, crawlable
+[**directory**](https://slop-detect.com/directory) of scored sites — an
+owner-gated catalogue with a real backlink to each listed site. We only store
+your email to send the alerts you asked for, only after you confirm, and never
+sell it — see the [privacy policy](https://slop-detect.com/privacy.md). Engine
+stays MIT and free forever; only continuity (history + alerts) is the paid layer.
 
 ## The 27 patterns
 
@@ -227,7 +249,7 @@ slop-detect/
 │   └── web/     slop-detect-web    ← Cloudflare Pages app powering slop-detect.com
 ```
 
-A monorepo with npm workspaces. The `core` package is the single source of truth for the 19 rules — `cli` and `web` are thin runtime adapters around it.
+A monorepo with npm workspaces. The `core` package is the single source of truth for the 27 rules — `cli` and `web` are thin runtime adapters around it.
 
 ## Quickstart — contributing
 

--- a/packages/web/wrangler.toml
+++ b/packages/web/wrangler.toml
@@ -27,3 +27,18 @@ id = "f8bbc9f7a16948a2995215321e679115"
 # Pages env vars and is never written to disk).
 [vars]
 TURNSTILE_SITEKEY = "0x4AAAAAADWirXpm1gXBhB5E"
+
+# ── Operational env (set as Pages env vars / secrets, NOT committed) ──────────
+# Cost & safety:
+#   SCAN_DAILY_CAP    daily global browser-scan budget (default 10000)
+#   SCAN_DISABLED     "1" to pause scanning (kill switch)
+#   ERROR_WEBHOOK     optional Slack/Discord/Sentry URL for error alerts
+# Captcha:
+#   TURNSTILE_SECRET  Turnstile secret (required for browser scans)
+# Monitoring alerts (all optional — absent ⇒ alerts no-op):
+#   RESEND_API_KEY    Resend API key
+#   ALERT_FROM        verified From, e.g. "Slop Detect <alerts@slop-detect.com>"
+#   CRON_SECRET       Bearer secret for POST /api/cron/sweep
+#   INTERNAL_API_KEY  an `unlimited`-tier API key for the sweep's internal re-scans
+#   SWEEP_MAX         domains re-scanned per sweep (default 50)
+# See PRODUCTION.md for the full launch checklist.


### PR DESCRIPTION
Front-door cleanup so the README matches what the code now does, and the operator knows which env vars to set.

- **README**: fixes stale rule counts (`19` → `27`, two places that contradicted the title), adds the `--remote` CLI example (zero-install scanning), and a short **"Monitor a domain + the directory"** section covering double-opt-in, the public directory + backlink, the privacy policy, and the MIT/free-engine boundary.
- **wrangler.toml**: documents the operational env vars introduced across #3/#5 (`SCAN_DAILY_CAP`, `SCAN_DISABLED`, `ERROR_WEBHOOK`, `RESEND_API_KEY`/`ALERT_FROM`, `CRON_SECRET`, `INTERNAL_API_KEY`, `SWEEP_MAX`) so they're discoverable at the config site, pointing to `PRODUCTION.md`.

Docs only. 109 tests (106 pass, 3 golden skipped), lint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and config comments only; no application logic or secrets committed.
> 
> **Overview**
> **README** is brought in line with v0.6.0: stale **19-rule** references are corrected to **27** (intro + monorepo blurb), the **`--remote`** CLI example is added for API-backed scans without Playwright, and a new **Monitor a domain + the directory** section documents `POST /api/watch`, double opt-in, the public directory/backlink, privacy, and the free-engine vs paid-continuity split.
> 
> **`packages/web/wrangler.toml`** gains an inline comment block listing operational Pages env vars (scan caps/kill switch, Turnstile secret, Resend alerts, cron sweep secrets) with defaults and a pointer to **`PRODUCTION.md`** — no runtime or binding changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a526860b5c5e1cb20f0c16af41c14030787a92b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->