### PR TITLE
fix(ci): add npm ci to calibrate workflow

### DIFF
--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - run: npm ci
       - name: Run calibration
         env:
           SLOP_API_KEY: ${{ secrets.SLOP_API_KEY }}


### PR DESCRIPTION
Preserves a valid autofix that landed on the (now-merged) PR #8 branch *after* it merged, so it isn't lost in branch cleanup.

`calibrate.yml` runs `run.mjs`, which imports `slop-detect-core` (a workspace package). Without `npm ci` to link the workspace, the job fails with `ERR_MODULE_NOT_FOUND`. This adds the missing `npm ci` step.

One-line CI fix (originally by Cursor Bugbot). No app code.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow step only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> The monthly **calibrate** GitHub Actions workflow now runs **`npm ci`** after Node setup and before **`run.mjs`**.
> 
> That links workspace packages (including **`slop-detect-core`**, pulled in via **`packages/cli`**) so the calibration job no longer fails with **`ERR_MODULE_NOT_FOUND`** on a bare checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458c4d84c864a806f4b2fcae45253a2113ef97ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->