### PR TITLE
Roadmap v2 implementation: drift alerts + client report + MCP design-system tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ curl -s -X POST -H 'Content-Type: application/json' \
   -d '{"url":"https://your-site.com","email":"you@example.com","list":true}'
 ```
 
+Add `"system": true` and the daily sweep also checks the domain against its own
+`DESIGN.md`, emailing you when the page **drifts off its declared design
+system** — the check that catches what an agent or a non-designer quietly broke.
+Every monitored domain gets a print-friendly client report at
+`slop-detect.com/report/<domain>`.
+
 `list: true` also opts the domain into the public, crawlable
 [**directory**](https://slop-detect.com/directory) of scored sites — an
 owner-gated catalogue with a real backlink to each listed site. See also

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,12 +138,13 @@ DESIGN.md. Workflow lock-in is the only durable distribution.
 
 | Move | Status |
 |---|---|
-| P1 `system` axis (core + CLI + API) | **In progress (this release)** |
-| P2a Drift alerts on `system` axis via existing sweep | After P1 |
-| P2b Agency dashboard + white-label PDF | Next quarter |
-| P2c Pricing live ($29–$149/mo) | With P2b |
+| P1 `system` axis (core + CLI + API) | ✅ Shipped |
+| P2a Drift alerts on `system` axis via existing sweep | ✅ Shipped (`watch { system:true }` → sweep checks DESIGN.md → drift email, once per event) |
+| P2b-lite Print-friendly client report (`/report/:domain`) | ✅ Shipped (the PDF-infra substitute) |
+| P2b Agency multi-site dashboard | Next quarter |
+| P2c Pricing live ($29–$149/mo) | With P2b (needs Stripe keys — operator task) |
 | P3 Community ruleset + calibration corpus growth | Ongoing |
-| P4 MCP design-system mode | After P1 |
+| P4 MCP design-system mode (`check_design_system` tool) | ✅ Shipped |
 
 ---
 

--- a/packages/mcp/src/api.js
+++ b/packages/mcp/src/api.js
@@ -87,6 +87,25 @@ export async function scanPage(url) {
   return res.json();
 }
 
+// POST {url, designMd} to /api/scan and return the parsed JSON — the
+// design-system compliance check ("does this page honor its own DESIGN.md?").
+// `designMdUrl` (optional) points at an explicit DESIGN.md; otherwise the API
+// auto-discovers <origin>/DESIGN.md. share:false — agent checks shouldn't mint
+// public permalinks.
+export async function checkSystem(url, designMdUrl) {
+  const res = await fetchWithTimeout(`${apiBase()}/api/scan`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      url,
+      designMd: typeof designMdUrl === 'string' && designMdUrl ? designMdUrl : true,
+      share: false
+    })
+  });
+  if (!res.ok) throw await toApiError(res);
+  return res.json();
+}
+
 // POST {url} to /api/aeo and return the AEO conformance report JSON — "can AI
 // engines (ChatGPT/Claude/Perplexity) actually read & cite this page?".
 export async function checkAeo(url) {

--- a/packages/mcp/src/format.js
+++ b/packages/mcp/src/format.js
@@ -45,6 +45,51 @@ export function formatScan(result) {
   return lines.join('\n');
 }
 
+// Renders the `system` block of a /api/scan result (DESIGN.md compliance).
+// Score is 0-100 where HIGHER is better — it measures alignment with the
+// site's OWN declared design system, not slop.
+export function formatSystem(result) {
+  const sys = result && result.system;
+  if (!sys) {
+    return 'No system block in the scan result — the API may not have run the design-system axis.';
+  }
+  if (!sys.declared) {
+    return [
+      'Design-system check: NO SYSTEM DECLARED.',
+      sys.message || 'No parseable DESIGN.md tokens were found for this page.',
+      '',
+      'To enable this check, publish a DESIGN.md (Google Labs spec — YAML',
+      'front-matter tokens: colors, typography, rounded, components) at the',
+      "site root, or pass design_md_url pointing at one."
+    ].join('\n');
+  }
+
+  const driftLines = (sys.drift || []).length
+    ? sys.drift.map((d) => `  • ${d.message} (${d.id})`).join('\n')
+    : '  • None — the page matches its declared system.';
+
+  const lines = [
+    `Design-system compliance${sys.name ? ` — "${sys.name}"` : ''}`,
+    `Score: ${sys.score}/100 (HIGHER is better — 100 = fully on-system)`,
+    `Tier: ${sys.tier} (Aligned ≥80 · Drifting ≥50 · Off-system <50)`,
+    sys.source ? `DESIGN.md: ${sys.source}` : null,
+    `Checks: ${sys.checksEvaluated} evaluated, ${sys.checksSkipped} skipped (missing data skips — it is never drift)`,
+    '',
+    'Drift:',
+    driftLines,
+    '',
+    'These are named, contestable checks against the tokens the site itself',
+    'declares — a fingerprint of drift, not a verdict on the design.',
+    '',
+    'Raw JSON:',
+    '```json',
+    JSON.stringify(sys, null, 2),
+    '```'
+  ].filter((l) => l !== null);
+
+  return lines.join('\n');
+}
+
 // Renders a /api/aeo report. Score is 0-100 where HIGHER is better (the inverse
 // of the slop score), so we spell that out too. Tier: AI-Ready / Partial /
 // Invisible.

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -12,8 +12,8 @@ import {
   ListToolsRequestSchema
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { scanPage, checkAeo, fixPrompt, ApiError } from './api.js';
-import { formatScan, formatAeo } from './format.js';
+import { scanPage, checkAeo, checkSystem, fixPrompt, ApiError } from './api.js';
+import { formatScan, formatAeo, formatSystem } from './format.js';
 
 // Read our own version from package.json so the MCP handshake never drifts from
 // the published version. Falls back to '0.0.0' if the file can't be read (e.g.
@@ -62,6 +62,29 @@ const TOOLS = [
     }
   },
   {
+    name: 'check_design_system',
+    description:
+      'Check whether a page honors its OWN declared design system (a DESIGN.md ' +
+      'file — Google Labs spec). Returns a compliance score 0-100 (HIGHER is ' +
+      'better), a tier (Aligned / Drifting / Off-system), and named drift ' +
+      'signals: fonts in use that are not declared, CTA/surface colors off the ' +
+      'palette, radii off the scale. Use this BEFORE shipping UI changes to a ' +
+      'site that has a design system — it catches brand drift that the slop ' +
+      'score (an absolute measure) cannot. By default looks for ' +
+      '<origin>/DESIGN.md next to the page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'The page URL to check (e.g. https://example.com).' },
+        design_md_url: {
+          type: 'string',
+          description: 'Optional: an explicit URL to the DESIGN.md to check against. Defaults to <origin>/DESIGN.md.'
+        }
+      },
+      required: ['url']
+    }
+  },
+  {
     name: 'fix_prompt',
     description:
       'Generate a copy-paste prompt that tells a coding agent exactly how to ' +
@@ -96,6 +119,11 @@ async function handleCall(name, args) {
   if (name === 'check_aeo') {
     const report = await checkAeo(url);
     return asToolResult(formatAeo(report));
+  }
+  if (name === 'check_design_system') {
+    const designMdUrl = args && typeof args.design_md_url === 'string' ? args.design_md_url.trim() : '';
+    const result = await checkSystem(url, designMdUrl || undefined);
+    return asToolResult(formatSystem(result));
   }
   if (name === 'fix_prompt') {
     const prompt = await fixPrompt(url);

--- a/packages/mcp/test/system.test.js
+++ b/packages/mcp/test/system.test.js
@@ -1,0 +1,52 @@
+// check_design_system tool — the API client body and the formatter output.
+
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkSystem } from '../src/api.js';
+import { formatSystem } from '../src/format.js';
+
+const realFetch = global.fetch;
+afterEach(() => { global.fetch = realFetch; });
+
+test('checkSystem posts designMd:true (auto) with share:false by default', async () => {
+  let seen = null;
+  global.fetch = async (url, opts) => {
+    seen = { url: String(url), body: JSON.parse(opts.body) };
+    return { ok: true, status: 200, json: async () => ({ system: { declared: true } }) };
+  };
+  await checkSystem('https://example.com');
+  assert.match(seen.url, /\/api\/scan$/);
+  assert.equal(seen.body.designMd, true);
+  assert.equal(seen.body.share, false, 'agent checks must not mint public permalinks');
+});
+
+test('checkSystem passes an explicit DESIGN.md URL through', async () => {
+  let seen = null;
+  global.fetch = async (_u, opts) => {
+    seen = JSON.parse(opts.body);
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+  await checkSystem('https://example.com', 'https://example.com/brand/DESIGN.md');
+  assert.equal(seen.designMd, 'https://example.com/brand/DESIGN.md');
+});
+
+test('formatSystem renders score, tier, drift items, and the polarity reminder', () => {
+  const out = formatSystem({
+    system: {
+      declared: true, name: 'Heritage', score: 55, tier: 'Drifting',
+      checksEvaluated: 5, checksSkipped: 0, source: 'https://example.com/DESIGN.md',
+      drift: [{ id: 'fonts.declared', message: 'font(s) in use but not in the system: inter' }]
+    }
+  });
+  assert.match(out, /55\/100/);
+  assert.match(out, /HIGHER is better/);
+  assert.match(out, /Drifting/);
+  assert.match(out, /inter \(fonts\.declared\)/);
+  assert.match(out, /not a verdict/i);
+});
+
+test('formatSystem explains the no-system state with how to fix it', () => {
+  const out = formatSystem({ system: { declared: false, message: 'No parseable DESIGN.md tokens — nothing to check against.' } });
+  assert.match(out, /NO SYSTEM DECLARED/);
+  assert.match(out, /publish a DESIGN\.md/);
+});

--- a/packages/web/API.md
+++ b/packages/web/API.md
@@ -182,9 +182,15 @@ so a signup form works without a captcha.
 | `domain`      | string  | yes      | Bare domain. A scheme/`www.`/path is stripped; must be a real hostname. |
 | `email`       | string  | yes      | Where regression alerts will go (validation phase: captured, not yet sent). |
 | `list`        | boolean | no       | `true` lists the domain in the public [directory](#public-directory) (dofollow backlink); `false` delists it; omit to keep the current state. |
+| `system`      | boolean | no       | `true` enables **design-system monitoring**: the daily sweep also checks the domain against its `<origin>/DESIGN.md` and emails on drift (Aligned → Drifting/Off-system, or a ≥15-point compliance drop). Omit to preserve; `false` disables. |
 | `unsubscribe` | boolean | no       | If `true`, stops monitoring **and** delists (requires the matching `email`). |
 
-The response echoes `listed` and, when listed, a `directoryUrl`.
+The response echoes `listed` (+ `directoryUrl` when listed), `systemMonitoring`,
+and — once the sweep has a reading — a `system` block (`score`, `tier`,
+`baseline`, `drifted`, named `drift` items). History points gain a compact
+`system` entry alongside the slop score. Drift alerts follow the same
+once-per-event / recovery-re-arms rule as slop-regression alerts, and only ever
+go to a verified (double-opt-in) address.
 
 **Response** `201` (new) / `200` (already monitored):
 
@@ -266,6 +272,15 @@ A listed domain's entry auto-refreshes whenever it's re-scanned.
 Server-rendered, crawlable HTML page listing every opt-in site (grade · score ·
 tier · dofollow link out · link to its scan). `?sort=slop` ranks sloppiest-first
 (default: cleanest-first). Emits `ItemList` JSON-LD and is in the sitemap. Public.
+
+### `GET /report/:domain`
+
+A **print-friendly client report** for a domain (the agency deliverable): latest
+slop grade/score, design-system compliance (when monitored), named drift items,
+triggered patterns, and score history — with an `@media print` stylesheet so
+"print / save PDF" produces a clean hand-off document without server-side PDF
+infrastructure. Public data only (never the subscriber's email); `noindex`;
+honest empty state for unscanned domains.
 
 ### `GET /api/sites`
 

--- a/packages/web/functions/_alerts.js
+++ b/packages/web/functions/_alerts.js
@@ -48,3 +48,32 @@ const RANK = { Clean: 0, Mild: 1, Heavy: 2 };
 function tierDrop(from, to) {
   return (RANK[to] ?? 0) > (RANK[from] ?? 0);
 }
+
+// Design-system drift alert (Roadmap v2 P2a): "your page no longer honors its
+// own DESIGN.md." Named, contestable drift items — signals, never verdicts.
+export function buildDriftAlert(domain, baseline, current, driftItems = [], opts = {}) {
+  const subject = `slop-detect: ${domain} drifted off its design system (${baseline.tier} → ${current.tier})`;
+  const lines = [
+    `${domain} no longer matches its declared design system (DESIGN.md).`,
+    ``,
+    `  Baseline: ${baseline.tier}${typeof baseline.score === 'number' ? `  ·  ${baseline.score}/100` : ''}`,
+    `  Now:      ${current.tier}${typeof current.score === 'number' ? `  ·  ${current.score}/100` : ''}`,
+    ``
+  ];
+  if (driftItems.length) {
+    lines.push('What drifted:');
+    for (const d of driftItems.slice(0, 5)) lines.push(`  ✗ ${d.message}`);
+    lines.push('');
+  }
+  lines.push(
+    'These are named checks against the tokens YOUR DESIGN.md declares — a',
+    'fingerprint of drift, not a verdict on the design.'
+  );
+  if (opts.resultUrl) lines.push('', `Full scan: ${opts.resultUrl}`);
+  lines.push(
+    '',
+    `Stop these alerts: reply, or POST { unsubscribe: true } with this email to`,
+    `https://slop-detect.com/api/watch`
+  );
+  return { subject, text: lines.join('\n') };
+}

--- a/packages/web/functions/_shared.js
+++ b/packages/web/functions/_shared.js
@@ -152,6 +152,19 @@ export function slimResult(data, id) {
       }
     };
   }
+  // System axis (Roadmap v2 P2a): persist a compact compliance summary so the
+  // watch sweep can detect drift and the report page can render it. Only when
+  // the axis actually ran against a parseable DESIGN.md.
+  if (data.system && data.system.declared) {
+    slim.system = {
+      score: data.system.score,
+      tier: data.system.tier,
+      name: data.system.name || null,
+      driftCount: (data.system.drift || []).length,
+      drift: (data.system.drift || []).slice(0, 5)
+        .map(d => ({ id: d.id, message: d.message }))
+    };
+  }
   return slim;
 }
 
@@ -303,6 +316,23 @@ export function isRegression(baseline, current) {
   return (current.score - baseline.score) >= REGRESSION_SCORE_DELTA;
 }
 
+// System-axis drift (Roadmap v2 P2a). The system score is 0–100 HIGHER-IS-BETTER
+// (alignment with the site's own DESIGN.md). A drift event is: the page is no
+// longer Aligned, AND either it fell from an Aligned baseline or its score
+// dropped meaningfully (≥15). A site that was never Aligned doesn't "drift" on
+// every sweep — only on a real worsening. 'No system'/'No data' never drift.
+const SYSTEM_DRIFT_DELTA = 15;
+const SYSTEM_OK = new Set(['Aligned']);
+const SYSTEM_BAD = new Set(['Drifting', 'Off-system']);
+
+export function isSystemDrift(baseline, current) {
+  if (!baseline || !current) return false;
+  if (!SYSTEM_BAD.has(current.tier)) return false;
+  if (SYSTEM_OK.has(baseline.tier)) return true;
+  if (typeof baseline.score !== 'number' || typeof current.score !== 'number') return false;
+  return (baseline.score - current.score) >= SYSTEM_DRIFT_DELTA;
+}
+
 // Called from the scan handler after a result is persisted. If the scanned
 // domain is being watched, append a history point, refresh last-seen, set the
 // baseline if it was never established, and recompute the regressed flag.
@@ -320,6 +350,9 @@ export async function recordScanForWatch(kv, slim) {
     tier: slim.tier,
     createdAt: slim.createdAt || new Date().toISOString()
   };
+  // History points carry a compact system reading when the axis ran, so the
+  // report page can chart compliance over time alongside the slop score.
+  if (slim.system) point.sys = { score: slim.system.score, tier: slim.system.tier };
   await appendHistory(kv, slim.domain, point);
 
   // Establish the baseline on the first observed scan if registration happened
@@ -346,6 +379,28 @@ export async function recordScanForWatch(kv, slim) {
   // `notified` tracks whether we've already alerted for THIS regression so a
   // future cron/email job fires once per transition, not on every re-scan.
   if (!regressed) watch.notified = false;
+
+  // System-axis tracking (P2a): same baseline/last/once-per-event pattern as the
+  // slop score, but on the compliance reading. Only updates when the scan
+  // actually ran the axis (slim.system present) so a designMd-less scan can't
+  // erase system state.
+  let systemDrift = false;
+  if (slim.system) {
+    if (watch.baselineSystemScore == null) {
+      watch.baselineSystemScore = slim.system.score;
+      watch.baselineSystemTier = slim.system.tier;
+    }
+    systemDrift = isSystemDrift(
+      { score: watch.baselineSystemScore, tier: watch.baselineSystemTier },
+      { score: slim.system.score, tier: slim.system.tier }
+    );
+    watch.lastSystemScore = slim.system.score;
+    watch.lastSystemTier = slim.system.tier;
+    watch.lastSystemAt = point.createdAt;
+    watch.lastSystemDrift = slim.system.drift || [];
+    watch.systemRegressed = systemDrift;
+    if (!systemDrift) watch.systemNotified = false;
+  }
   await putWatch(kv, watch);
 
   // Reconcile the derived directory row with the watch (the source of truth):
@@ -357,12 +412,20 @@ export async function recordScanForWatch(kv, slim) {
     else await deleteListing(kv, slim.domain);
   } catch (_) { /* directory row is derived; reconciled on a later scan */ }
 
-  return {
+  const summary = {
     watched: true,
     regressed,
     baseline,
     delta: point.score - baseline.score
   };
+  if (slim.system) {
+    summary.system = {
+      score: slim.system.score,
+      tier: slim.system.tier,
+      drifted: systemDrift
+    };
+  }
+  return summary;
 }
 
 // Public-facing view of a watch — never leaks the subscriber's email.
@@ -383,8 +446,21 @@ export function publicWatch(watch, history) {
       tier: watch.lastTier, id: watch.lastId, at: watch.lastCheckedAt
     },
     regressed: !!watch.regressed,
+    // System axis (P2a): compliance monitoring state. Never includes the email.
+    systemMonitoring: !!watch.system,
+    system: watch.lastSystemScore == null ? null : {
+      score: watch.lastSystemScore,
+      tier: watch.lastSystemTier,
+      at: watch.lastSystemAt,
+      baseline: watch.baselineSystemScore == null ? null : {
+        score: watch.baselineSystemScore, tier: watch.baselineSystemTier
+      },
+      drifted: !!watch.systemRegressed,
+      drift: (watch.lastSystemDrift || []).map(d => ({ id: d.id, message: d.message }))
+    },
     history: (history || []).map(h => ({
-      score: h.score, grade: h.grade, tier: h.tier, at: h.createdAt
+      score: h.score, grade: h.grade, tier: h.tier, at: h.createdAt,
+      ...(h.sys ? { system: { score: h.sys.score, tier: h.sys.tier } } : {})
     }))
   };
 }

--- a/packages/web/functions/_sweep.js
+++ b/packages/web/functions/_sweep.js
@@ -6,14 +6,18 @@
 // How it stays correct:
 //   • Only VERIFIED watches are processed (double-opt-in consent gate).
 //   • Re-scanning a watched domain runs recordScanForWatch inside the scan,
-//     which updates history + recomputes `regressed` and resets `notified=false`
-//     when the page is healthy again.
-//   • We alert only when regressed && verified && !notified, then set
-//     notified=true — so each regression pages the owner exactly once, and a
-//     recovery re-arms it.
+//     which updates history + recomputes `regressed` / `systemRegressed` and
+//     resets the matching `notified` flag when the page is healthy again.
+//   • Each alert fires once per event and a recovery re-arms it:
+//       slop regression  → regressed && !notified         → sendAlert
+//       system drift     → systemRegressed && !systemNotified → sendDriftAlert
+//     (Roadmap v2 P2a: the system-drift alert is the agency value proposition.)
+//
+// `scanDomain` receives the WHOLE watch so the caller can request the system
+// axis only for watches that opted into it (watch.system).
 
-export async function monitorSweep({ watches, scanDomain, getWatch, putWatch, sendAlert, max = 50 }) {
-  const summary = { considered: 0, scanned: 0, alerted: 0, skippedUnverified: 0, errors: 0 };
+export async function monitorSweep({ watches, scanDomain, getWatch, putWatch, sendAlert, sendDriftAlert, max = 50 }) {
+  const summary = { considered: 0, scanned: 0, alerted: 0, driftAlerted: 0, skippedUnverified: 0, errors: 0 };
   let processed = 0;
 
   for (const w of watches || []) {
@@ -23,20 +27,25 @@ export async function monitorSweep({ watches, scanDomain, getWatch, putWatch, se
     processed++;
     summary.considered++;
     try {
-      // Re-scan — this updates the watch (history + regressed flag) as a side
+      // Re-scan — this updates the watch (history + regression flags) as a side
       // effect via recordScanForWatch on the scan path.
-      await scanDomain(w.domain);
+      await scanDomain(w);
       summary.scanned++;
 
       const fresh = await getWatch(w.domain);
-      if (fresh && fresh.regressed && fresh.verified && !fresh.notified) {
+      if (!fresh || !fresh.verified) continue;
+      let dirty = false;
+
+      if (fresh.regressed && !fresh.notified) {
         const res = await sendAlert(fresh);
-        if (res && res.sent) {
-          fresh.notified = true;
-          await putWatch(fresh);
-          summary.alerted++;
-        }
+        if (res && res.sent) { fresh.notified = true; dirty = true; summary.alerted++; }
       }
+      if (typeof sendDriftAlert === 'function' &&
+          fresh.systemRegressed && !fresh.systemNotified) {
+        const res = await sendDriftAlert(fresh);
+        if (res && res.sent) { fresh.systemNotified = true; dirty = true; summary.driftAlerted++; }
+      }
+      if (dirty) await putWatch(fresh);
     } catch (_) {
       summary.errors++;
     }

--- a/packages/web/functions/api/cron/sweep.js
+++ b/packages/web/functions/api/cron/sweep.js
@@ -15,7 +15,7 @@
 import { listWatches, getWatch, putWatch } from '../../_shared.js';
 import { monitorSweep } from '../../_sweep.js';
 import { sendEmail } from '../../_email.js';
-import { buildRegressionAlert } from '../../_alerts.js';
+import { buildRegressionAlert, buildDriftAlert } from '../../_alerts.js';
 import { report } from '../../_report.js';
 
 function json(data, status = 200) {
@@ -45,18 +45,22 @@ export async function onRequestPost({ request, env }) {
   const origin = new URL(request.url).origin;
   const max = Math.min(200, Math.max(1, parseInt(env.SWEEP_MAX || '50', 10) || 50));
 
-  // Re-scan a domain through the public scan path (keyed unlimited → bypasses
-  // limits/cost-cap/Turnstile). The scan triggers recordScanForWatch, which
-  // updates the watch's history + regressed flag as a side effect.
-  const scanDomain = async (domain) => {
+  // Re-scan a watched domain through the public scan path (keyed unlimited →
+  // bypasses limits/cost-cap/Turnstile). Watches that opted into design-system
+  // monitoring (watch.system) also run the system axis against the domain's
+  // <origin>/DESIGN.md. The scan triggers recordScanForWatch, which updates the
+  // watch's history + regression/drift flags as a side effect.
+  const scanDomain = async (watch) => {
+    const body = { url: `https://${watch.domain}`, axes: ['design'] };
+    if (watch.system) body.designMd = true;
     const res = await fetch(`${origin}/api/scan`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-API-Key': env.INTERNAL_API_KEY },
-      body: JSON.stringify({ url: `https://${domain}`, axes: ['design'] })
+      body: JSON.stringify(body)
     });
     if (!res.ok && res.status !== 422) {
       // 422 = the page couldn't be scored (bot wall/dead) — not fatal for a sweep.
-      throw new Error(`scan ${domain} -> ${res.status}`);
+      throw new Error(`scan ${watch.domain} -> ${res.status}`);
     }
   };
 
@@ -68,6 +72,15 @@ export async function onRequestPost({ request, env }) {
     return sendEmail(env, { to: watch.email, subject: msg.subject, text: msg.text });
   };
 
+  // System-drift alert (P2a) — fires once per drift event, recovery re-arms.
+  const sendDriftAlert = async (watch) => {
+    const baseline = { score: watch.baselineSystemScore, tier: watch.baselineSystemTier };
+    const current = { score: watch.lastSystemScore, tier: watch.lastSystemTier };
+    const resultUrl = watch.lastId ? `${origin}/r/${watch.lastId}` : null;
+    const msg = buildDriftAlert(watch.domain, baseline, current, watch.lastSystemDrift || [], { resultUrl });
+    return sendEmail(env, { to: watch.email, subject: msg.subject, text: msg.text });
+  };
+
   const watches = await listWatches(env.RESULTS, { limit: 1000 });
   const summary = await monitorSweep({
     watches,
@@ -75,6 +88,7 @@ export async function onRequestPost({ request, env }) {
     getWatch: (d) => getWatch(env.RESULTS, d),
     putWatch: (w) => putWatch(env.RESULTS, w),
     sendAlert,
+    sendDriftAlert,
     max
   });
 

--- a/packages/web/functions/api/watch.js
+++ b/packages/web/functions/api/watch.js
@@ -116,9 +116,18 @@ export async function onRequestPost({ request, env }) {
     : body.list === false ? false
     : (existing?.listed ?? false);
 
+  // Design-system monitoring (Roadmap v2 P2a): `system: true` makes the daily
+  // sweep also check the domain against its <origin>/DESIGN.md and alert on
+  // drift (the agency value proposition). Same explicit-set / omit-preserves
+  // semantics as `list`; covered by the same ownership guard above.
+  const systemMonitoring = body.system === true ? true
+    : body.system === false ? false
+    : (existing?.system ?? false);
+
   const watch = {
     domain,
     email,
+    system: systemMonitoring,
     plan: existing?.plan || 'trial',
     createdAt: existing?.createdAt || now,
     updatedAt: now,
@@ -135,6 +144,16 @@ export async function onRequestPost({ request, env }) {
     listed,
     regressed: existing?.regressed ?? false,
     notified:  existing?.notified  ?? false,
+    // System-axis state is owned by recordScanForWatch — preserve it across
+    // re-subscribes so toggling `list`/email can't erase the compliance baseline.
+    baselineSystemScore: existing?.baselineSystemScore ?? null,
+    baselineSystemTier:  existing?.baselineSystemTier  ?? null,
+    lastSystemScore: existing?.lastSystemScore ?? null,
+    lastSystemTier:  existing?.lastSystemTier  ?? null,
+    lastSystemAt:    existing?.lastSystemAt    ?? null,
+    lastSystemDrift: existing?.lastSystemDrift ?? [],
+    systemRegressed: existing?.systemRegressed ?? false,
+    systemNotified:  existing?.systemNotified  ?? false,
     // Privacy/consent: record WHEN the email was submitted and under which
     // policy version (lawful basis = consent). `verified` stays false until a
     // double-opt-in confirmation is added — no alert email may be sent to an

--- a/packages/web/functions/report/[domain].js
+++ b/packages/web/functions/report/[domain].js
@@ -1,0 +1,171 @@
+// GET /report/:domain — a print-friendly client report (Roadmap v2 P2b-lite).
+//
+// The agency deliverable: one page summarizing a domain's slop score, its
+// design-system compliance (when monitored), score history, and drift items —
+// styled for screen AND for printing to PDF (@media print), which is the
+// indie-smart substitute for server-side PDF generation infrastructure.
+//
+// Public data only: latest stored scan (d:/r: keys), the watch's PUBLIC view
+// (publicWatch — never the email), and history. A domain with no data renders
+// an honest empty state. Anti-slop by construction, like /directory.
+
+import {
+  normalizeDomain,
+  getLatestForDomain,
+  getWatch,
+  getHistory,
+  publicWatch,
+  tierColors,
+  escapeHtml
+} from '../_shared.js';
+
+const ORIGIN = 'https://slop-detect.com';
+
+function sysColors(tier) {
+  if (tier === 'Aligned') return { fg: '#4ade80' };
+  if (tier === 'Drifting') return { fg: '#fbbf24' };
+  if (tier === 'Off-system') return { fg: '#f87171' };
+  return { fg: '#8a8a92' };
+}
+
+function historyRows(history) {
+  return history.slice(-20).reverse().map((h) => {
+    const c = tierColors(h.tier);
+    const sys = h.system
+      ? `<td style="color:${sysColors(h.system.tier).fg}">${h.system.score}/100 ${escapeHtml(h.system.tier)}</td>`
+      : '<td class="dim">—</td>';
+    return `<tr>
+      <td>${escapeHtml(String(h.at || '').slice(0, 10))}</td>
+      <td><span style="color:${c.fg}">${escapeHtml(h.grade || '—')}</span></td>
+      <td>${h.score}/100</td>
+      <td style="color:${c.fg}">${escapeHtml(h.tier || '')}</td>
+      ${sys}
+    </tr>`;
+  }).join('');
+}
+
+export async function onRequestGet({ params, request, env }) {
+  const origin = new URL(request.url).origin;
+  const domain = normalizeDomain(String(params.domain || ''));
+  if (!domain) {
+    return new Response('Invalid domain', { status: 400, headers: { 'Content-Type': 'text/plain' } });
+  }
+
+  let latest = null, watch = null, history = [];
+  if (env.RESULTS) {
+    [latest, watch, history] = await Promise.all([
+      getLatestForDomain(env.RESULTS, domain).catch(() => null),
+      getWatch(env.RESULTS, domain).catch(() => null),
+      getHistory(env.RESULTS, domain).catch(() => [])
+    ]);
+  }
+  const pub = watch ? publicWatch(watch, history) : null;
+  const hasData = !!(latest || (history && history.length));
+
+  const c = tierColors(latest?.tier);
+  const sys = pub?.system || null;
+  const sc = sysColors(sys?.tier);
+  const today = new Date().toISOString().slice(0, 10);
+
+  const scoreBlock = latest ? `
+    <section class="grid">
+      <div class="card">
+        <div class="k">design-slop fingerprint</div>
+        <div class="big" style="color:${c.fg}">${escapeHtml(latest.grade || '—')}</div>
+        <div class="sub">${latest.score}/100 · <span style="color:${c.fg}">${escapeHtml(latest.tier || '')}</span></div>
+        <div class="note">${latest.patternsFlagged}/${latest.patternsTotal} patterns triggered · defs ${escapeHtml(latest.definitionsVersion || '')}</div>
+      </div>
+      <div class="card">
+        <div class="k">design-system compliance</div>
+        ${sys ? `
+        <div class="big" style="color:${sc.fg}">${sys.score}<small>/100</small></div>
+        <div class="sub" style="color:${sc.fg}">${escapeHtml(sys.tier)}</div>
+        <div class="note">vs its own DESIGN.md · higher is better${sys.drifted ? ' · <strong>drifted</strong>' : ''}</div>
+        ` : `
+        <div class="big dim">—</div>
+        <div class="note">Not monitored against a DESIGN.md yet. Opt in via
+          <code>POST /api/watch { system: true }</code>.</div>
+        `}
+      </div>
+    </section>` : '';
+
+  const driftBlock = sys && sys.drift && sys.drift.length ? `
+    <h2>What drifted</h2>
+    <ul class="drift">
+      ${sys.drift.map((d) => `<li><span class="x">✗</span> ${escapeHtml(d.message)} <span class="dim">(${escapeHtml(d.id)})</span></li>`).join('')}
+    </ul>` : '';
+
+  const histBlock = history.length ? `
+    <h2>History</h2>
+    <table>
+      <thead><tr><th>date</th><th>grade</th><th>slop score</th><th>tier</th><th>system</th></tr></thead>
+      <tbody>${historyRows(history)}</tbody>
+    </table>` : '';
+
+  const tellsBlock = latest?.triggered?.length ? `
+    <h2>Triggered patterns</h2>
+    <ul class="drift">
+      ${latest.triggered.slice(0, 10).map((t) => `<li><span class="x">✗</span> ${escapeHtml(t.label || t.short || t.id)} <span class="dim">(+${t.weight})</span></li>`).join('')}
+    </ul>` : '';
+
+  const body = hasData
+    ? scoreBlock + driftBlock + tellsBlock + histBlock
+    : `<p class="empty">No scan data for <strong>${escapeHtml(domain)}</strong> yet.
+       <a href="${origin}/">Run a scan</a>, then revisit this report.</p>`;
+
+  const html = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Report: ${escapeHtml(domain)} · slop-detect</title>
+<meta name="robots" content="noindex">
+<link rel="canonical" href="${ORIGIN}/report/${escapeHtml(domain)}">
+<style>
+  :root{color-scheme:dark light}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{background:#0a0a0b;color:#e7e7ea;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;line-height:1.55;padding:48px 20px 80px}
+  .wrap{max-width:720px;margin:0 auto}
+  a{color:inherit}
+  .kick{font-family:ui-monospace,Menlo,monospace;font-size:12px;letter-spacing:.04em;color:#6b6b73;text-transform:uppercase}
+  h1{font-size:28px;font-weight:650;letter-spacing:-0.01em;margin:6px 0 2px}
+  h2{font-size:17px;margin:30px 0 8px}
+  .meta{color:#8a8a92;font-size:13px;font-family:ui-monospace,Menlo,monospace;margin-bottom:24px}
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  .card{border:1px solid #232327;border-radius:10px;padding:18px}
+  .k{font-family:ui-monospace,Menlo,monospace;font-size:11.5px;color:#8a8a92;text-transform:uppercase;letter-spacing:.04em;margin-bottom:10px}
+  .big{font-size:44px;font-weight:750;line-height:1}
+  .big small{font-size:18px;color:#6b6b73}
+  .sub{font-size:16px;font-weight:600;margin-top:6px}
+  .note{color:#8a8a92;font-size:12.5px;margin-top:8px}
+  .dim{color:#6b6b73}
+  .drift{list-style:none}
+  .drift li{padding:7px 0;border-bottom:1px solid #18181b;font-size:14.5px}
+  .x{color:#f87171;margin-right:6px}
+  table{border-collapse:collapse;width:100%;font-size:13.5px}
+  th,td{text-align:left;padding:7px 12px 7px 0;border-bottom:1px solid #18181b}
+  th{color:#8a8a92;font-weight:500;font-family:ui-monospace,Menlo,monospace;font-size:11.5px}
+  td{font-family:ui-monospace,Menlo,monospace}
+  .empty{color:#a1a1aa;padding:24px 0}
+  footer{margin-top:36px;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#5a5a62}
+  footer a{color:#8a8a92}
+  .printbtn{float:right;font-size:12.5px;font-family:ui-monospace,Menlo,monospace;color:#8a8a92;background:none;border:1px solid #3a3a40;border-radius:6px;padding:5px 12px;cursor:pointer}
+  @media(max-width:560px){.grid{grid-template-columns:1fr}}
+  @media print{
+    body{background:#fff;color:#111;padding:0}
+    .card{border-color:#ccc}
+    .printbtn{display:none}
+    th,td,.drift li{border-color:#ddd}
+    footer,a{color:#555}
+  }
+</style></head><body><div class="wrap">
+  <button class="printbtn" onclick="window.print()">print / save PDF</button>
+  <div class="kick">slop-detect / client report</div>
+  <h1>${escapeHtml(domain)}</h1>
+  <div class="meta">prepared ${today} · slop-detect.com${pub?.monitoring ? ' · monitored' : ''}</div>
+  ${body}
+  <footer>Scores are deterministic, named checks — a fingerprint, not a verdict.
+    Reproduce: <a href="${origin}/">slop-detect.com</a> · npx slop-detect ${escapeHtml(domain)}</footer>
+</div></body></html>`;
+
+  return new Response(html, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=120' }
+  });
+}

--- a/packages/web/test/alerts.test.js
+++ b/packages/web/test/alerts.test.js
@@ -131,7 +131,7 @@ test('sweep respects max and records errors without aborting', async () => {
   const store = new Map(watches.map(w => [w.domain, { ...w }]));
   const s = await monitorSweep({
     watches: [...store.values()],
-    scanDomain: async (d) => { if (d === 'a.com') throw new Error('scan failed'); },
+    scanDomain: async (w) => { if (w.domain === 'a.com') throw new Error('scan failed'); },
     getWatch: async (d) => store.get(d) || null,
     putWatch: async (w) => store.set(w.domain, w),
     sendAlert: async () => ({ sent: true }),

--- a/packages/web/test/drift.test.js
+++ b/packages/web/test/drift.test.js
@@ -1,0 +1,296 @@
+// System-drift monitoring (Roadmap v2 P2a) + the agency report page (P2b-lite).
+// Pure predicate, watch tracking, sweep alerting, email copy, the /api/watch
+// opt-in flag, and /report/:domain rendering — all against in-memory mocks.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isSystemDrift,
+  recordScanForWatch,
+  getWatch,
+  slimResult,
+  publicWatch,
+  getHistory
+} from '../functions/_shared.js';
+import { monitorSweep } from '../functions/_sweep.js';
+import { buildDriftAlert } from '../functions/_alerts.js';
+import { onRequestPost as watchPost } from '../functions/api/watch.js';
+import { onRequestGet as reportGet } from '../functions/report/[domain].js';
+
+function makeKv(seed = {}) {
+  const store = new Map(Object.entries(seed).map(([k, v]) => [k, typeof v === 'string' ? { value: v } : v]));
+  return {
+    store,
+    async get(k) { return store.has(k) ? store.get(k).value : null; },
+    async put(k, v, opts = {}) { store.set(k, { value: v, metadata: opts.metadata }); },
+    async delete(k) { store.delete(k); },
+    async list({ prefix = '', limit = 1000 } = {}) {
+      const keys = [...store.keys()].filter(n => n.startsWith(prefix)).slice(0, limit)
+        .map(n => ({ name: n, metadata: store.get(n).metadata }));
+      return { keys, list_complete: true };
+    }
+  };
+}
+
+const slim = (over = {}) => ({
+  id: 'r1', domain: 'example.com', score: 8, grade: 'A-', tier: 'Clean',
+  createdAt: '2026-06-10T00:00:00.000Z', ...over
+});
+const sysSlim = (sysOver = {}, over = {}) => slim({
+  system: { score: 95, tier: 'Aligned', name: 'Heritage', driftCount: 0, drift: [], ...sysOver },
+  ...over
+});
+
+// ── isSystemDrift (pure) ─────────────────────────────────────────────────────
+test('isSystemDrift: falling from an Aligned baseline is drift', () => {
+  assert.equal(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: 60, tier: 'Drifting' }), true);
+  assert.equal(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: 30, tier: 'Off-system' }), true);
+});
+
+test('isSystemDrift: staying Aligned, or improving, is never drift', () => {
+  assert.equal(isSystemDrift({ score: 85, tier: 'Aligned' }, { score: 82, tier: 'Aligned' }), false);
+  assert.equal(isSystemDrift({ score: 40, tier: 'Off-system' }, { score: 70, tier: 'Drifting' }), false);
+});
+
+test('isSystemDrift: a never-Aligned site only drifts on a meaningful worsening (≥15)', () => {
+  const base = { score: 60, tier: 'Drifting' };
+  assert.equal(isSystemDrift(base, { score: 55, tier: 'Drifting' }), false, '-5 is noise');
+  assert.equal(isSystemDrift(base, { score: 45, tier: 'Drifting' }), true, '-15 is drift');
+});
+
+test('isSystemDrift: No system / No data tiers never drift', () => {
+  assert.equal(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: null, tier: 'No system' }), false);
+  assert.equal(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: null, tier: 'No data' }), false);
+});
+
+// ── slimResult carries the compact system summary ───────────────────────────
+test('slimResult persists a compact system block only when the axis ran', () => {
+  const withSys = slimResult({
+    url: 'https://example.com', score: 8, tier: 'Clean', grade: 'A-', patterns: [],
+    system: { declared: true, score: 70, tier: 'Drifting', name: 'H', drift: [{ id: 'fonts.declared', message: 'inter undeclared', evidence: {} }] }
+  }, 'id1');
+  assert.equal(withSys.system.score, 70);
+  assert.equal(withSys.system.drift[0].id, 'fonts.declared');
+  assert.equal(withSys.system.drift[0].evidence, undefined, 'evidence blobs are not persisted');
+
+  const noSys = slimResult({ url: 'https://x.com', score: 8, tier: 'Clean', grade: 'A-', patterns: [] }, 'id2');
+  assert.equal(noSys.system, undefined);
+
+  const undeclared = slimResult({
+    url: 'https://x.com', score: 8, tier: 'Clean', grade: 'A-', patterns: [],
+    system: { declared: false, score: null, tier: 'No system' }
+  }, 'id3');
+  assert.equal(undeclared.system, undefined, 'No-system results are not persisted as compliance data');
+});
+
+// ── recordScanForWatch system tracking ───────────────────────────────────────
+test('recordScanForWatch sets a system baseline, then flags drift and resets on recovery', async () => {
+  const kv = makeKv({
+    'w:example.com': JSON.stringify({ domain: 'example.com', email: 'o@x.io', system: true, verified: true })
+  });
+
+  // First system reading establishes the baseline (Aligned 95) — no drift.
+  let out = await recordScanForWatch(kv, sysSlim({}, { id: 's1' }));
+  assert.equal(out.system.drifted, false);
+  let w = await getWatch(kv, 'example.com');
+  assert.equal(w.baselineSystemScore, 95);
+  assert.equal(w.baselineSystemTier, 'Aligned');
+
+  // Agent pushes off-system change → drift flagged, drift items stored.
+  out = await recordScanForWatch(kv, sysSlim(
+    { score: 55, tier: 'Drifting', drift: [{ id: 'colors.cta', message: 'violet CTA off-palette' }] },
+    { id: 's2' }
+  ));
+  assert.equal(out.system.drifted, true);
+  w = await getWatch(kv, 'example.com');
+  assert.equal(w.systemRegressed, true);
+  assert.equal(w.lastSystemDrift[0].id, 'colors.cta');
+  assert.equal(w.baselineSystemScore, 95, 'baseline must not move');
+
+  // Recovery → flag clears and systemNotified re-arms.
+  w.systemNotified = true;
+  await kv.put('w:example.com', JSON.stringify(w));
+  out = await recordScanForWatch(kv, sysSlim({}, { id: 's3' }));
+  w = await getWatch(kv, 'example.com');
+  assert.equal(w.systemRegressed, false);
+  assert.equal(w.systemNotified, false, 'recovery re-arms the alert');
+
+  // History points carry the system reading.
+  const hist = await getHistory(kv, 'example.com');
+  assert.equal(hist.length, 3);
+  assert.equal(hist[1].sys.tier, 'Drifting');
+});
+
+test('a designMd-less scan does not erase system state', async () => {
+  const kv = makeKv({
+    'w:example.com': JSON.stringify({
+      domain: 'example.com', email: 'o@x.io',
+      baselineSystemScore: 95, baselineSystemTier: 'Aligned',
+      lastSystemScore: 55, lastSystemTier: 'Drifting', systemRegressed: true
+    })
+  });
+  await recordScanForWatch(kv, slim({ id: 'plain' })); // no .system
+  const w = await getWatch(kv, 'example.com');
+  assert.equal(w.lastSystemScore, 55, 'system reading untouched');
+  assert.equal(w.systemRegressed, true, 'drift flag untouched');
+});
+
+// ── sweep: drift alert once, recovery re-arms; scanDomain gets the watch ─────
+function sweepHarness(watches) {
+  const store = new Map(watches.map(w => [w.domain, { ...w }]));
+  const sent = [], drifted = [], scanned = [];
+  return {
+    store, sent, drifted, scanned,
+    run: () => monitorSweep({
+      watches: [...store.values()],
+      scanDomain: async (w) => { scanned.push({ domain: w.domain, system: !!w.system }); },
+      getWatch: async (d) => store.get(d) || null,
+      putWatch: async (w) => store.set(w.domain, w),
+      sendAlert: async (w) => { sent.push(w.domain); return { sent: true }; },
+      sendDriftAlert: async (w) => { drifted.push(w.domain); return { sent: true }; }
+    })
+  };
+}
+
+test('sweep fires the drift alert exactly once per drift event', async () => {
+  const h = sweepHarness([{
+    domain: 'a.com', verified: true, system: true,
+    regressed: false, notified: false,
+    systemRegressed: true, systemNotified: false
+  }]);
+  const s1 = await h.run();
+  assert.equal(s1.driftAlerted, 1);
+  assert.equal(s1.alerted, 0, 'slop alert independent of drift alert');
+  assert.deepEqual(h.drifted, ['a.com']);
+  assert.equal(h.store.get('a.com').systemNotified, true);
+
+  const s2 = await h.run();
+  assert.equal(s2.driftAlerted, 0, 'no duplicate drift alert');
+});
+
+test('sweep can fire BOTH alerts in one pass and passes the watch to scanDomain', async () => {
+  const h = sweepHarness([{
+    domain: 'b.com', verified: true, system: true,
+    regressed: true, notified: false,
+    systemRegressed: true, systemNotified: false
+  }]);
+  const s = await h.run();
+  assert.equal(s.alerted, 1);
+  assert.equal(s.driftAlerted, 1);
+  assert.deepEqual(h.scanned, [{ domain: 'b.com', system: true }], 'scanDomain sees watch.system');
+});
+
+test('sweep without a sendDriftAlert callback skips drift silently (backward compatible)', async () => {
+  const store = new Map([['a.com', { domain: 'a.com', verified: true, systemRegressed: true, systemNotified: false }]]);
+  const s = await monitorSweep({
+    watches: [...store.values()],
+    scanDomain: async () => {},
+    getWatch: async (d) => store.get(d),
+    putWatch: async (w) => store.set(w.domain, w),
+    sendAlert: async () => ({ sent: true })
+  });
+  assert.equal(s.driftAlerted, 0);
+});
+
+// ── drift email copy ─────────────────────────────────────────────────────────
+test('buildDriftAlert names the drift, frames signals-not-verdicts, offers unsubscribe', () => {
+  const m = buildDriftAlert('example.com',
+    { score: 95, tier: 'Aligned' },
+    { score: 55, tier: 'Drifting' },
+    [{ id: 'fonts.declared', message: 'font(s) in use but not in the system: inter' }],
+    { resultUrl: 'https://slop-detect.com/r/abc' });
+  assert.match(m.subject, /example\.com/);
+  assert.match(m.subject, /Aligned → Drifting/);
+  assert.match(m.text, /inter/);
+  assert.match(m.text, /not a verdict/i);
+  assert.match(m.text, /unsubscribe/i);
+  assert.match(m.text, /\/r\/abc/);
+});
+
+// ── /api/watch { system: true } opt-in ──────────────────────────────────────
+test('POST /api/watch { system:true } enables compliance monitoring; omit preserves', async () => {
+  const kv = makeKv();
+  const env = { RESULTS: kv };
+  const req = (body) => ({ json: async () => body, url: 'https://slop-detect.com/api/watch' });
+
+  let res = await watchPost({ request: req({ domain: 'example.com', email: 'o@x.io', system: true }), env });
+  let j = await res.json();
+  assert.equal(j.systemMonitoring, true);
+
+  // Re-subscribe without the flag — preserved.
+  res = await watchPost({ request: req({ domain: 'example.com', email: 'o@x.io' }), env });
+  j = await res.json();
+  assert.equal(j.systemMonitoring, true);
+
+  // Explicit off.
+  res = await watchPost({ request: req({ domain: 'example.com', email: 'o@x.io', system: false }), env });
+  j = await res.json();
+  assert.equal(j.systemMonitoring, false);
+});
+
+test('re-subscribing does not erase the system baseline; publicWatch exposes it sans email', async () => {
+  const kv = makeKv({
+    'w:example.com': JSON.stringify({
+      domain: 'example.com', email: 'o@x.io', system: true,
+      baselineSystemScore: 95, baselineSystemTier: 'Aligned',
+      lastSystemScore: 55, lastSystemTier: 'Drifting', systemRegressed: true,
+      lastSystemDrift: [{ id: 'colors.cta', message: 'off-palette' }]
+    })
+  });
+  const env = { RESULTS: kv };
+  const res = await watchPost({
+    request: { json: async () => ({ domain: 'example.com', email: 'o@x.io' }), url: 'https://slop-detect.com/api/watch' }, env
+  });
+  const j = await res.json();
+  assert.equal(j.system.baseline.score, 95, 'baseline preserved across re-subscribe');
+  assert.equal(j.system.drifted, true);
+  assert.equal(j.system.drift[0].id, 'colors.cta');
+  assert.ok(!JSON.stringify(j).includes('o@x.io'), 'email never leaks');
+});
+
+// ── /report/:domain (P2b-lite) ───────────────────────────────────────────────
+test('/report renders scores, system compliance, drift, and history — without the email', async () => {
+  const kv = makeKv({
+    'd:example.com': 'r9',
+    'r:r9': JSON.stringify({
+      id: 'r9', domain: 'example.com', score: 12, grade: 'B+', tier: 'Mild',
+      patternsFlagged: 3, patternsTotal: 27, definitionsVersion: '2026.08',
+      triggered: [{ id: 'slop_fonts', label: 'AI-default font stack', weight: 8 }]
+    }),
+    'w:example.com': JSON.stringify({
+      domain: 'example.com', email: 'secret@x.io', system: true, verified: true,
+      lastSystemScore: 55, lastSystemTier: 'Drifting', systemRegressed: true,
+      baselineSystemScore: 95, baselineSystemTier: 'Aligned',
+      lastSystemDrift: [{ id: 'fonts.declared', message: 'inter undeclared' }]
+    }),
+    'h:example.com': JSON.stringify([
+      { id: 'r8', score: 8, grade: 'A-', tier: 'Clean', createdAt: '2026-06-01T00:00:00Z', sys: { score: 95, tier: 'Aligned' } },
+      { id: 'r9', score: 12, grade: 'B+', tier: 'Mild', createdAt: '2026-06-10T00:00:00Z', sys: { score: 55, tier: 'Drifting' } }
+    ])
+  });
+  const res = await reportGet({
+    params: { domain: 'example.com' },
+    request: { url: 'https://slop-detect.com/report/example.com' },
+    env: { RESULTS: kv }
+  });
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.match(html, /B\+/);
+  assert.match(html, /Drifting/);
+  assert.match(html, /inter undeclared/);
+  assert.match(html, /History/);
+  assert.match(html, /@media print/, 'print stylesheet present (the PDF substitute)');
+  assert.ok(!html.includes('secret@x.io'), 'email never appears in the report');
+  // Anti-slop self-check.
+  assert.doesNotMatch(html, /Inter,|Geist|Space Grotesk/);
+});
+
+test('/report shows an honest empty state for an unknown domain', async () => {
+  const res = await reportGet({
+    params: { domain: 'unseen.com' },
+    request: { url: 'https://slop-detect.com/report/unseen.com' },
+    env: { RESULTS: makeKv() }
+  });
+  const html = await res.text();
+  assert.match(html, /No scan data/i);
+});


### PR DESCRIPTION
Implements every remaining code-completable item from ROADMAP v2 — turning last PR's `system` axis into the actual product loop.

## P2a — Design-system drift alerts (the agency value proposition)

`POST /api/watch { system: true }` → the daily sweep scans the domain with `designMd: true` → on drift, the owner gets a **named-drift email** (once per event; recovery re-arms — same proven pattern as slop-regression alerts; verified addresses only).

- `isSystemDrift` (pure): drift = no-longer-Aligned **and** (fell from an Aligned baseline **or** ≥15-pt compliance drop). A never-Aligned site doesn't "drift" on every sweep; `No system`/`No data` never drift.
- `recordScanForWatch` tracks a system baseline + last reading + top-5 drift items; history points carry `sys{score,tier}`; a designMd-less scan **cannot erase** system state.
- `monitorSweep` gains a second, independent alert path (`sendDriftAlert`); `scanDomain` now receives the whole watch so only opted-in domains pay the DESIGN.md fetch. Backward compatible when the callback is omitted.
- `buildDriftAlert`: named, contestable drift items + signals-not-verdicts framing + unsubscribe.

## P2b-lite — `GET /report/:domain` (the agency deliverable)

Print-friendly client report: slop grade/score, system compliance, drift items, triggered patterns, history table — with an `@media print` stylesheet so "print / save PDF" replaces server-side PDF infrastructure (the indie-smart call from the research). Public data only (email can never appear — tested), `noindex`, honest empty state, anti-slop by construction.

## P4 — MCP `check_design_system` tool

Agents can now check a page against its DESIGN.md *before shipping UI changes* — the in-the-loop positioning from the research. Uses `share: false` so agent checks mint no public permalinks; the formatter spells out the higher-is-better polarity and explains the no-system state with how to fix it.

## Tests

**+19** (15 web drift/report + 4 MCP): the pure drift predicate's full truth table, baseline/recovery/re-arm semantics, both-alerts-in-one-sweep, the state-preservation invariants (re-subscribe can't erase the baseline; plain scans can't erase system state), email-never-leaks assertions on both the API and the report page, and the MCP client/formatter. **147 total: 140 pass, 0 fail**, 7 browser-gated golden skips. Lint clean.

## Explicitly not in this PR
P2c (live pricing) needs Stripe keys — operator task, documented in the roadmap. P2b full multi-site dashboard is next quarter's scope.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production watch/sweep/email pipeline and subscriber KV state; behavior is heavily tested but mis-tuned drift thresholds could spam or miss alerts.
> 
> **Overview**
> Closes the Roadmap v2 loop on **DESIGN.md compliance**: monitoring, alerts, client reports, and agent tooling.
> 
> **Monitoring & alerts (P2a):** `POST /api/watch` gains optional `system: true` so the daily sweep re-scans with `designMd` only for opted-in watches. `isSystemDrift`, `recordScanForWatch`, and `slimResult`/`publicWatch` track compliance baselines, drift items, and history `sys` points; scans without the system axis no longer wipe that state. `monitorSweep` and the cron handler add a parallel **drift email** path (`buildDriftAlert`, `systemNotified`, `driftAlerted`) alongside existing slop-regression alerts.
> 
> **Agency report (P2b-lite):** New **`GET /report/:domain`** serves a print-friendly HTML summary (slop + system compliance, drift, patterns, history) with public data only.
> 
> **MCP (P4):** New **`check_design_system`** tool via `checkSystem` → `/api/scan` with `designMd` and `share: false`, plus `formatSystem` output.
> 
> Docs (`README`, `ROADMAP`, `API.md`) and tests (`drift.test.js`, MCP `system.test.js`) updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dda8388464906fd03ec836f275e04a519ad889a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->