### PR TITLE
Roadmap v2 + the system axis (DESIGN.md compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,29 @@ slop-detect https://example.com --preset minimal       # the 3 dead-giveaways
 The API accepts `{ "url": "...", "preset": "strict" }`. New patterns can be added
 declaratively — see [CONTRIBUTING.md](CONTRIBUTING.md#the-low-friction-path-declarative-rules).
 
+## The system axis — DESIGN.md compliance
+
+The absolute slop score asks "does this look AI-generated?" The **system axis**
+asks the durable question: **"does this page honor its own declared design
+system?"** Declare your tokens in a [DESIGN.md](https://github.com/google-labs-code/design.md)
+(Google Labs' open spec — colors, typography, radii, components), and
+slop-detect reports **drift**: fonts in use that aren't declared, CTA/surface
+colors off the palette, radii off the scale. Relative, per-site, and immune to
+the false-positive trap — a bespoke site checked against its own system scores
+*Aligned*, never "slop."
+
+```bash
+slop-detect https://your-site.com --design-md auto        # <origin>/DESIGN.md
+slop-detect https://your-site.com --design-md ./DESIGN.md  # local file
+
+curl -s -X POST -H 'Content-Type: application/json' \
+  https://slop-detect.com/api/scan \
+  -d '{"url":"https://your-site.com","designMd":true}' | jq .system
+```
+
+Higher is better: `Aligned` (≥80) · `Drifting` (≥50) · `Off-system` (<50).
+Every drift item is a named, contestable signal — never a verdict.
+
 ## Multi-axis slop — design + copy
 
 Slop isn't only visual. The same page that wears a v0 template usually has

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,203 +1,159 @@
-# slop-detect — Strategic Roadmap
+# slop-detect — Strategic Roadmap v2
 
-> Where this open-source project goes next, and why.
-> Last updated: 2026-05-28 · Current version: v0.1.2
-
-This roadmap is grounded in a mid-2026 landscape scan of the AI-design-slop space
-and a study of how shareable dev-tool OSS projects grow and sustain themselves.
-It is opinionated on purpose. See [Appendix: Research basis](#appendix-research-basis).
-
-> **Now reading this differently.** The flywheel below is built and shipping —
-> but it was sequenced before we confirmed a buyer. The immediate priority is no
-> longer "build the next phase"; it's a time-boxed experiment to find who pays.
-> See **[VALIDATION.md](VALIDATION.md)** — a 30-day buyer-validation plan with a
-> pre-committed go / no-go gate (decision date 2026-07-05). This roadmap resumes
-> once the market has picked the lane.
+> Where this project goes next, and why.
+> Last updated: 2026-06-05 · Current version: v0.6.0
+> Supersedes the v1 roadmap (preserved in git history). Grounded in the
+> June 2026 deep-research pass — see "Research basis" at the bottom — and in
+> our own calibration evidence (`CALIBRATION.md`).
 
 ---
 
-## 1. The thesis
+## 1. The thesis (revised)
 
-slop-detect today is a **detector**: it scores a landing page against a fixed
-16-rule fingerprint. That is a good wedge, but the research is unambiguous about
-two pressures:
+**Slop is the hook, not the product.**
 
-1. **A static fingerprint is a depreciating asset.** The patterns Adrian Krebs
-   catalogued are early-2026 artifacts. As guardrails spread (Google's
-   `DESIGN.md` standard, anti-slop skills like Hallmark, design-system features
-   in v0/Lovable/Bolt) and as the aesthetic mean moves (bento grids, aurora
-   gradients, generative UI), **the defaults shift every few months**. A fixed
-   16-rule list will decay.
+Three research findings force the revision:
 
-2. **Detection-only is commoditizing.** There are now ~20+ named slop tools.
-   The commercial leader (Sailop) productized *prevention + remediation +
-   templates*. Pure detectors risk becoming free utilities.
+1. **The fixed visual fingerprint decays in ~6–18 months.** Signature-style
+   detectors reliably degrade (antivirus, AI-text detectors), and the
+   generators are being actively engineered to suppress the default look:
+   Google's **DESIGN.md** standard (Apache-2.0, ~15k★, ships `lint`/`export`
+   tooling) injects per-brand constraints into AI builders and agents — the
+   design-world equivalent of malware polymorphism. The thing we detect is
+   being standardized away.
 
-So the strategy is a deliberate two-part position:
+2. **Absolute slop-grading is commoditized.** Impeccable (~34.7k★, free, OSS)
+   owns the "most patterns" game; Sailop, aiwebsitedetector et al. fill the
+   rest, all enumerating the same tells. A rule list is copyable in an
+   afternoon. Meanwhile "slop" the meme peaked (2025 Word of the Year) — the
+   attention is a **depreciating asset to harvest, not a moat to defend**.
 
-> **Be the neutral, open measurement standard for design slop — the
-> "Lighthouse for design taste" — and make the score travel.**
->
-> Win on (a) a **continuously-updated, versioned, community-sourced ruleset**
-> ("slop definitions", like virus definitions) so currency is the moat, and
-> (b) **distribution surfaces** (shareable score cards, embeddable badges, a
-> GitHub Action / PR check, an MCP server) so the score embeds itself into
-> developer workflow and social feeds.
+3. **Our own evidence shows the fatal failure mode.** The detector scores
+   Linear/Vercel as Heavy and Stripe as Mild — punishing a *style* as
+   *provenance*, the exact false-positive trap that killed OpenAI's own AI-text
+   classifier and discredited the text-detector industry (Stanford/Cell). An
+   absolute "is this AI?" verdict cannot be made reliable; a **relative**
+   question can.
 
-Everything below serves that thesis.
+So the strategy inverts:
+
+> **Free, loud slop grader = acquisition channel (now, while attention peaks).**
+> **Paid product = continuous design-system / brand-drift monitoring —
+> "your non-designers and coding agents keep shipping to your site; we keep it
+> on-brand and on-system" — sold to agencies and teams as recurring continuity.**
+> **Technical posture: ride DESIGN.md, don't fight it.** Compliance with a
+> site's *own declared system* is a relative signal that cannot decay and
+> structurally cannot false-positive on great custom design.
 
 ---
 
-## 2. North-star metrics
+## 2. The product ladder
 
-| Metric | Why it matters |
+```
+acquire (free, peak-hype)          retain (paid, durable)
+┌──────────────────────────┐       ┌──────────────────────────────────┐
+│ slop grader (web/CLI/MCP)│  ───► │ monitored domains (built, v0.6)  │
+│ leaderboard + directory  │       │ + design-system drift (NEW axis) │
+│ badges + share cards     │       │ + agency multi-site dashboards   │
+│ AEO axis (free funnel)   │       │ + white-label PDF reports        │
+└──────────────────────────┘       │ + CI gate on system compliance   │
+                                   └──────────────────────────────────┘
+```
+
+The continuity layer (watch/alerts/directory) shipped in v0.6.0. The missing
+piece — and **the first deliverable of this roadmap** — is the relative axis
+that makes monitoring worth paying for:
+
+### P1 — The `system` axis: DESIGN.md compliance (NOW)
+
+"Does this page honor its declared design system?" Parse a site's `DESIGN.md`
+(Google Labs spec: YAML front-matter tokens — colors, typography, rounded,
+spacing, components), compare against what the scanned page actually renders
+(fonts in use, CTA/surface colors, radii), and report **drift** as named,
+contestable signals. Ships in core (pure, zero-dep), CLI (`--design-md`), and
+the web API. This:
+- **fixes the Linear/Stripe false-positive class structurally** — a bespoke
+  site checked against its own tokens scores *aligned*, not "slop";
+- **cannot decay** — the reference point is per-customer, not a global fashion;
+- **aligns us with the standard that would otherwise obsolete us**.
+
+### P2 — Sell continuity to agencies (NEXT, 1–2 quarters)
+
+The research is unambiguous about the indie buyer: **digital agencies** pay
+recurring for white-label reports, scheduled multi-site audits, and drift
+alerts ($29–$149/mo band; flat-rate beats per-site at 10–20 client sites).
+Build: multi-domain dashboard, branded PDF export, drift-alert emails (the
+pipeline shipped in v0.6), CI gate on `system` compliance. Open-core stays MIT
+(Plausible/Sentry/Semgrep model); charge for continuity, collaboration, scale.
+Realistic target: **$1–10K MRR within 12–18 months**, plus $800–4K/mo
+well-structured GitHub Sponsors.
+
+### P3 — Versioned community ruleset ("slop definitions") (ONGOING)
+
+Keep the free fingerprint current on the **Semgrep registry model**:
+community-contributed, versioned, months-cadence refresh; favor structural
+tells (badge-above-H1, stripe borders) that outlast color fashion; track
+DESIGN.md/builder updates as the leading decay indicator. Calibration
+(`CALIBRATION.md`, labeled corpus, honest precision/recall) is **strategic**,
+not housekeeping: signals-not-verdicts is the credibility model.
+
+### P4 — Agent-loop depth (ONGOING)
+
+The MCP server's job shifts from "scan after the fact" to "**the design-system
+check inside the coding-agent loop** before it ships" — consuming the repo's
+DESIGN.md. Workflow lock-in is the only durable distribution.
+
+---
+
+## 3. What we will NOT do (research-backed guardrails)
+
+- **No ML/vision/LLM-judge as the core engine.** Per-call cost, OOD collapse
+  (18–30% on current generators), and the false-positive credibility crisis.
+  At most: an opt-in *pairwise* LLM critique layer; never the scoring authority.
+- **No head-on AEO/citation-tracking business.** The monetizable core is owned
+  by funded startups (Profound ~$1B) and Semrush/Ahrefs; our crawlability/
+  llms.txt axis is the commoditized free slice — keep it as funnel only.
+- **No "% AI" verdicts, ever.** Named rules, contestable signals, page-not-person.
+- **No one-time licenses.** (Tailwind UI's collapse is the cautionary tale.)
+  Recurring only.
+- **No rule-count arms race with Impeccable.** Differentiate on continuity +
+  compliance + workflow, not pattern count.
+- **Engine stays MIT, free, offline-capable. Forever.** (Unchanged from v1.)
+
+---
+
+## 4. North-star metrics (revised)
+
+| Metric | Why |
 |---|---|
-| **Scans / week** (web + API + CLI + action) | Core usage; top of every funnel |
-| **Badges embedded in the wild** | Self-replicating backlink loop |
-| **Score cards shared** (OG image views) | Viral coefficient |
-| **Community rules merged** | Ruleset currency = the moat |
-| **Repos running `slop-detect-action`** | Workflow stickiness |
-| **GitHub stars / npm weekly downloads** | Credibility + discovery |
-
-We are NOT optimizing for revenue in the near term. Revenue is a Phase 4
-question and is deliberately structured to never compromise the OSS core.
+| Monitored domains (free → paid) | The business |
+| Agencies on multi-site plans | The buyer the research says converts |
+| Pages checked against a DESIGN.md | Adoption of the durable axis |
+| Definitions version freshness / community rules merged | Anti-decay |
+| Scans/week + leaderboard/directory traffic | Top of funnel (harvest the hype) |
 
 ---
 
-## 3. Phased plan
+## 5. Sequencing
 
-### Phase 1 — Make the score travel (distribution primitives)
-
-*Theme: every scan should produce something shareable and embeddable.
-These are the highest-leverage, lowest-cost moves in the whole roadmap.*
-
-- **P1.1 — Shareable score card + OG image** (`#01`)
-  Persist each scan to a short URL (`slop-detect.com/r/<id>`) that renders an
-  auto-generated OG image: big letter grade + score + a punchy one-liner verdict.
-  This is the #1 viral primitive every grader tool relies on.
-- **P1.2 — Embeddable badge** (`#02`)
-  `slop-detect.com/badge/<domain>.svg` returning a live "slop: A · 6/100" badge,
-  plus copy-paste HTML/Markdown/React snippets. Submit as a first-party
-  shields.io service badge for discovery.
-- **P1.3 — Letter grades + tier polish** (`#03`)
-  Add an A–F letter grade layer on top of the 0–100 score (graders that spread
-  all use a memorable letter). Keep numeric score as source of truth.
-
-### Phase 2 — Embed into the workflow (CI + agents)
-
-*Theme: move from one-off scans to recurring, in-workflow checks.*
-
-- **P2.1 — `slop-detect-action` GitHub Action** (`#04`)
-  Marketplace-listed action: scan deploy-preview URLs, post a **sticky PR
-  comment** with score + diff vs. baseline, set a **status check** with a
-  configurable `fail-under` threshold. Optionally update the README badge.
-- **P2.2 — Public REST API with rate-limited tiers** (`#05`)
-  Formalize `/api/scan` + `/api/fix-prompt` as a documented public API with
-  per-key rate limits. Free tier generous; keys for bulk/embedded use.
-- **P2.3 — MCP server** (`#06`)
-  Ship `slop-detect-mcp` so Cursor / Claude Code / Windsurf agents can
-  self-audit a page before shipping. Complements the existing agent skill.
-
-### Phase 3 — Keep the ruleset current (the moat)
-
-*Theme: turn a fixed fingerprint into a living, versioned, community standard.*
-
-- **P3.1 — Versioned "slop definitions"** (`#07`)
-  Version and date the ruleset (e.g. `definitions@2026.06`). Surface which
-  definition version produced a score. Establish a changelog for pattern changes.
-- **P3.2 — Declarative rule format + contribution flow** (`#08`)
-  Define a declarative rule schema (the eslint/semgrep playbook) so contributing
-  a 17th/18th pattern is low-friction. Web + PR contribution paths, attribution,
-  named presets (`strict`, `marketing`, `minimal`).
-- **P3.3 — New-pattern tracking** (`#09`)
-  Add emerging 2026 patterns (bento-grid walls, aurora/mesh gradients,
-  generative-UI tells) and retire/down-weight decayed ones. This is recurring
-  maintenance, not a one-off.
-- **P3.4 — AI-builder provenance signal** (`#10`)
-  Optional companion signal: "likely built with v0 / Lovable / Bolt / Framer".
-  Owns an SEO-rich keyword space and pairs uniquely with the genericness score
-  ("built with Lovable AND scores 78/100").
-
-### Phase 4 — Expand the surface & sustain (franchise + funding)
-
-*Theme: grow beyond visual design and fund the OSS core — without betraying it.*
-
-- **P4.1 — Multi-axis slop score (design + copy + code)** (`#11`)
-  Add deterministic **copy-slop** (em-dash overload, "delve", "in today's
-  fast-paced world", rule-of-three, "unlock/elevate/seamless") and a **code-slop**
-  hook. One page → three sub-scores → one unified slop score. Reuses the existing
-  scoring architecture.
-- **P4.2 — Data-journalism leaderboard** (`#12`)
-  Periodically scan a famous corpus ("Top 500 YC / SaaS landing pages ranked by
-  AI slop"), publish a public leaderboard + "Hall of Clean / Hall of Slop". Pure
-  linkbait that rides the "slop is Word of the Year" zeitgeist.
-- **P4.3 — `DESIGN.md` compliance mode** (`#13`)
-  As Google's `DESIGN.md` standard spreads, audit "does this page honor its
-  declared design system, or regress to defaults?" Aligns us with the standard
-  rather than against it.
-- **P4.4 — Sustainability: Pro tier + sponsors** (`#14`)
-  Keep the engine MIT and offline-capable forever. Monetize **continuity,
-  collaboration, scale, and compliance** only: historical tracking + regression
-  alerts (Pro ~$9–19/mo), team dashboards (~$49–99/mo), white-label agency PDF
-  reports, and GitHub Sponsors / Open Collective for goodwill.
+| Move | Status |
+|---|---|
+| P1 `system` axis (core + CLI + API) | **In progress (this release)** |
+| P2a Drift alerts on `system` axis via existing sweep | After P1 |
+| P2b Agency dashboard + white-label PDF | Next quarter |
+| P2c Pricing live ($29–$149/mo) | With P2b |
+| P3 Community ruleset + calibration corpus growth | Ongoing |
+| P4 MCP design-system mode | After P1 |
 
 ---
 
-## 4. Prioritization (leverage vs. effort)
+## Research basis (June 2026)
 
-| Move | Leverage | Effort | When |
-|---|---|---|---|
-| P1.1 Score card + OG image | 🔴 High | Low | **Now** |
-| P1.2 Embeddable badge | 🔴 High | Low | **Now** |
-| P1.3 Letter grades | 🟡 Med | Low | **Now** |
-| P2.1 GitHub Action | 🔴 High | Med | Next |
-| P3.2 Declarative rules + contribution | 🔴 High | Med | Next |
-| P2.3 MCP server | 🟡 Med | Low | Next |
-| P3.1 Versioned definitions | 🟡 Med | Low | Next |
-| P2.2 Public API tiers | 🟡 Med | Med | Later |
-| P3.3 New-pattern tracking | 🟡 Med | Recurring | Ongoing |
-| P3.4 Provenance signal | 🟡 Med | Med | Later |
-| P4.1 Multi-axis slop | 🟢 Strategic | High | Later |
-| P4.2 Data-journalism leaderboard | 🔴 High | Med | Opportunistic |
-| P4.3 DESIGN.md mode | 🟢 Strategic | Med | Later |
-| P4.4 Pro tier / sponsors | 🟢 Strategic | Med | Phase 4 |
-
-**Recommended next sprint:** P1.1 + P1.2 + P1.3 (the distribution primitives) —
-they compound, they're cheap, and they make every existing scan more valuable.
-
----
-
-## 5. Guardrails (what we will NOT do)
-
-- We will **not** feature-gate the detection engine. `slop-detect-core` and the
-  CLI stay MIT, free, and offline-capable forever. Trust is the asset.
-- We will **not** position a slop score as a verdict on a person or company. It
-  is one signal among many ("everyone uses AI now" is a strong, correct
-  counter-narrative — overclaiming gets us dunked on).
-- We will **not** let the ruleset go stale. A decayed fingerprint is worse than
-  no fingerprint. Currency > cleverness.
-- We will **not** become a fixer-template store (that lane is taken). We are the
-  neutral, open *measurement* standard.
-
----
-
-## Appendix: Research basis
-
-This roadmap synthesizes two research streams (May 2026):
-
-**Landscape** — "AI slop" is mainstream (Merriam-Webster 2025 Word of the Year;
-the "Slop Rebellion"). Adrian Krebs's ~1,400-page Playwright study (67% carry AI
-fingerprints) is the defining artifact and our methodological baseline. Sailop is
-the commercial leader (298-rule engine, rule-injection CLI, paid templates, MCP).
-Provenance detectors (aiwebsitedetector.com et al.) own a separate SEO space.
-Google's `DESIGN.md` (open-sourced Apr 2026, 14K★) plus anti-slop skills will
-reduce raw slop over time — making *currency* the moat. "Slop" is generalizing
-into a 3-axis franchise: design / copy / code.
-
-**Growth** — Every viral grader (HubSpot Website Grader, securityheaders.com,
-Mozilla Observatory, Lighthouse, websitecarbon.com) wins on the same loop:
-*free instant value → a memorable grade → a shareable/embeddable artifact →
-a leaderboard/shame dynamic*. Badges (shields.io) and CI integration
-(Lighthouse CI) are the two proven distribution flywheels. Monetization that
-respects OSS (Snyk/Sentry/semgrep model): keep the engine free, charge for
-continuity, collaboration, scale, and compliance.
+Deep-research pass across market, shelf-life, AEO, monetization, and technical
+frontier. Key citations: DESIGN.md spec + adoption (github.com/google-labs-code/design.md);
+Impeccable (impeccable.style); fingerprint-decay precedents (arXiv 2603.23146,
+SentinelOne signature-vs-behavioral); false-positive precedent (Stanford/Cell
+Liang & Zou; OpenAI classifier shutdown); MLLM-as-UI-judge limits (arXiv
+2510.08783); AEO incumbency (Fortune: Profound $96M Series C; Semrush/Ahrefs AI
+visibility); indie monetization (Plausible $1M-ARR write-up; Semgrep registry;
+agency audit-tool pricing; Tailwind UI decline, devclass Jan 2026).

--- a/packages/cli/bin/slop.js
+++ b/packages/cli/bin/slop.js
@@ -7,12 +7,12 @@
 // Scores any URL against the AI-design-slop fingerprint and emits a
 // pretty terminal report or a machine-readable JSON blob.
 
-import { scanUrl, scanRemote, aeoRemote } from '../src/detector.js';
+import { scanUrl, scanRemote, aeoRemote, loadDesignMd } from '../src/detector.js';
 import { isPreset, PRESETS, PATTERNS, DEFINITIONS_VERSION, runAeoChecks } from 'slop-detect-core';
 
 const args = process.argv.slice(2);
 const urls = [];
-const flags = { json: false, screenshot: false, verbose: false, preset: 'full', axes: ['design'], failOn: null, aeo: false, remote: false, api: null };
+const flags = { json: false, screenshot: false, verbose: false, preset: 'full', axes: ['design'], failOn: null, aeo: false, remote: false, api: null, designMd: null };
 
 // Tier severity ordering for --fail-on. A scan exits non-zero when its tier is
 // at or above the requested threshold. 'blocked'/'error' always count as failures
@@ -43,6 +43,14 @@ for (let i = 0; i < args.length; i++) {
   else if (a === '--api' || a.startsWith('--api=')) {
     flags.api = a.startsWith('--api=') ? a.slice('--api='.length) : args[++i];
     flags.remote = true; // a custom API endpoint implies remote scanning
+  }
+  else if (a === '--design-md' || a.startsWith('--design-md=')) {
+    const val = a.startsWith('--design-md=') ? a.slice('--design-md='.length) : args[++i];
+    if (!val) {
+      console.error('--design-md needs a value: a file path, a URL, or "auto" (looks for <origin>/DESIGN.md).');
+      process.exit(2);
+    }
+    flags.designMd = val;
   }
   else if (a === '--axes' || a.startsWith('--axes=')) {
     const val = a.startsWith('--axes=') ? a.slice('--axes='.length) : args[++i];
@@ -128,6 +136,10 @@ Options:
   --remote          Scan via the slop-detect.com API instead of a local browser
                     (no Playwright/Chromium install needed). Honors SLOP_API_KEY.
   --api <url>       Use a custom API base (implies --remote). Env: SLOP_API
+  --design-md <src> System axis: check the page against its declared design
+                    system (DESIGN.md spec). <src> = file path, URL, or "auto"
+                    (looks for <origin>/DESIGN.md). Reports drift, not slop —
+                    higher is better. Local scans only for now.
   --fail-on <tier>  Exit non-zero (1) if any page scores at/above tier: mild | heavy.
                     A blocked or errored scan also exits 1. Use this to gate CI.
   --help, -h        Show this help
@@ -292,12 +304,57 @@ function renderAeo(aeo) {
   }
 }
 
+function systemTierStyle(tier) {
+  if (tier === 'Aligned') return C.green;
+  if (tier === 'Drifting') return C.yellow;
+  if (tier === 'Off-system') return C.red;
+  return C.grey;
+}
+function systemEmoji(tier) {
+  if (tier === 'Aligned') return '🟢';
+  if (tier === 'Drifting') return '🟡';
+  if (tier === 'Off-system') return '🔴';
+  return '⚪';
+}
+
+function renderSystem(sys) {
+  if (!sys.declared) {
+    console.log(`  ${C.grey}⚪ system  — ${sys.message}${C.reset}\n`);
+    return;
+  }
+  const ts = systemTierStyle(sys.tier);
+  const name = sys.name ? ` ${C.grey}(${sys.name})${C.reset}` : '';
+  console.log(`  ${systemEmoji(sys.tier)} ${C.bold}system ${C.reset} ${ts}${sys.tier.padEnd(10)}${C.reset}` +
+    `  score ${C.bold}${String(sys.score).padStart(3)}${C.reset}/100` +
+    `  ${C.grey}(${sys.checksEvaluated} checks · ${sys.checksSkipped} skipped)${C.reset}${name}`);
+  console.log(`  ${C.grey}Does this page honor its declared design system?${C.reset}`);
+  console.log();
+  if (sys.drift.length) {
+    console.log(`${C.bold}Drift:${C.reset}`);
+    for (const d of sys.drift) {
+      console.log(`  ${C.red}✗${C.reset} ${d.message}  ${C.grey}(${d.id})${C.reset}`);
+      if (flags.verbose && d.evidence) {
+        console.log(`      ${C.grey}${JSON.stringify(d.evidence).slice(0, 200)}${C.reset}`);
+      }
+    }
+    console.log();
+  }
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 (async () => {
   const results = [];
   for (const url of urls) {
     try {
       const scanOpts = { screenshot: flags.screenshot, preset: flags.preset, axes: flags.axes, api: flags.api };
+      if (flags.designMd && !flags.remote) {
+        const loaded = await loadDesignMd(flags.designMd, url);
+        if (loaded) scanOpts.designMd = loaded.text;
+        else if (!flags.json) console.error(`${C.grey}No DESIGN.md found for ${url} (auto) — skipping the system axis.${C.reset}`);
+      } else if (flags.designMd && flags.remote) {
+        console.error('--design-md is not supported with --remote yet; drop --remote to scan locally.');
+        process.exit(2);
+      }
       const r = flags.remote ? await scanRemote(url, scanOpts) : await scanUrl(url, scanOpts);
       if (flags.aeo) {
         try {
@@ -311,6 +368,7 @@ function renderAeo(aeo) {
       results.push(r);
       if (!flags.json) {
         renderPretty(r);
+        if (r.system) renderSystem(r.system);
         if (r.aeo && !r.aeo.error) renderAeo(r.aeo);
         else if (r.aeo && r.aeo.error) console.log(`  ${C.yellow}⚠ AEO check failed: ${r.aeo.error}${C.reset}\n`);
       }

--- a/packages/cli/src/detector.js
+++ b/packages/cli/src/detector.js
@@ -14,6 +14,9 @@ import {
   scorePatterns,
   applyPreset,
   extractTextContext,
+  extractSystemContext,
+  parseDesignMd,
+  scoreSystemCompliance,
   scoreCopy,
   combineAxes
 } from 'slop-detect-core';
@@ -137,7 +140,7 @@ function normalizeAxes(axes) {
   return [...new Set(out)];
 }
 
-function buildPageScript() {
+function buildPageScript(opts = {}) {
   const patternCalls = PATTERNS.map(p => `
     try {
       signals[${JSON.stringify(p.id)}] = (${p.extract.toString()})(ctx);
@@ -193,6 +196,14 @@ function buildPageScript() {
     let textContext = null;
     try { textContext = extractTextContext(); } catch (e) { textContext = { error: e.message }; }
 
+    // System axis (DESIGN.md compliance): observe fonts/colors/radii in use.
+    // Only injected when a DESIGN.md was supplied — scoring is Node-side.
+    let systemContext = null;
+    ${opts.includeSystem ? `
+    const extractSystemContext = ${extractSystemContext.toString()};
+    try { systemContext = extractSystemContext(); } catch (e) { systemContext = { error: e.message }; }
+    ` : ''}
+
     return {
       title: document.title,
       url: location.href,
@@ -202,9 +213,32 @@ function buildPageScript() {
       h1Font: h1 ? getComputedStyle(h1).fontFamily : null,
       visibleCount: visible.length,
       signals,
-      textContext
+      textContext,
+      systemContext
     };
   })();`;
+}
+
+// ── DESIGN.md loading (system axis) ──────────────────────────────────────────
+// Resolve the --design-md value to raw text. `auto` looks for <origin>/DESIGN.md
+// next to the scanned page; a 404 in auto mode returns null ("no system
+// declared") rather than an error, since absence is a normal state.
+export async function loadDesignMd(source, pageUrl) {
+  if (source === 'auto') {
+    const url = new URL('/DESIGN.md', pageUrl).toString();
+    try {
+      const res = await fetch(url, { headers: { Accept: 'text/markdown,text/plain,*/*' } });
+      if (!res.ok) return null;
+      return { text: await res.text(), from: url };
+    } catch { return null; }
+  }
+  if (/^https?:\/\//i.test(source)) {
+    const res = await fetch(source);
+    if (!res.ok) throw new Error(`Could not fetch DESIGN.md from ${source} (HTTP ${res.status})`);
+    return { text: await res.text(), from: source };
+  }
+  const { readFile } = await import('node:fs/promises');
+  return { text: await readFile(source, 'utf8'), from: source };
 }
 
 // ── Remote mode ──────────────────────────────────────────────────────────────
@@ -273,7 +307,7 @@ export async function scanUrl(url, opts = {}) {
     await page.waitForLoadState('networkidle', { timeout: 8000 }).catch(() => {});
     await page.waitForTimeout(500);
 
-    const data = await page.evaluate(buildPageScript());
+    const data = await page.evaluate(buildPageScript({ includeSystem: !!opts.designMd }));
 
     // Anti-bot / dead-page detection — don't silently return Clean 0.
     const blocked = detectBlocked(data);
@@ -353,6 +387,14 @@ export async function scanUrl(url, opts = {}) {
       const summaries = {};
       for (const a of reqAxes) if (axes[a]) summaries[a] = axes[a];
       Object.assign(result, combineAxes(summaries));
+    }
+
+    // System axis: opts.designMd carries the raw DESIGN.md text (the caller
+    // handles loading from file/URL). Scored Node-side against the observed
+    // fonts/colors/radii. Reported separately from the slop score — it measures
+    // alignment with the site's OWN system (higher is better), not slop.
+    if (opts.designMd) {
+      result.system = scoreSystemCompliance(parseDesignMd(opts.designMd), data.systemContext);
     }
 
     if (opts.screenshot) {

--- a/packages/cli/test/fixtures/artisan-DESIGN.md
+++ b/packages/cli/test/fixtures/artisan-DESIGN.md
@@ -1,0 +1,23 @@
+---
+name: Sheffield Heritage
+colors:
+  ink: "#1a1a1a"
+  paper: "#fbfaf7"
+  line: "#dddddd"
+typography:
+  h1:
+    fontFamily: Georgia
+    fontSize: 44px
+  body:
+    fontFamily: Georgia
+rounded:
+  sm: 4px
+components:
+  button-primary:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.paper}"
+---
+
+## Overview
+Ink on paper. Serif, restrained, built to outlive its owner — the design system
+of the clean-artisan fixture, for the system-axis golden test.

--- a/packages/cli/test/fixtures/mismatched-DESIGN.md
+++ b/packages/cli/test/fixtures/mismatched-DESIGN.md
@@ -1,0 +1,16 @@
+---
+name: Violet Modern
+colors:
+  primary: "#7c3aed"
+  surface: "#0b0b12"
+typography:
+  body:
+    fontFamily: Inter
+rounded:
+  md: 12px
+---
+
+## Overview
+A deliberately WRONG system for the clean-artisan fixture (Inter + violet +
+dark) — the golden test asserts the serif/ink/paper page reads as drift
+against it.

--- a/packages/cli/test/golden.test.js
+++ b/packages/cli/test/golden.test.js
@@ -55,3 +55,25 @@ test('the two fixtures are clearly separated (slop scores well above clean)', { 
   assert.ok(slop.score - clean.score >= 15,
     `expected a clear gap; clean=${clean.score} slop=${slop.score}`);
 });
+
+// ── System axis (DESIGN.md compliance) — end-to-end in a real browser ────────
+import { readFile } from 'node:fs/promises';
+const fixtureText = (name) => readFile(new URL(`./fixtures/${name}`, import.meta.url), 'utf8');
+
+test('a page that honors its DESIGN.md scores Aligned', { skip: !RUN }, async () => {
+  const md = await fixtureText('artisan-DESIGN.md');
+  const r = await scanUrl(fixture('clean-artisan.html'), { axes: ['design'], designMd: md });
+  assert.ok(r.system, 'system axis attached');
+  assert.equal(r.system.declared, true);
+  assert.equal(r.system.tier, 'Aligned',
+    `expected Aligned, got ${r.system.tier} (${r.system.score}) drift=${JSON.stringify(r.system.drift)}`);
+});
+
+test('the same page against the WRONG system reads as drift, with named signals', { skip: !RUN }, async () => {
+  const md = await fixtureText('mismatched-DESIGN.md');
+  const r = await scanUrl(fixture('clean-artisan.html'), { axes: ['design'], designMd: md });
+  assert.notEqual(r.system.tier, 'Aligned', `got ${r.system.tier} (${r.system.score})`);
+  const ids = r.system.drift.map((d) => d.id);
+  assert.ok(ids.includes('fonts.declared'), 'Georgia is not in the Inter-only system');
+  assert.ok(ids.includes('colors.cta'), 'ink CTA is not in the violet palette');
+});

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -32,6 +32,16 @@ export {
   toMarkdownUrl,
   runAeoChecks
 } from './aeo.js';
+export {
+  parseDesignMd,
+  extractFrontMatter,
+  extractSystemContext,
+  flattenDesignTokens,
+  scoreSystemCompliance,
+  primaryFamily,
+  parseCssColor,
+  SYSTEM_CHECKS
+} from './system.js';
 
 import { gradeForScore, verdictFor } from './verdict.js';
 import { COPY_PATTERNS } from './copyPatterns.js';

--- a/packages/core/src/system.js
+++ b/packages/core/src/system.js
@@ -1,0 +1,412 @@
+// The `system` axis — DESIGN.md compliance ("does this page honor its declared
+// design system?").
+//
+// WHY THIS AXIS EXISTS (Roadmap v2 P1): the absolute slop fingerprint decays as
+// AI builders adopt per-brand constraints, and it false-positives on premium
+// bespoke design (Linear/Stripe — see CALIBRATION.md). Compliance with a site's
+// OWN declared tokens is a *relative* signal: it cannot decay (the reference is
+// per-customer, not a global fashion) and it cannot punish great custom design.
+// Higher is better, like the AEO axis — this measures alignment, not slop.
+//
+// Reference format: Google Labs DESIGN.md spec (github.com/google-labs-code/design.md,
+// Apache-2.0, alpha): YAML front matter between `---` fences carries the
+// normative tokens (colors, typography, rounded, spacing, components — with
+// `{path.to.token}` cross-references); markdown prose follows. "The tokens are
+// the normative values."
+//
+// Pure JS, zero deps. The YAML reader below is a deliberate SUBSET parser
+// (nested maps + scalar leaves + comments — what the spec's token schema uses).
+// It degrades gracefully: anything it can't read is skipped, and a file with no
+// readable tokens yields null so the axis reports "no system declared" rather
+// than inventing drift. Signals, never verdicts.
+
+// ── Front-matter extraction ──────────────────────────────────────────────────
+export function extractFrontMatter(text) {
+  if (typeof text !== 'string') return null;
+  const m = text.match(/^﻿?\s*---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  return m ? m[1] : null;
+}
+
+// Minimal YAML-subset reader: nested maps, scalar leaves, quoted/unquoted
+// values, full-line + trailing comments. Arrays and multi-line scalars are
+// skipped (not used by the DESIGN.md token schema).
+function parseYamlSubset(src) {
+  const root = {};
+  // Stack of { indent, node } — current nesting path.
+  const stack = [{ indent: -1, node: root }];
+  for (const rawLine of src.split(/\r?\n/)) {
+    if (!rawLine.trim() || /^\s*#/.test(rawLine)) continue;
+    const indent = rawLine.match(/^ */)[0].length;
+    const line = rawLine.trim();
+    if (line.startsWith('- ')) continue; // arrays: out of scope, skip safely
+
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    let value = line.slice(idx + 1).trim();
+
+    // Pop to the parent for this indentation level.
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop();
+    const parent = stack[stack.length - 1].node;
+
+    if (value === '') {
+      const child = {};
+      parent[key] = child;
+      stack.push({ indent, node: child });
+      continue;
+    }
+    // Quoted value: take the quoted content verbatim (protects "#1A1C1E").
+    const q = value.match(/^(['"])(.*?)\1/);
+    if (q) value = q[2];
+    else {
+      // Unquoted: strip a trailing comment (space + #).
+      const c = value.search(/\s#/);
+      if (c >= 0) value = value.slice(0, c).trim();
+    }
+    parent[key] = value;
+  }
+  return root;
+}
+
+// Resolve {path.to.token} references against the parsed tree (one pass, with a
+// small chain allowance; unresolvable references stay as-is).
+function resolveRefs(tree) {
+  const lookup = (path) => {
+    let node = tree;
+    for (const part of path.split('.')) {
+      if (!node || typeof node !== 'object') return undefined;
+      node = node[part];
+    }
+    return typeof node === 'string' ? node : undefined;
+  };
+  const walk = (node) => {
+    for (const k of Object.keys(node)) {
+      const v = node[k];
+      if (v && typeof v === 'object') { walk(v); continue; }
+      if (typeof v !== 'string') continue;
+      let cur = v, hops = 0;
+      while (hops++ < 4) {
+        const m = cur.match(/^\{([\w.-]+)\}$/);
+        if (!m) break;
+        const resolved = lookup(m[1]);
+        if (resolved === undefined || resolved === cur) break;
+        cur = resolved;
+      }
+      node[k] = cur;
+    }
+  };
+  walk(tree);
+  return tree;
+}
+
+// Parse a DESIGN.md document into its token tree. Returns null when there is no
+// readable front matter or no recognizable tokens (caller reports "no system").
+export function parseDesignMd(text) {
+  const fm = extractFrontMatter(text);
+  if (!fm) return null;
+  let tree;
+  try { tree = resolveRefs(parseYamlSubset(fm)); } catch { return null; }
+  const hasTokens = ['colors', 'typography', 'rounded', 'spacing', 'components']
+    .some((k) => tree[k] && typeof tree[k] === 'object' && Object.keys(tree[k]).length > 0);
+  if (!hasTokens) return null;
+  return {
+    name: typeof tree.name === 'string' ? tree.name : null,
+    colors: tree.colors || {},
+    typography: tree.typography || {},
+    rounded: tree.rounded || {},
+    spacing: tree.spacing || {},
+    components: tree.components || {}
+  };
+}
+
+// ── Token flattening ─────────────────────────────────────────────────────────
+const GENERIC_FONTS = new Set([
+  'sans-serif', 'serif', 'monospace', 'cursive', 'fantasy', 'system-ui',
+  'ui-sans-serif', 'ui-serif', 'ui-monospace', 'ui-rounded', '-apple-system',
+  'blinkmacsystemfont', 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol',
+  'noto color emoji', 'emoji', 'math'
+]);
+
+function normFont(name) {
+  return String(name || '').replace(/['"]/g, '').trim().toLowerCase();
+}
+
+// First concrete (non-generic) family in a CSS font-family stack.
+export function primaryFamily(stack) {
+  for (const part of String(stack || '').split(',')) {
+    const f = normFont(part);
+    if (f && !GENERIC_FONTS.has(f)) return f;
+  }
+  return null;
+}
+
+// Parse a CSS color (hex 3/4/6/8, rgb()/rgba()) → [r,g,b] or null. oklch/named
+// colors fall back to exact-string matching in the comparator.
+export function parseCssColor(str) {
+  const s = String(str || '').trim().toLowerCase();
+  let m = s.match(/^#([0-9a-f]{3,4})$/);
+  if (m) {
+    const h = m[1];
+    return [0, 1, 2].map((i) => parseInt(h[i] + h[i], 16));
+  }
+  m = s.match(/^#([0-9a-f]{6})([0-9a-f]{2})?$/);
+  if (m) {
+    const h = m[1];
+    return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+  }
+  m = s.match(/^rgba?\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)/);
+  if (m) return [Number(m[1]), Number(m[2]), Number(m[3])];
+  return null;
+}
+
+function colorsMatch(a, b, tolerance = 10) {
+  const ca = parseCssColor(a);
+  const cb = parseCssColor(b);
+  if (ca && cb) {
+    return Math.abs(ca[0] - cb[0]) <= tolerance &&
+           Math.abs(ca[1] - cb[1]) <= tolerance &&
+           Math.abs(ca[2] - cb[2]) <= tolerance;
+  }
+  // Unparseable format (oklch, named): exact normalized string only.
+  return String(a).trim().toLowerCase() === String(b).trim().toLowerCase();
+}
+
+// Flatten a parsed DESIGN.md into comparable sets: declared font families,
+// palette colors (colors.* + component bg/text colors), and the rounded scale.
+export function flattenDesignTokens(parsed) {
+  const fonts = new Set();
+  const colors = [];
+  const radii = [];
+
+  for (const t of Object.values(parsed.typography || {})) {
+    const fam = typeof t === 'object' ? t.fontFamily : t;
+    const f = typeof fam === 'string' ? primaryFamily(fam) || normFont(fam) : null;
+    if (f) fonts.add(f);
+  }
+  const pushColor = (v) => { if (typeof v === 'string' && v.trim()) colors.push(v.trim()); };
+  const walkColors = (node) => {
+    for (const v of Object.values(node || {})) {
+      if (v && typeof v === 'object') walkColors(v);
+      else pushColor(v);
+    }
+  };
+  walkColors(parsed.colors);
+  for (const comp of Object.values(parsed.components || {})) {
+    if (!comp || typeof comp !== 'object') continue;
+    pushColor(comp.backgroundColor);
+    pushColor(comp.textColor);
+    const fam = comp.typography && typeof comp.typography === 'object'
+      ? comp.typography.fontFamily : null;
+    const f = typeof fam === 'string' ? primaryFamily(fam) || normFont(fam) : null;
+    if (f) fonts.add(f);
+  }
+  for (const v of Object.values(parsed.rounded || {})) {
+    const px = parseFloat(v);
+    if (Number.isFinite(px)) radii.push(px);
+  }
+  return { fonts: [...fonts], colors, radii };
+}
+
+// ── In-page observation ──────────────────────────────────────────────────────
+// Serialized into the page (fn.toString(), like extractTextContext) — must be
+// fully self-contained: no closures over module scope.
+export function extractSystemContext() {
+  const out = { fonts: {}, ctas: [], surface: null, headings: [], radii: [] };
+  const seenRadii = new Set();
+  const visible = (el) => {
+    if (!el.getClientRects || el.getClientRects().length === 0) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 1 && r.height > 1;
+  };
+  const els = document.querySelectorAll('body *');
+  let inspected = 0;
+  for (const el of els) {
+    if (inspected >= 2500) break;
+    const tag = el.tagName;
+    if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' ||
+        tag === 'META' || tag === 'LINK' || tag === 'SVG' || tag === 'PATH') continue;
+    if (!visible(el)) continue;
+    inspected++;
+    const cs = getComputedStyle(el);
+
+    // Font tally: only elements carrying their own text.
+    let hasText = false;
+    for (const n of el.childNodes) {
+      if (n.nodeType === 3 && n.textContent.trim().length > 1) { hasText = true; break; }
+    }
+    if (hasText) {
+      const fam = cs.fontFamily || '';
+      out.fonts[fam] = (out.fonts[fam] || 0) + 1;
+    }
+
+    // Distinct corner radii (skip pills/circles — shape choices, not scale).
+    const br = parseFloat(cs.borderTopLeftRadius);
+    if (Number.isFinite(br) && br >= 3 && br <= 64 && !seenRadii.has(br)) {
+      seenRadii.add(br);
+      out.radii.push(br);
+    }
+
+    // CTA colors: visible buttons/links with a real background fill.
+    if ((tag === 'A' || tag === 'BUTTON') && out.ctas.length < 30) {
+      const bg = cs.backgroundColor || '';
+      const a = bg.match(/rgba?\([^)]*?,\s*([\d.]+)\)$/);
+      const opaque = bg && bg !== 'transparent' && (!a || parseFloat(a[1]) >= 0.5);
+      if (opaque) {
+        out.ctas.push({
+          bg,
+          text: (el.textContent || '').trim().slice(0, 40)
+        });
+      }
+    }
+
+    // Heading colors.
+    if ((tag === 'H1' || tag === 'H2' || tag === 'H3') && out.headings.length < 12) {
+      out.headings.push({ tag, color: cs.color, fontFamily: cs.fontFamily });
+    }
+  }
+  const bodyBg = getComputedStyle(document.body).backgroundColor;
+  const htmlBg = getComputedStyle(document.documentElement).backgroundColor;
+  out.surface = (bodyBg && bodyBg !== 'rgba(0, 0, 0, 0)') ? bodyBg : htmlBg;
+  return out;
+}
+
+// ── Scoring ──────────────────────────────────────────────────────────────────
+// Weighted checks like the AEO axis. Higher is better. Checks that cannot be
+// evaluated (nothing declared, or nothing observed) are SKIPPED and excluded
+// from the denominator — absence of data must never read as drift.
+export const SYSTEM_CHECKS = [
+  { id: 'fonts.declared',  weight: 35, label: 'Fonts in use are declared in the system' },
+  { id: 'colors.cta',      weight: 30, label: 'CTA / button colors come from the palette' },
+  { id: 'colors.surface',  weight: 15, label: 'Page surface color comes from the palette' },
+  { id: 'colors.headings', weight: 10, label: 'Heading colors come from the palette' },
+  { id: 'radii.scale',     weight: 10, label: 'Corner radii follow the declared scale' }
+];
+
+function tierForRatio(ratio) {
+  if (ratio >= 0.8) return 'Aligned';
+  if (ratio >= 0.5) return 'Drifting';
+  return 'Off-system';
+}
+
+export function scoreSystemCompliance(parsed, observed) {
+  if (!parsed) {
+    return { axis: 'system', declared: false, score: null, tier: 'No system',
+      message: 'No parseable DESIGN.md tokens — nothing to check against.', checks: [], drift: [] };
+  }
+  const tokens = flattenDesignTokens(parsed);
+  const obs = observed || {};
+  const checks = [];
+  const drift = [];
+  const push = (id, status, message, evidence) => {
+    const def = SYSTEM_CHECKS.find((c) => c.id === id);
+    checks.push({ ...def, status, message, evidence });
+    if (status === 'fail') drift.push({ id, message, evidence });
+  };
+
+  // 1. Fonts: every meaningfully-used concrete family should be declared.
+  {
+    const tally = obs.fonts || {};
+    const total = Object.values(tally).reduce((a, b) => a + b, 0);
+    if (!tokens.fonts.length || !total) {
+      push('fonts.declared', 'skip', !tokens.fonts.length
+        ? 'no typography tokens declared' : 'no text observed');
+    } else {
+      const used = new Map(); // primary family -> count
+      for (const [stack, n] of Object.entries(tally)) {
+        const fam = primaryFamily(stack);
+        if (fam) used.set(fam, (used.get(fam) || 0) + n);
+      }
+      // "Meaningful" = ≥10% of text elements, so one icon-font widget isn't drift.
+      const undeclared = [...used.entries()]
+        .filter(([fam, n]) => n / total >= 0.1 && !tokens.fonts.includes(fam))
+        .map(([fam]) => fam);
+      if (undeclared.length) {
+        push('fonts.declared', 'fail',
+          `font(s) in use but not in the system: ${undeclared.join(', ')}`,
+          { undeclared, declared: tokens.fonts });
+      } else {
+        push('fonts.declared', 'pass', 'all primary fonts are declared', { declared: tokens.fonts });
+      }
+    }
+  }
+
+  // 2. CTA colors ∈ palette.
+  {
+    const ctas = obs.ctas || [];
+    if (!tokens.colors.length || !ctas.length) {
+      push('colors.cta', 'skip', !tokens.colors.length ? 'no color tokens declared' : 'no filled CTAs observed');
+    } else {
+      const off = ctas.filter((c) => !tokens.colors.some((t) => colorsMatch(t, c.bg)));
+      if (off.length) {
+        push('colors.cta', 'fail',
+          `${off.length}/${ctas.length} CTA color(s) not in the palette`,
+          { samples: off.slice(0, 4).map((c) => ({ bg: c.bg, text: c.text })) });
+      } else {
+        push('colors.cta', 'pass', `all ${ctas.length} CTA colors match the palette`);
+      }
+    }
+  }
+
+  // 3. Surface ∈ palette.
+  {
+    if (!tokens.colors.length || !obs.surface) {
+      push('colors.surface', 'skip', !tokens.colors.length ? 'no color tokens declared' : 'no surface color observed');
+    } else if (tokens.colors.some((t) => colorsMatch(t, obs.surface, 14))) {
+      push('colors.surface', 'pass', 'surface color matches the palette');
+    } else {
+      push('colors.surface', 'fail', `surface ${obs.surface} is not in the palette`, { surface: obs.surface });
+    }
+  }
+
+  // 4. Heading colors ∈ palette.
+  {
+    const hs = obs.headings || [];
+    if (!tokens.colors.length || !hs.length) {
+      push('colors.headings', 'skip', !tokens.colors.length ? 'no color tokens declared' : 'no headings observed');
+    } else {
+      const off = hs.filter((h) => !tokens.colors.some((t) => colorsMatch(t, h.color, 14)));
+      if (off.length > hs.length / 2) {
+        push('colors.headings', 'fail',
+          `${off.length}/${hs.length} heading color(s) not in the palette`,
+          { samples: off.slice(0, 3).map((h) => ({ tag: h.tag, color: h.color })) });
+      } else {
+        push('colors.headings', 'pass', 'heading colors match the palette');
+      }
+    }
+  }
+
+  // 5. Radii ∈ declared scale (±2px).
+  {
+    const radii = obs.radii || [];
+    if (!tokens.radii.length || !radii.length) {
+      push('radii.scale', 'skip', !tokens.radii.length ? 'no rounded tokens declared' : 'no rounded corners observed');
+    } else {
+      const off = radii.filter((r) => !tokens.radii.some((t) => Math.abs(t - r) <= 2));
+      if (off.length > radii.length / 2) {
+        push('radii.scale', 'fail',
+          `radii off the declared scale: ${off.slice(0, 5).join(', ')}px`,
+          { offScale: off.slice(0, 8), declared: tokens.radii });
+      } else {
+        push('radii.scale', 'pass', 'corner radii follow the declared scale');
+      }
+    }
+  }
+
+  const evaluated = checks.filter((c) => c.status !== 'skip');
+  const maxScore = evaluated.reduce((s, c) => s + c.weight, 0);
+  const got = evaluated.filter((c) => c.status === 'pass').reduce((s, c) => s + c.weight, 0);
+  const ratio = maxScore ? got / maxScore : 1;
+
+  return {
+    axis: 'system',
+    declared: true,
+    name: parsed.name,
+    score: Math.round(ratio * 100),       // 0–100, higher is better
+    maxScore: 100,
+    tier: maxScore ? tierForRatio(ratio) : 'No data',
+    checksEvaluated: evaluated.length,
+    checksSkipped: checks.length - evaluated.length,
+    checks,
+    drift
+  };
+}

--- a/packages/core/test/system.test.js
+++ b/packages/core/test/system.test.js
@@ -1,0 +1,157 @@
+// The `system` axis (DESIGN.md compliance) — parser, token flattening, and the
+// drift scorer. Pure functions; no DOM (extractSystemContext is covered by the
+// browser golden tests).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseDesignMd,
+  extractFrontMatter,
+  flattenDesignTokens,
+  scoreSystemCompliance,
+  primaryFamily,
+  parseCssColor
+} from '../src/system.js';
+
+// A DESIGN.md in the Google Labs spec shape (front matter + prose), including a
+// {token.reference}, quoted hex (the # must survive), and a trailing comment.
+const SAMPLE = `---
+name: Heritage
+colors:
+  primary: "#1A1C1E"
+  tertiary: "#B8422E"
+  paper: "#FBFAF7"
+typography:
+  h1:
+    fontFamily: Public Sans
+    fontSize: 3rem
+  body:
+    fontFamily: Georgia
+rounded:
+  sm: 4px
+  md: 8px
+spacing:
+  md: 16px   # base unit
+components:
+  button-primary:
+    backgroundColor: "{colors.tertiary}"
+    textColor: "#ffffff"
+---
+
+## Overview
+Architectural Minimalism meets Journalistic Gravitas.
+`;
+
+// ── parsing ──────────────────────────────────────────────────────────────────
+test('extractFrontMatter pulls the fenced YAML block', () => {
+  const fm = extractFrontMatter(SAMPLE);
+  assert.match(fm, /name: Heritage/);
+  assert.doesNotMatch(fm, /Overview/);
+  assert.equal(extractFrontMatter('no front matter here'), null);
+});
+
+test('parseDesignMd reads nested tokens, quoted hex, comments, and resolves {refs}', () => {
+  const p = parseDesignMd(SAMPLE);
+  assert.equal(p.name, 'Heritage');
+  assert.equal(p.colors.primary, '#1A1C1E');
+  assert.equal(p.typography.h1.fontFamily, 'Public Sans');
+  assert.equal(p.spacing.md, '16px', 'trailing comment stripped');
+  assert.equal(p.components['button-primary'].backgroundColor, '#B8422E', '{colors.tertiary} resolved');
+});
+
+test('parseDesignMd returns null for prose-only or token-free files', () => {
+  assert.equal(parseDesignMd('# Just a readme\nNo front matter.'), null);
+  assert.equal(parseDesignMd('---\nname: OnlyAName\n---\nprose'), null, 'a name alone is not a token set');
+});
+
+// ── flattening + matching primitives ─────────────────────────────────────────
+test('flattenDesignTokens gathers fonts, palette (incl. component colors), radii', () => {
+  const t = flattenDesignTokens(parseDesignMd(SAMPLE));
+  assert.deepEqual(t.fonts.sort(), ['georgia', 'public sans']);
+  assert.ok(t.colors.includes('#B8422E'), 'resolved component bg in palette');
+  assert.ok(t.colors.includes('#ffffff'));
+  assert.deepEqual(t.radii, [4, 8]);
+});
+
+test('primaryFamily skips generic families and quotes', () => {
+  assert.equal(primaryFamily('"Inter", ui-sans-serif, system-ui'), 'inter');
+  assert.equal(primaryFamily('-apple-system, BlinkMacSystemFont, "Segoe UI", Georgia'), 'segoe ui');
+  assert.equal(primaryFamily('sans-serif'), null);
+});
+
+test('parseCssColor handles hex (3/6) and rgb()/rgba()', () => {
+  assert.deepEqual(parseCssColor('#fff'), [255, 255, 255]);
+  assert.deepEqual(parseCssColor('#B8422E'), [184, 66, 46]);
+  assert.deepEqual(parseCssColor('rgb(184, 66, 46)'), [184, 66, 46]);
+  assert.deepEqual(parseCssColor('rgba(184,66,46,0.9)'), [184, 66, 46]);
+  assert.equal(parseCssColor('oklch(62% 0.18 250)'), null);
+});
+
+// ── scoring ──────────────────────────────────────────────────────────────────
+const parsed = parseDesignMd(SAMPLE);
+
+// A page that honors the system: Georgia text, tertiary CTAs, paper surface.
+const ALIGNED = {
+  fonts: { 'Georgia, serif': 40, '"Public Sans", sans-serif': 10 },
+  ctas: [{ bg: 'rgb(184, 66, 46)', text: 'Buy' }],
+  surface: 'rgb(251, 250, 247)',
+  headings: [{ tag: 'H1', color: 'rgb(26, 28, 30)' }],
+  radii: [4, 8]
+};
+
+// The same page after an agent "improved" it: Inter, an off-palette violet CTA.
+const DRIFTED = {
+  ...ALIGNED,
+  fonts: { 'Inter, ui-sans-serif': 45, 'Georgia, serif': 5 },
+  ctas: [{ bg: 'rgb(124, 58, 237)', text: 'Get started' }]
+};
+
+test('an on-system page scores Aligned with no drift', () => {
+  const r = scoreSystemCompliance(parsed, ALIGNED);
+  assert.equal(r.declared, true);
+  assert.equal(r.tier, 'Aligned');
+  assert.equal(r.score, 100);
+  assert.equal(r.drift.length, 0);
+});
+
+test('undeclared font + off-palette CTA read as named drift, not a verdict', () => {
+  const r = scoreSystemCompliance(parsed, DRIFTED);
+  assert.notEqual(r.tier, 'Aligned');
+  const ids = r.drift.map((d) => d.id);
+  assert.ok(ids.includes('fonts.declared'), 'Inter flagged as undeclared');
+  assert.ok(ids.includes('colors.cta'), 'violet CTA flagged as off-palette');
+  const fontDrift = r.drift.find((d) => d.id === 'fonts.declared');
+  assert.match(fontDrift.message, /inter/);
+});
+
+test('a rarely-used font (<10% of text) is not drift (icon-font tolerance)', () => {
+  const r = scoreSystemCompliance(parsed, {
+    ...ALIGNED,
+    fonts: { 'Georgia, serif': 95, 'FontAwesome': 3 }
+  });
+  assert.ok(!r.drift.some((d) => d.id === 'fonts.declared'));
+});
+
+test('missing data is SKIPPED, never drift', () => {
+  // Nothing observed at all → every check skips → perfect-by-absence is avoided
+  // by tier "No data" semantics: score stays 100 but checksEvaluated is 0.
+  const r = scoreSystemCompliance(parsed, {});
+  assert.equal(r.checksEvaluated, 0);
+  assert.equal(r.drift.length, 0);
+  assert.equal(r.tier, 'No data');
+});
+
+test('no parseable DESIGN.md → declared:false, null score', () => {
+  const r = scoreSystemCompliance(null, ALIGNED);
+  assert.equal(r.declared, false);
+  assert.equal(r.score, null);
+  assert.equal(r.tier, 'No system');
+});
+
+test('color matching tolerates rendering rounding (±10/channel)', () => {
+  const r = scoreSystemCompliance(parsed, {
+    ...ALIGNED,
+    ctas: [{ bg: 'rgb(186, 68, 48)', text: 'Buy' }] // tertiary ±2
+  });
+  assert.ok(!r.drift.some((d) => d.id === 'colors.cta'));
+});

--- a/packages/web/API.md
+++ b/packages/web/API.md
@@ -26,6 +26,7 @@ Run the detector against a URL inside a headless Chromium and return the score
 | `url`        | string  | yes      | Target URL. `https://` is prepended if no scheme is present. |
 | `preset`     | string  | no       | `full` (default), `strict`, `marketing`, `minimal`.          |
 | `axes`       | array \| `"all"` | no | Axes to score: `["design"]` (default), `["design","copy"]`, or `"all"`. |
+| `designMd`   | boolean \| string | no | **System axis** — check the page against its declared design system ([DESIGN.md spec](https://github.com/google-labs-code/design.md)). `true` looks for `<origin>/DESIGN.md`; a URL fetches that file (SSRF-guarded). Adds a `system` block to the response. |
 | `screenshot` | boolean | no       | If `true`, includes a base64 JPEG of the above-fold render.  |
 | `share`      | boolean | no       | Default `true`. Set `false` to skip persistence/permalink.   |
 
@@ -73,6 +74,30 @@ Run the detector against a URL inside a headless Chromium and return the score
 `unifiedScore` = max axis score + 6 per additional dirty (non-Clean) axis, clamped
 to 100. The copy axis flags a `thin: true` when there's too little prose (<40 words)
 to judge, and stays Clean rather than guessing.
+
+**System axis** — when `designMd` is set, the response carries a separate
+`system` block (it measures alignment with the site's *own* declared system,
+so **higher is better** and it is *not* folded into the slop score):
+
+```json
+{
+  "system": {
+    "axis": "system", "declared": true, "name": "Heritage",
+    "score": 65, "tier": "Drifting",
+    "checksEvaluated": 5, "checksSkipped": 0,
+    "drift": [
+      { "id": "fonts.declared", "message": "font(s) in use but not in the system: inter" },
+      { "id": "colors.cta", "message": "2/6 CTA color(s) not in the palette" }
+    ],
+    "checks": [],
+    "source": "https://example.com/DESIGN.md"
+  }
+}
+```
+
+Tiers: `Aligned` (≥80) · `Drifting` (≥50) · `Off-system` (<50) · `No system`
+(no parseable DESIGN.md tokens) · `No data` (nothing observable to check).
+Missing data is always *skipped*, never reported as drift.
 
 **Error responses:**
 

--- a/packages/web/functions/api/scan.js
+++ b/packages/web/functions/api/scan.js
@@ -17,6 +17,9 @@ import {
   applyPreset,
   isPreset,
   extractTextContext,
+  extractSystemContext,
+  parseDesignMd,
+  scoreSystemCompliance,
   scoreCopy,
   combineAxes
 } from 'slop-detect-core';
@@ -55,8 +58,16 @@ export async function onRequestPost({ request, env }) {
   if (checked.error) return json({ error: checked.error }, checked.status);
   const url = checked.url;
 
+  // System axis (DESIGN.md compliance) — opt in via { designMd: true } (looks
+  // for <origin>/DESIGN.md next to the scanned page) or { designMd: "<url>" }.
+  const wantsSystem = body.designMd === true || typeof body.designMd === 'string';
+  if (typeof body.designMd === 'string') {
+    const dv = validateScanUrl(body.designMd);
+    if (dv.error) return json({ error: `designMd: ${dv.error}` }, dv.status || 400);
+  }
+
   // Build the page-side IIFE that runs all detectors in one round-trip.
-  const pageScript = buildPageScript();
+  const pageScript = buildPageScript({ includeSystem: wantsSystem });
 
   let browser;
   try {
@@ -167,6 +178,34 @@ export async function onRequestPost({ request, env }) {
       Object.assign(result, combineAxes(summaries));
     }
 
+    // System axis: fetch the DESIGN.md (explicit URL or <origin>/DESIGN.md next
+    // to the final page), SSRF-guarded + size-capped, and score drift against
+    // what the page actually rendered. Reported separately from the slop score
+    // (it measures alignment with the site's OWN system; higher is better).
+    if (wantsSystem) {
+      const mdUrl = typeof body.designMd === 'string'
+        ? body.designMd
+        : new URL('/DESIGN.md', data.url || url).toString();
+      let mdText = null;
+      if (isAllowedUrl(mdUrl)) {
+        try {
+          const ctl = new AbortController();
+          const t = setTimeout(() => ctl.abort(), 8000);
+          const res = await fetch(mdUrl, {
+            signal: ctl.signal,
+            headers: { Accept: 'text/markdown,text/plain,*/*' }
+          });
+          clearTimeout(t);
+          if (res.ok) mdText = (await res.text()).slice(0, 200_000);
+        } catch (_) { /* unreachable DESIGN.md → reported as "no system" below */ }
+      }
+      result.system = scoreSystemCompliance(
+        mdText ? parseDesignMd(mdText) : null,
+        data.systemContext
+      );
+      result.system.source = mdText ? mdUrl : null;
+    }
+
     // Persist a slim snapshot so the scan gets a shareable permalink (/r/:id),
     // a cached OG card (/og/:id.png), and feeds the per-domain badge.
     // Skip persistence when the caller opts out (e.g. CI dry-runs).
@@ -255,7 +294,7 @@ function detectBlocked(data, _ctx) {
 }
 
 // ── Page-side script assembler ──────────────────────────────────────────────
-function buildPageScript() {
+function buildPageScript(opts = {}) {
   const patternCalls = PATTERNS.map(p => `
     try {
       signals[${JSON.stringify(p.id)}] = (${p.extract.toString()})(ctx);
@@ -309,6 +348,13 @@ function buildPageScript() {
     let textContext = null;
     try { textContext = extractTextContext(); } catch (e) { textContext = { error: e.message }; }
 
+    // System axis: observe fonts/colors/radii (scored Worker-side).
+    let systemContext = null;
+    ${opts.includeSystem ? `
+    const extractSystemContext = ${extractSystemContext.toString()};
+    try { systemContext = extractSystemContext(); } catch (e) { systemContext = { error: e.message }; }
+    ` : ''}
+
     return {
       title: document.title,
       url: location.href,
@@ -318,7 +364,8 @@ function buildPageScript() {
       h1Font: h1 ? getComputedStyle(h1).fontFamily : null,
       visibleCount: visible.length,
       signals,
-      textContext
+      textContext,
+      systemContext
     };
   })();`;
 }


### PR DESCRIPTION
Implements the decision from the June 2026 deep-research pass: **slop is the hook, not the product.**

## 1. ROADMAP v2 (the strategy)

Three findings forced the revision: the fixed fingerprint **decays in ~6–18 months** (DESIGN.md-style constraints are standardizing away the default look), absolute slop-grading is **commoditized** (Impeccable ~34.7k★ owns the free rule-count game), and our own calibration evidence shows the **false-positive trap** (Linear/Vercel → Heavy, Stripe → Mild).

New thesis: free slop grader = **acquisition channel** while the hype peaks; paid product = **design-system / brand-drift continuity monitoring for agencies** ($29–149/mo, open-core); technical posture: **ride DESIGN.md, don't fight it**. Includes research-backed "will NOT do" guardrails (no ML core, no AEO head-on, no "% AI" verdicts, no one-time licenses, no rule-count arms race).

## 2. The system axis (Roadmap v2 P1 — the durable signal)

**"Does this page honor its declared design system?"** Relative, per-site, decay-proof, and structurally incapable of the Linear/Stripe false positive — a bespoke site checked against its own tokens scores *Aligned*, never "slop."

- **`core/system.js`** (pure, zero-dep): parses the [Google Labs DESIGN.md spec](https://github.com/google-labs-code/design.md) (YAML front-matter tokens, `{token.references}` resolved; deliberate subset parser that degrades to "no system", never invents drift); a serializable in-page observer (font tally, CTA/surface/heading colors, radii); a 5-check weighted scorer — `Aligned` ≥80 / `Drifting` ≥50 / `Off-system` <50, **higher is better**, missing data *skips*, 10%-of-text tolerance so icon fonts aren't drift.
- **CLI**: `--design-md <file|url|auto>` (`auto` = `<origin>/DESIGN.md`, 404 is a normal state) + a drift renderer.
- **Web API**: `{ "designMd": true | "<url>" }` on `/api/scan` — SSRF-guarded, 8s timeout, 200KB cap; response gains a separate `system` block (not folded into the slop score).
- **Tests**: 12 pure core tests + 2 browser golden tests (an aligned fixture and a deliberately wrong system that must read as named drift). README + API.md documented.

Signals-not-verdicts throughout: every drift item is a named, contestable check.

## Tests
128 total: **121 pass, 0 fail**, 7 browser-gated golden skips (run in the Chromium Smoke job). Lint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New scoring path and server-side DESIGN.md fetches expand the scan API surface; behavior is well-tested and isolated from existing slop scores, but YAML/CSS heuristics may need tuning on real sites.
> 
> **Overview**
> **ROADMAP v2** reframes the project: free slop grading as acquisition, paid **design-system drift** monitoring as the product, and **DESIGN.md compliance** as the durable technical bet (replacing the old phased distribution roadmap).
> 
> **New `system` axis** in `packages/core/src/system.js`: parses Google Labs **DESIGN.md** YAML front matter (subset parser, `{token}` refs), collects rendered fonts/CTA/surface/heading colors and radii in-page, and scores **drift** with weighted checks (`Aligned` / `Drifting` / `Off-system`). Results stay **separate** from the slop score (higher = better).
> 
> **Surfaces:** CLI `--design-md` (file, URL, or `auto` for `<origin>/DESIGN.md`; local only—`--remote` rejected); `POST /api/scan` with `designMd: true | "<url>"` (SSRF-guarded fetch, 200KB cap); README and `API.md` updated. **Tests:** unit tests in `system.test.js` plus browser golden tests with aligned/mismatched fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f72849a69115b72968149dece85581eaec2b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->