### PR TITLE
Landing UX review: conversion bridge + staleness fixes + brand unification

### DIFF
--- a/packages/web/functions/_brand.js
+++ b/packages/web/functions/_brand.js
@@ -1,0 +1,36 @@
+// Shared brand identity for server-rendered pages (/directory, /leaderboard,
+// /report/:domain) so they read as the SAME product as the landing page: the
+// forensic-instrument register — Hanken Grotesk prose, Martian Mono readouts,
+// cold-blue accent, blue-tinted neutrals, §-registration marks. One source of
+// truth; pages interpolate these constants instead of hand-rolling tokens.
+// Anti-slop by construction, like everything else here.
+
+export const BRAND_FONTS_HEAD = `
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=Martian+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">`;
+
+export const BRAND_CSS = `
+  :root{
+    color-scheme:dark;
+    --bg:#0a0b0e; --bg-2:#0e1014; --panel:#131620; --panel-2:#1a1e2a;
+    --border:#262b38; --border-2:#353c4d;
+    --text:#f2f4f8; --text-2:#c2c7d2; --muted:#9aa1b1; --dim:#6f7689;
+    --accent:#5b9dff; --accent-soft:rgba(91,157,255,0.10); --accent-ink:#06080d;
+    --green:#4ade80; --yellow:#fbbf24; --red:#f87171;
+    --sans:"Hanken Grotesk",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+    --mono:"Martian Mono",ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  }
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.55}
+  a{color:inherit}
+  .eyebrow{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+  .eyebrow .reg{
+    font-family:var(--mono);font-size:11px;font-weight:600;color:var(--accent);
+    border:1px solid var(--border-2);background:var(--accent-soft);
+    border-radius:5px;padding:3px 7px;letter-spacing:-0.04em;
+  }
+  .eyebrow .reg-label{
+    font-family:var(--mono);font-size:11.5px;color:var(--dim);
+    text-transform:uppercase;letter-spacing:0.04em;
+  }`;

--- a/packages/web/functions/directory.js
+++ b/packages/web/functions/directory.js
@@ -11,6 +11,7 @@
 // purple, no glows — this page should itself score Clean on slop-detect.
 
 import { listAllSites, tierColors, escapeHtml } from './_shared.js';
+import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
 
 const ORIGIN = 'https://slop-detect.com';
 
@@ -86,45 +87,38 @@ export async function onRequestGet({ request, env }) {
 <meta property="og:description" content="Opt-in catalogue of sites ranked by the AI-design-slop fingerprint.">
 <meta property="og:url" content="${ORIGIN}/directory">
 <meta property="og:image" content="${ORIGIN}/og.png">
-<script type="application/ld+json">${jsonLd(sites, origin)}</script>
-<style>
-  :root{color-scheme:dark}
-  *{margin:0;padding:0;box-sizing:border-box}
-  body{
-    background:#0a0a0b;color:#e7e7ea;
-    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
-    line-height:1.5;padding:48px 20px 80px;
-  }
+<script type="application/ld+json">${jsonLd(sites, origin)}</script>${BRAND_FONTS_HEAD}
+<style>${BRAND_CSS}
+  body{padding:48px 20px 80px}
   .wrap{max-width:820px;margin:0 auto}
-  a{color:inherit}
-  header{border-bottom:1px solid #232327;padding-bottom:20px;margin-bottom:8px}
-  .kick{font-family:ui-monospace,Menlo,monospace;font-size:12px;letter-spacing:.04em;color:#6b6b73;text-transform:uppercase}
-  h1{font-size:30px;font-weight:650;letter-spacing:-0.01em;margin:6px 0 8px}
-  .sub{color:#a1a1aa;font-size:15px;max-width:60ch}
-  .sub a{color:#e7e7ea;text-decoration:underline;text-underline-offset:2px}
+  header{border-bottom:1px solid var(--border);padding-bottom:20px;margin-bottom:8px}
+  h1{font-size:30px;font-weight:700;letter-spacing:-0.02em;margin:2px 0 8px}
+  .sub{color:var(--muted);font-size:15px;max-width:60ch}
+  .sub a{color:var(--text);text-decoration:underline;text-underline-offset:2px}
   .bar{display:flex;justify-content:space-between;align-items:center;
-       font-family:ui-monospace,Menlo,monospace;font-size:12.5px;color:#8a8a92;
+       font-family:var(--mono);font-size:12px;color:var(--dim);
        padding:14px 2px 8px}
-  .bar a{color:#e7e7ea;text-decoration:none;border-bottom:1px solid #3a3a40;padding-bottom:1px}
+  .bar a{color:var(--text-2);text-decoration:none;border-bottom:1px solid var(--border-2);padding-bottom:1px}
+  .bar a:hover{color:var(--text)}
   ol{list-style:none}
   .r{display:grid;grid-template-columns:34px 78px 64px 1fr auto;gap:12px;align-items:baseline;
-     padding:13px 2px;border-bottom:1px solid #18181b;font-size:15px}
-  .g{font-family:ui-monospace,Menlo,monospace;font-weight:700;font-size:14px;
+     padding:13px 2px;border-bottom:1px solid var(--bg-2);font-size:15px}
+  .g{font-family:var(--mono);font-weight:700;font-size:14px;
      border:1px solid;border-radius:5px;text-align:center;padding:1px 0}
-  .sc{font-family:ui-monospace,Menlo,monospace;color:#d4d4d8;font-size:14px}
-  .sc small{color:#6b6b73;font-size:11px}
-  .t{font-family:ui-monospace,Menlo,monospace;font-size:12.5px}
+  .sc{font-family:var(--mono);color:var(--text-2);font-size:13px}
+  .sc small{color:var(--dim);font-size:11px}
+  .t{font-family:var(--mono);font-size:12px}
   .d{min-width:0;overflow:hidden}
-  .dom{font-weight:550;text-decoration:none;border-bottom:1px solid #3a3a40;padding-bottom:1px}
-  .dom:hover{border-color:#e7e7ea}
-  .ti{display:block;color:#71717a;font-size:12.5px;margin-top:2px;
+  .dom{font-weight:600;text-decoration:none;border-bottom:1px solid var(--border-2);padding-bottom:1px}
+  .dom:hover{border-color:var(--text)}
+  .ti{display:block;color:var(--dim);font-size:12.5px;margin-top:2px;
       white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .scan{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#8a8a92;text-decoration:none;white-space:nowrap}
-  .scan:hover{color:#e7e7ea}
-  .empty{padding:28px 2px;color:#8a8a92}
-  .empty a{color:#e7e7ea}
-  footer{margin-top:28px;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#5a5a62}
-  footer a{color:#8a8a92}
+  .scan{font-family:var(--mono);font-size:11.5px;color:var(--dim);text-decoration:none;white-space:nowrap}
+  .scan:hover{color:var(--text)}
+  .empty{padding:28px 2px;color:var(--muted)}
+  .empty a{color:var(--text)}
+  footer{margin-top:28px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  footer a{color:var(--muted)}
   @media(max-width:560px){
     .r{grid-template-columns:30px 1fr auto;gap:8px}
     .t,.scan{display:none}
@@ -132,7 +126,7 @@ export async function onRequestGet({ request, env }) {
 </style>
 </head><body><div class="wrap">
   <header>
-    <div class="kick">slop-detect / directory</div>
+    <div class="eyebrow"><span class="reg">&sect;dir</span><span class="reg-label">the directory</span></div>
     <h1>Sites scored for AI design slop</h1>
     <p class="sub">An opt-in catalogue. Owners <a href="${origin}/">claim their domain</a>
       to appear here &mdash; with a live badge and a link back to their site.

--- a/packages/web/functions/leaderboard.js
+++ b/packages/web/functions/leaderboard.js
@@ -11,6 +11,7 @@
 // purple — this page should itself score Clean.
 
 import { tierColors, escapeHtml } from './_shared.js';
+import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
 
 const ORIGIN = 'https://slop-detect.com';
 
@@ -90,45 +91,43 @@ export async function onRequestGet({ request }) {
 <meta property="og:description" content="How much of the web now looks AI-generated — a reproducible scan of well-known landing pages.">
 <meta property="og:url" content="${ORIGIN}/leaderboard">
 <meta property="og:image" content="${ORIGIN}/og.png">
-<style>
-  :root{color-scheme:dark}
-  *{margin:0;padding:0;box-sizing:border-box}
-  body{background:#0a0a0b;color:#e7e7ea;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;line-height:1.55;padding:48px 20px 80px}
+${BRAND_FONTS_HEAD}
+<style>${BRAND_CSS}
+  body{padding:48px 20px 80px}
   .wrap{max-width:760px;margin:0 auto}
-  a{color:inherit}
-  .kick{font-family:ui-monospace,Menlo,monospace;font-size:12px;letter-spacing:.04em;color:#6b6b73;text-transform:uppercase}
-  h1{font-size:32px;font-weight:650;letter-spacing:-0.01em;margin:6px 0 14px}
-  h2{font-size:20px;margin:36px 0 6px}
-  .lead{font-size:19px;color:#d4d4d8;max-width:62ch}
-  .lead strong{color:#fff}
-  .note{color:#8a8a92;font-size:14px;margin-bottom:12px;max-width:62ch}
+  h1{font-size:32px;font-weight:700;letter-spacing:-0.02em;margin:2px 0 14px}
+  h2{font-size:20px;font-weight:700;letter-spacing:-0.01em;margin:36px 0 6px}
+  .lead{font-size:19px;color:var(--text-2);max-width:62ch}
+  .lead strong{color:var(--text)}
+  .note{color:var(--muted);font-size:14px;margin-bottom:12px;max-width:62ch}
   .rows{list-style:none;margin-top:8px}
-  .r{display:grid;grid-template-columns:34px 78px 1fr auto;gap:12px;align-items:baseline;padding:11px 2px;border-bottom:1px solid #18181b}
-  .g{font-family:ui-monospace,Menlo,monospace;font-weight:700;font-size:14px;border:1px solid;border-radius:5px;text-align:center;padding:1px 0}
-  .sc{font-family:ui-monospace,Menlo,monospace;color:#d4d4d8;font-size:14px}
-  .sc small{color:#6b6b73;font-size:11px}
-  .dom{font-weight:550;text-decoration:none;border-bottom:1px solid #3a3a40;padding-bottom:1px}
-  .dom:hover{border-color:#e7e7ea}
-  .scan{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#8a8a92;text-decoration:none;white-space:nowrap}
+  .r{display:grid;grid-template-columns:34px 78px 1fr auto;gap:12px;align-items:baseline;padding:11px 2px;border-bottom:1px solid var(--bg-2)}
+  .g{font-family:var(--mono);font-weight:700;font-size:14px;border:1px solid;border-radius:5px;text-align:center;padding:1px 0}
+  .sc{font-family:var(--mono);color:var(--text-2);font-size:13px}
+  .sc small{color:var(--dim);font-size:11px}
+  .dom{font-weight:600;text-decoration:none;border-bottom:1px solid var(--border-2);padding-bottom:1px}
+  .dom:hover{border-color:var(--text)}
+  .scan{font-family:var(--mono);font-size:11.5px;color:var(--dim);text-decoration:none;white-space:nowrap}
   table{border-collapse:collapse;margin-top:8px;width:100%;max-width:420px}
-  th,td{text-align:left;padding:7px 14px 7px 0;font-size:14px;border-bottom:1px solid #18181b}
-  th{color:#8a8a92;font-weight:500;font-family:ui-monospace,Menlo,monospace;font-size:12px}
-  td:nth-child(3),th:nth-child(3),td:nth-child(2),th:nth-child(2){font-family:ui-monospace,Menlo,monospace}
-  .cta{margin:40px 0;padding:20px;border:1px solid #232327;border-radius:10px}
-  .cta a{color:#e7e7ea;border-bottom:1px solid #3a3a40;text-decoration:none}
-  .meth{margin-top:40px;color:#71717a;font-size:13px;max-width:64ch}
-  .meth code{font-family:ui-monospace,Menlo,monospace;color:#a1a1aa}
-  footer{margin-top:32px;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#5a5a62}
-  footer a{color:#8a8a92}
+  th,td{text-align:left;padding:7px 14px 7px 0;font-size:14px;border-bottom:1px solid var(--bg-2)}
+  th{color:var(--dim);font-weight:500;font-family:var(--mono);font-size:11.5px}
+  td:nth-child(3),th:nth-child(3),td:nth-child(2),th:nth-child(2){font-family:var(--mono)}
+  .cta{margin:40px 0;padding:18px 20px;background:var(--accent-soft);border:1px solid var(--border-2);border-radius:10px}
+  .cta a{color:var(--text);border-bottom:1px solid var(--border-2);text-decoration:none}
+  .cta a:hover{border-color:var(--text)}
+  .meth{margin-top:40px;color:var(--dim);font-size:13px;max-width:64ch}
+  .meth code{font-family:var(--mono);color:var(--muted)}
+  footer{margin-top:32px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  footer a{color:var(--muted)}
   @media(max-width:560px){.r{grid-template-columns:30px 64px 1fr}.scan{display:none}}
 </style></head><body><div class="wrap">
-  <div class="kick">slop-detect / report</div>
+  <div class="eyebrow"><span class="reg">&sect;rpt</span><span class="reg-label">the report</span></div>
   <h1>The State of AI Design Slop</h1>
   ${headline}
 
   <div class="cta">
     Wondering about your own site? <a href="${origin}/">Scan it free</a> &middot;
-    keep it clean over time with <a href="${origin}/privacy.md">monitoring</a>.
+    keep it clean over time with <a href="${origin}/#monitor">monitoring</a>.
   </div>
 
   ${hall}
@@ -136,7 +135,7 @@ export async function onRequestGet({ request }) {
 
   <p class="meth">Methodology: each URL scanned once in a headless browser against the
     27-pattern, weighted, deterministic AI-design-slop fingerprint
-    (definitions ${escapeHtml(data?.definitionsVersion || '2026.08')}), ${escapeHtml(String(when))}.
+    (definitions ${escapeHtml(data?.definitionsVersion || '2026.09')}), ${escapeHtml(String(when))}.
     Reproduce any row: <code>npx slop-detect &lt;url&gt;</code>. A slop score is a
     <em>fingerprint, not a verdict</em> — everyone uses AI now; this measures how
     generic the result reads, nothing about the team behind it.</p>

--- a/packages/web/functions/report/[domain].js
+++ b/packages/web/functions/report/[domain].js
@@ -18,6 +18,7 @@ import {
   tierColors,
   escapeHtml
 } from '../_shared.js';
+import { BRAND_FONTS_HEAD, BRAND_CSS } from '../_brand.js';
 
 const ORIGIN = 'https://slop-detect.com';
 
@@ -118,46 +119,44 @@ export async function onRequestGet({ params, request, env }) {
 <title>Report: ${escapeHtml(domain)} · slop-detect</title>
 <meta name="robots" content="noindex">
 <link rel="canonical" href="${ORIGIN}/report/${escapeHtml(domain)}">
-<style>
-  :root{color-scheme:dark light}
-  *{margin:0;padding:0;box-sizing:border-box}
-  body{background:#0a0a0b;color:#e7e7ea;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;line-height:1.55;padding:48px 20px 80px}
+${BRAND_FONTS_HEAD}
+<style>${BRAND_CSS}
+  body{padding:48px 20px 80px}
   .wrap{max-width:720px;margin:0 auto}
-  a{color:inherit}
-  .kick{font-family:ui-monospace,Menlo,monospace;font-size:12px;letter-spacing:.04em;color:#6b6b73;text-transform:uppercase}
-  h1{font-size:28px;font-weight:650;letter-spacing:-0.01em;margin:6px 0 2px}
-  h2{font-size:17px;margin:30px 0 8px}
-  .meta{color:#8a8a92;font-size:13px;font-family:ui-monospace,Menlo,monospace;margin-bottom:24px}
+  h1{font-size:28px;font-weight:700;letter-spacing:-0.02em;margin:2px 0 2px}
+  h2{font-size:17px;font-weight:700;margin:30px 0 8px}
+  .meta{color:var(--dim);font-size:12.5px;font-family:var(--mono);margin-bottom:24px}
   .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-  .card{border:1px solid #232327;border-radius:10px;padding:18px}
-  .k{font-family:ui-monospace,Menlo,monospace;font-size:11.5px;color:#8a8a92;text-transform:uppercase;letter-spacing:.04em;margin-bottom:10px}
-  .big{font-size:44px;font-weight:750;line-height:1}
-  .big small{font-size:18px;color:#6b6b73}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:18px}
+  .k{font-family:var(--mono);font-size:11px;color:var(--dim);text-transform:uppercase;letter-spacing:.04em;margin-bottom:10px}
+  .big{font-size:44px;font-weight:800;line-height:1;font-family:var(--mono);letter-spacing:-0.03em}
+  .big small{font-size:18px;color:var(--dim)}
   .sub{font-size:16px;font-weight:600;margin-top:6px}
-  .note{color:#8a8a92;font-size:12.5px;margin-top:8px}
-  .dim{color:#6b6b73}
+  .note{color:var(--muted);font-size:12.5px;margin-top:8px}
+  .dim{color:var(--dim)}
   .drift{list-style:none}
-  .drift li{padding:7px 0;border-bottom:1px solid #18181b;font-size:14.5px}
-  .x{color:#f87171;margin-right:6px}
-  table{border-collapse:collapse;width:100%;font-size:13.5px}
-  th,td{text-align:left;padding:7px 12px 7px 0;border-bottom:1px solid #18181b}
-  th{color:#8a8a92;font-weight:500;font-family:ui-monospace,Menlo,monospace;font-size:11.5px}
-  td{font-family:ui-monospace,Menlo,monospace}
-  .empty{color:#a1a1aa;padding:24px 0}
-  footer{margin-top:36px;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#5a5a62}
-  footer a{color:#8a8a92}
-  .printbtn{float:right;font-size:12.5px;font-family:ui-monospace,Menlo,monospace;color:#8a8a92;background:none;border:1px solid #3a3a40;border-radius:6px;padding:5px 12px;cursor:pointer}
+  .drift li{padding:7px 0;border-bottom:1px solid var(--bg-2);font-size:14.5px}
+  .x{color:var(--red);margin-right:6px}
+  table{border-collapse:collapse;width:100%;font-size:13px}
+  th,td{text-align:left;padding:7px 12px 7px 0;border-bottom:1px solid var(--bg-2)}
+  th{color:var(--dim);font-weight:500;font-family:var(--mono);font-size:11px}
+  td{font-family:var(--mono)}
+  .empty{color:var(--muted);padding:24px 0}
+  footer{margin-top:36px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  footer a{color:var(--muted)}
+  .printbtn{float:right;font-size:12px;font-family:var(--mono);color:var(--muted);background:none;border:1px solid var(--border-2);border-radius:6px;padding:5px 12px;cursor:pointer}
+  .printbtn:hover{color:var(--text);border-color:var(--muted)}
   @media(max-width:560px){.grid{grid-template-columns:1fr}}
   @media print{
     body{background:#fff;color:#111;padding:0}
-    .card{border-color:#ccc}
+    .card{border-color:#ccc;background:#fff}
     .printbtn{display:none}
     th,td,.drift li{border-color:#ddd}
     footer,a{color:#555}
   }
 </style></head><body><div class="wrap">
   <button class="printbtn" onclick="window.print()">print / save PDF</button>
-  <div class="kick">slop-detect / client report</div>
+  <div class="eyebrow"><span class="reg">&sect;cli</span><span class="reg-label">client report</span></div>
   <h1>${escapeHtml(domain)}</h1>
   <div class="meta">prepared ${today} · slop-detect.com${pub?.monitoring ? ' · monitored' : ''}</div>
   ${body}

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -88,7 +88,7 @@
       "operatingSystem": "Web, Node.js (CLI), MCP",
       "url": "https://slop-detect.com",
       "downloadUrl": "https://www.npmjs.com/package/slop-detect",
-      "softwareVersion": "0.5.1",
+      "softwareVersion": "0.6.0",
       "license": "https://opensource.org/licenses/MIT",
       "isAccessibleForFree": true,
       "publisher": { "@id": "https://slop-detect.com/#org" },
@@ -97,9 +97,11 @@
         "27-pattern deterministic design-slop fingerprint",
         "Copy-slop axis (LLM phrasing tells)",
         "AEO axis — can AI engines read & cite a page",
+        "System axis — DESIGN.md compliance: does a page honor its own declared design system",
+        "Domain monitoring with regression and design-drift email alerts (double opt-in)",
         "Real headless Chromium (Cloudflare Browser Rendering)",
-        "CLI with --fail-on for CI gating",
-        "MCP server: scan_page, check_aeo, fix_prompt"
+        "CLI with --fail-on for CI gating and --design-md for system checks",
+        "MCP server: scan_page, check_aeo, check_design_system, fix_prompt"
       ],
       "offers": {
         "@type": "Offer",
@@ -133,7 +135,7 @@
           "name": "How do AI agents and developers use it?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Via the CLI (npx slop-detect <url>, add --aeo for the AEO axis, --fail-on heavy to gate CI), the MCP server slop-detect-mcp (tools scan_page, check_aeo, fix_prompt), or the HTTP API at https://slop-detect.com/api/scan. An OpenAPI spec is published at /openapi.json."
+            "text": "Via the CLI (npx slop-detect <url>, add --aeo for the AEO axis, --design-md auto for the system axis, --fail-on heavy to gate CI), the MCP server slop-detect-mcp (tools scan_page, check_aeo, check_design_system, fix_prompt), or the HTTP API at https://slop-detect.com/api/scan. An OpenAPI spec is published at /openapi.json."
           }
         },
         {
@@ -142,6 +144,14 @@
           "acceptedAnswer": {
             "@type": "Answer",
             "text": "A complementary axis that scores whether AI engines (ChatGPT, Claude, Perplexity, Google AI Overviews) can fetch, read and cite a page. It checks AI-crawler access, robots.txt, indexability, a markdown twin, llms.txt, and content-negotiation headers. Higher AEO is better — the inverse polarity of the slop score."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can it monitor a domain over time?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. POST /api/watch with a domain and email to monitor it: the daily sweep re-scans the domain and emails you (double opt-in) when the slop score regresses. Add system: true and it also checks the page against the site's own DESIGN.md, alerting when the design drifts off its declared system. Every monitored domain gets a print-friendly client report at slop-detect.com/report/<domain>."
           }
         },
         {
@@ -937,6 +947,79 @@
   .rules-teaser b { color: var(--text-2); font-weight: 500; }
   #rulesDetails[open] + .rules-teaser { display: none; }
   .rules-teaser:empty { display: none; }
+
+  /* §04 monitoring (the conversion bridge). Same forensic register: flat
+     panels, registration marks, no gradients, no glow. */
+  .watch-form {
+    margin-top: 20px;
+    background: var(--panel);
+    border: 1px solid var(--border-2);
+    border-radius: 12px;
+    padding: 16px;
+    max-width: 620px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .watch-form:focus-within { border-color: var(--accent); }
+  .watch-row { display: flex; gap: 8px; flex-wrap: wrap; }
+  .watch-row input {
+    flex: 1;
+    min-width: 180px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text);
+    font-size: 15px;
+    padding: 10px 12px;
+    outline: none;
+    font-family: var(--mono);
+  }
+  .watch-row input:focus { border-color: var(--border-2); }
+  .watch-row input::placeholder { color: var(--dim); }
+  .watch-row button {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border: 0;
+    border-radius: 8px;
+    padding: 10px 20px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .watch-row button:hover { opacity: 0.9; }
+  .watch-row button:disabled { opacity: 0.5; cursor: wait; }
+  .watch-opts { display: flex; flex-direction: column; gap: 7px; }
+  .watch-opts label {
+    display: flex; align-items: baseline; gap: 9px;
+    font-size: 14px; color: var(--text-2); cursor: pointer; line-height: 1.45;
+  }
+  .watch-opts input { accent-color: var(--accent); flex-shrink: 0; transform: translateY(1px); }
+  .watch-opts .opt-note { color: var(--dim); font-size: 12.5px; font-family: var(--mono); }
+  .watch-msg {
+    display: none;
+    margin-top: 4px;
+    padding: 11px 13px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    font-size: 13.5px;
+    color: var(--text-2);
+    line-height: 1.5;
+  }
+  .watch-msg.show { display: block; }
+  .watch-msg.ok { border-color: var(--green); }
+  .watch-msg.err { border-color: var(--red); color: var(--red); }
+  .watch-fine { margin-top: 12px; font-size: 12.5px; color: var(--dim); line-height: 1.55; max-width: 62ch; }
+  .watch-fine a { color: var(--muted); }
+  .monitor-nudge {
+    margin-top: 14px;
+    font-size: 14px;
+    color: var(--muted);
+    font-family: var(--mono);
+  }
+  .monitor-nudge a { color: var(--accent); cursor: pointer; }
   /* Inline CLI commands: tinted chips that wrap as units instead of overflowing. */
   .cli-line code {
     display: inline-block;
@@ -996,8 +1079,10 @@
     <div class="topbar-inner">
       <div class="brand"><span class="glyph">&#9143;</span> Slop Detector</div>
       <nav class="topbar-links">
-        <a href="#how" class="hide-sm">How it works</a>
         <a href="#fingerprint" class="hide-sm">The fingerprint</a>
+        <a href="#monitor" class="hide-sm">Monitoring</a>
+        <a href="/leaderboard" class="hide-sm">Leaderboard</a>
+        <a href="/directory" class="hide-sm">Directory</a>
         <a href="https://github.com/ravidsrk/slop-detect" target="_blank" rel="noopener">GitHub</a>
       </nav>
     </div>
@@ -1033,7 +1118,7 @@
             <button data-url="https://www.aura.build">aura.build</button>
             <button data-url="https://lovable.dev">lovable.dev</button>
             <button data-url="https://stripe.com">stripe.com</button>
-            <button data-url="https://engagemii.com/aeo">engagemii.com/aeo</button>
+            <button data-url="https://linear.app">linear.app</button>
           </div>
         </div>
 
@@ -1076,9 +1161,9 @@
           <div class="eyebrow"><span class="reg">&sect;01</span><span class="reg-label">the fingerprint</span></div>
           <h2>Slop is a fingerprint, not a verdict</h2>
           <div class="block-note">
-            <b id="ruleCountTag2">27</b> weighted patterns<br>
-            across 4 axes<br>
-            defs <span id="rulesDefs2">2026.08</span>
+            <b id="ruleCountTag2">27</b> weighted design patterns<br>
+            + copy, AEO &amp; system axes<br>
+            defs <span id="rulesDefs2">2026.09</span>
           </div>
         </div>
         <div class="block-main">
@@ -1095,6 +1180,8 @@
             <div class="check"><h3><span class="n">color</span> Gradients &amp; glow</h3><p>Gradient hero text, gradient-heavy backgrounds, aurora blobs, colored glows, vibe-purple.</p></div>
             <div class="check"><h3><span class="n">layout</span> The convention stack</h3><p>Centered hero, eyebrow pill, glassmorphism, bento grids, nested cards, icon-card rows.</p></div>
             <div class="check"><h3><span class="n">copy</span> AI phrasing</h3><p>An optional second axis scores the words: the hedge-y, em-dash-heavy register LLMs default to.</p></div>
+            <div class="check"><h3><span class="n">aeo</span> AI readability</h3><p>Can ChatGPT, Claude and Perplexity actually fetch, read and cite the page? Crawler access, robots.txt, llms.txt. Higher is better.</p></div>
+            <div class="check"><h3><span class="n">system</span> DESIGN.md compliance</h3><p>The relative axis: does the page honor its <em>own</em> declared design system? Drift, not slop — bespoke design checked against its own tokens can never false-positive.</p></div>
           </div>
         </div>
       </div>
@@ -1155,6 +1242,62 @@
       </p>
     </section>
 
+    <hr class="divider">
+
+    <!-- Monitoring: the conversion bridge (a score is a snapshot; drift is the disease) -->
+    <section class="block" id="monitor">
+      <div class="block-grid">
+        <div class="block-head">
+          <div class="eyebrow"><span class="reg">&sect;04</span><span class="reg-label">keep it clean</span></div>
+          <h2>A score is a snapshot. Drift is the disease.</h2>
+          <div class="block-note">
+            re-scanned daily<br>
+            alert on regression<br>
+            free during the trial
+          </div>
+        </div>
+        <div class="block-main">
+          <p class="body">
+            Sites do not become slop in one commit. A teammate ships a section, an agent
+            "improves" a hero, and six weeks later the page reads like everyone else's.
+            Monitoring re-scans your domain daily and emails you when the score regresses.
+            Publish a <a href="https://github.com/google-labs-code/design.md" target="_blank" rel="noopener">DESIGN.md</a>
+            and it also checks every scan against <em>your own</em> declared tokens, then
+            names exactly what drifted: a font nobody approved, a CTA off the palette.
+          </p>
+
+          <form class="watch-form" id="watchForm">
+            <div class="watch-row">
+              <input id="watchDomain" type="text" placeholder="your-site.com" autocomplete="off" spellcheck="false" required>
+              <input id="watchEmail" type="email" placeholder="you@company.com" autocomplete="email" required>
+              <button type="submit" id="watchGo">Monitor</button>
+            </div>
+            <div class="watch-opts">
+              <label>
+                <input type="checkbox" id="watchSystem" checked>
+                <span>Check it against its <code>DESIGN.md</code> and alert on design drift
+                  <span class="opt-note">&middot; the system axis</span></span>
+              </label>
+              <label>
+                <input type="checkbox" id="watchList">
+                <span>List it in the public <a href="/directory">directory</a>
+                  <span class="opt-note">&middot; live badge + dofollow backlink</span></span>
+              </label>
+            </div>
+            <div class="watch-msg" id="watchMsg"></div>
+          </form>
+
+          <p class="watch-fine">
+            Double opt-in: nothing is emailed until you confirm. Your address is stored only
+            to send the alerts you asked for, never shared, and one request deletes it
+            (<a href="/privacy.md">privacy</a>). Every monitored domain gets a print-ready
+            client report at <code>/report/&lt;domain&gt;</code>. The engine stays MIT and
+            free forever; monitoring is the continuity layer.
+          </p>
+        </div>
+      </div>
+    </section>
+
     <!-- Footer -->
     <footer>
       <div class="footer-grid">
@@ -1166,7 +1309,9 @@
           <h5>product</h5>
           <a href="#how">How it works</a>
           <a href="#fingerprint">The fingerprint</a>
-          <a href="#rulesDetails">The patterns</a>
+          <a href="#monitor">Monitor a domain</a>
+          <a href="/leaderboard">Leaderboard</a>
+          <a href="/directory">Directory</a>
         </div>
         <div class="footer-col">
           <h5>install</h5>
@@ -1178,6 +1323,7 @@
           <h5>source</h5>
           <a href="https://github.com/ravidsrk/slop-detect" target="_blank" rel="noopener">GitHub</a>
           <a href="https://www.adriankrebs.ch/blog/design-slop/" target="_blank" rel="noopener">The study</a>
+          <a href="/privacy.md">Privacy</a>
         </div>
       </div>
       <div class="footer-fine">
@@ -1225,8 +1371,10 @@ const form = $('form'), urlInput = $('url'), goBtn = $('go'),
     const { count, version, patterns } = await res.json();
 
     const tag = $('ruleCountTag'); if (tag) tag.textContent = count;
+    const tag2 = $('ruleCountTag2'); if (tag2) tag2.textContent = count;
     const sum = $('rulesSummaryCount'); if (sum) sum.textContent = count;
     const defs = $('rulesDefs'); if (defs && version) defs.textContent = '· defs ' + version;
+    const defs2 = $('rulesDefs2'); if (defs2 && version) defs2.textContent = version;
 
     const list = $('rulesList');
     if (list && Array.isArray(patterns)) {
@@ -1366,6 +1514,52 @@ function escapeHtml(s) {
   }[c]));
 }
 
+function domainOf(u) {
+  try { return new URL(u).hostname.replace(/^www\./, ''); }
+  catch { return String(u || '').replace(/^https?:\/\//, '').replace(/^www\./, '').split('/')[0]; }
+}
+
+// ── Monitor form (§04) — POST /api/watch, render the API's honest response ───
+const watchForm = $('watchForm');
+if (watchForm) watchForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const btn = $('watchGo'), msg = $('watchMsg');
+  const domain = $('watchDomain').value.trim();
+  const email = $('watchEmail').value.trim();
+  if (!domain || !email) return;
+
+  btn.disabled = true; btn.textContent = 'Setting up…';
+  msg.className = 'watch-msg show'; msg.textContent = 'Registering monitor…';
+  try {
+    const r = await fetch('/api/watch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        domain, email,
+        system: $('watchSystem').checked,
+        list: $('watchList').checked
+      })
+    });
+    const data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.message || data.error || ('HTTP ' + r.status));
+
+    const dom = data.domain || domain;
+    const bits = [];
+    bits.push(`<b>${escapeHtml(dom)}</b> is registered.`);
+    if (data.note) bits.push(escapeHtml(data.note));
+    if (data.verificationSent) bits.push('Check your inbox to confirm and switch alerts on.');
+    bits.push(`Client report: <a href="/report/${encodeURIComponent(dom)}">/report/${escapeHtml(dom)}</a>` +
+      (data.directoryUrl ? ` &middot; <a href="${escapeHtml(data.directoryUrl)}">directory</a>` : ''));
+    msg.className = 'watch-msg show ok';
+    msg.innerHTML = bits.join(' ');
+  } catch (err) {
+    msg.className = 'watch-msg show err';
+    msg.textContent = '✗ ' + err.message;
+  } finally {
+    btn.disabled = false; btn.textContent = 'Monitor';
+  }
+});
+
 let lastResult = null;
 
 function render(d, totalMs) {
@@ -1409,6 +1603,9 @@ function render(d, totalMs) {
       ${d.verdict ? `<div class="score-verdict">${escapeHtml(d.verdict)}</div>` : ''}
       ${fixCta}
       ${sharePanel(d)}
+      <div class="monitor-nudge">keep it clean &rarr;
+        <a id="monitorNudgeLink">monitor ${escapeHtml(domainOf(d.finalUrl || d.url))}</a>
+        &middot; daily re-scan, drift alerts</div>
     </div>
     ${triggered.length ? `
       <div class="pat-section">
@@ -1429,6 +1626,16 @@ function render(d, totalMs) {
 
   const fixBtn = document.getElementById('fixPromptBtn');
   if (fixBtn) fixBtn.addEventListener('click', openFixPrompt);
+
+  // Post-scan conversion nudge: prefill the monitor form with this domain.
+  const nudge = document.getElementById('monitorNudgeLink');
+  if (nudge) nudge.addEventListener('click', () => {
+    const wd = $('watchDomain');
+    if (wd) wd.value = domainOf(d.finalUrl || d.url);
+    document.getElementById('monitor').scrollIntoView({ behavior: 'smooth' });
+    const we = $('watchEmail');
+    if (we) setTimeout(() => we.focus({ preventScroll: true }), 450);
+  });
 
   wireSharePanel(d);
 

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -1514,11 +1514,6 @@ function escapeHtml(s) {
   }[c]));
 }
 
-function domainOf(u) {
-  try { return new URL(u).hostname.replace(/^www\./, ''); }
-  catch { return String(u || '').replace(/^https?:\/\//, '').replace(/^www\./, '').split('/')[0]; }
-}
-
 // ── Monitor form (§04) — POST /api/watch, render the API's honest response ───
 const watchForm = $('watchForm');
 if (watchForm) watchForm.addEventListener('submit', async (e) => {
@@ -1536,8 +1531,12 @@ if (watchForm) watchForm.addEventListener('submit', async (e) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         domain, email,
-        system: $('watchSystem').checked,
-        list: $('watchList').checked
+        // Additive opt-ins: only SEND a flag when the box is checked, so an
+        // unchecked box means "leave it as-is" (the watch API preserves omitted
+        // flags) rather than an explicit `false` that would delist / disable on
+        // a resubmit. Turning a feature off is the unsubscribe path, not this form.
+        ...($('watchSystem').checked ? { system: true } : {}),
+        ...($('watchList').checked ? { list: true } : {})
       })
     });
     const data = await r.json();

--- a/packages/web/test/landing.test.js
+++ b/packages/web/test/landing.test.js
@@ -40,6 +40,19 @@ test('the section is honest: double opt-in, privacy, free engine', () => {
   assert.match(html, /MIT/, 'free-engine promise stated');
 });
 
+test('monitor opt-ins are additive — an unchecked box never delists on resubmit', () => {
+  // Regression (Bugbot #12): sending list:false/system:false on every submit
+  // would delist a domain the owner had listed. Flags must only be SENT when checked.
+  assert.ok(!/list:\s*\$\('watchList'\)\.checked/.test(html), 'list must not be sent unconditionally');
+  assert.ok(!/system:\s*\$\('watchSystem'\)\.checked/.test(html), 'system must not be sent unconditionally');
+  assert.match(html, /watchList'\)\.checked \? \{ list: true \}/, 'list opt-in only when checked');
+  assert.match(html, /watchSystem'\)\.checked \? \{ system: true \}/, 'system opt-in only when checked');
+});
+
+test('exactly one domainOf helper (no shadowed duplicate)', () => {
+  assert.equal((html.match(/function domainOf/g) || []).length, 1);
+});
+
 // ── navigation to the product surfaces ───────────────────────────────────────
 test('nav/footer link the directory, leaderboard, monitor, and privacy', () => {
   assert.match(html, /href="\/directory"/);

--- a/packages/web/test/landing.test.js
+++ b/packages/web/test/landing.test.js
@@ -1,0 +1,102 @@
+// Landing page (public/index.html) + brand-unification regression tests.
+// The deep review found the page frozen at v0.5.1 with no conversion path —
+// these assertions stop that class of drift from recurring.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { onRequestGet as directoryGet } from '../functions/directory.js';
+import { onRequestGet as leaderboardGet } from '../functions/leaderboard.js';
+import { onRequestGet as reportGet } from '../functions/report/[domain].js';
+
+const html = readFileSync(new URL('../public/index.html', import.meta.url), 'utf8');
+
+// ── staleness guards ─────────────────────────────────────────────────────────
+test('landing page carries no stale version or definitions strings', () => {
+  assert.ok(!html.includes('0.5.1'), 'JSON-LD softwareVersion must track releases');
+  assert.ok(!html.includes('2026.08'), 'defs label must not lag DEFINITIONS_VERSION');
+});
+
+test('landing page mentions the full current tool surface', () => {
+  assert.ok(html.includes('check_design_system'), 'MCP tool list must include the system-axis tool');
+  assert.match(html, /DESIGN\.md/, 'the system axis must be presented');
+});
+
+// ── conversion bridge (§04) ──────────────────────────────────────────────────
+test('the monitoring conversion section exists and posts to /api/watch', () => {
+  assert.match(html, /id="monitor"/, 'the #monitor section anchor');
+  assert.match(html, /id="watchForm"/);
+  assert.match(html, /id="watchDomain"/);
+  assert.match(html, /id="watchEmail"/);
+  assert.match(html, /id="watchSystem"/, 'system-axis opt-in checkbox');
+  assert.match(html, /id="watchList"/, 'directory opt-in checkbox');
+  assert.match(html, /\/api\/watch/, 'form submits to the watch API');
+  assert.match(html, /monitorNudgeLink/, 'post-scan nudge into the funnel');
+});
+
+test('the section is honest: double opt-in, privacy, free engine', () => {
+  assert.match(html, /[Dd]ouble opt-in/);
+  assert.match(html, /href="\/privacy\.md"/, 'privacy policy linked');
+  assert.match(html, /MIT/, 'free-engine promise stated');
+});
+
+// ── navigation to the product surfaces ───────────────────────────────────────
+test('nav/footer link the directory, leaderboard, monitor, and privacy', () => {
+  assert.match(html, /href="\/directory"/);
+  assert.match(html, /href="\/leaderboard"/);
+  assert.match(html, /href="#monitor"/);
+  assert.match(html, /href="\/privacy\.md"/);
+});
+
+// ── anti-slop: fonts stay system-distinct ────────────────────────────────────
+test('the Google Fonts request loads only the brand faces (no Inter/Geist)', () => {
+  const fontsUrl = (html.match(/https:\/\/fonts\.googleapis\.com\/css2[^"]+/) || [''])[0];
+  assert.ok(fontsUrl.includes('Hanken+Grotesk'), 'brand prose face present');
+  assert.ok(fontsUrl.includes('Martian+Mono'), 'brand mono face present');
+  assert.ok(!/Inter|Geist|Space\+Grotesk/.test(fontsUrl), 'no slop faces requested');
+});
+
+// ── brand unification: sub-pages share the landing identity ─────────────────
+function makeKv(seed = {}) {
+  const store = new Map(Object.entries(seed).map(([k, v]) => [k, typeof v === 'string' ? { value: v } : v]));
+  return {
+    async get(k) { return store.has(k) ? store.get(k).value : null; },
+    async put(k, v, o = {}) { store.set(k, { value: v, metadata: o.metadata }); },
+    async delete(k) { store.delete(k); },
+    async list({ prefix = '', limit = 1000 } = {}) {
+      const keys = [...store.keys()].filter(n => n.startsWith(prefix)).slice(0, limit)
+        .map(n => ({ name: n, metadata: store.get(n).metadata }));
+      return { keys, list_complete: true };
+    }
+  };
+}
+
+const BRAND_MARKS = [/Hanken\+Grotesk/, /Martian\+Mono/, /--accent:#5b9dff/, /class="eyebrow"/];
+
+test('/directory wears the landing brand (fonts, accent, registration mark)', async () => {
+  const res = await directoryGet({ request: { url: 'https://slop-detect.com/directory' }, env: { RESULTS: makeKv() } });
+  const out = await res.text();
+  for (const re of BRAND_MARKS) assert.match(out, re);
+});
+
+test('/leaderboard wears the landing brand', async () => {
+  const orig = globalThis.fetch;
+  globalThis.fetch = async () => new Response('nope', { status: 404 });
+  try {
+    const res = await leaderboardGet({ request: { url: 'https://slop-detect.com/leaderboard' } });
+    const out = await res.text();
+    for (const re of BRAND_MARKS) assert.match(out, re);
+    assert.match(out, /#monitor/, 'leaderboard CTA routes into the monitoring funnel');
+  } finally { globalThis.fetch = orig; }
+});
+
+test('/report wears the landing brand and keeps its print stylesheet', async () => {
+  const res = await reportGet({
+    params: { domain: 'example.com' },
+    request: { url: 'https://slop-detect.com/report/example.com' },
+    env: { RESULTS: makeKv() }
+  });
+  const out = await res.text();
+  for (const re of BRAND_MARKS) assert.match(out, re);
+  assert.match(out, /@media print/);
+});


### PR DESCRIPTION
Implements the full landing-page/UI review. The finding: the page was a beautiful acquisition hook **frozen at v0.5.1** — stale structured data, zero mention of the actual product (monitoring / system axis / directory / leaderboard / reports), no conversion path, and three sub-pages wearing a different design language.

## 🔴 Staleness (correctness bugs)
- JSON-LD `softwareVersion` 0.5.1 → **0.6.0**; `featureList` + both MCP tool lists gain the **system axis / `check_design_system`**; new monitoring FAQ entry.
- The §01 defs label had **silently drifted** (hardcoded `2026.08`) — now live-updated from `/api/patterns` like the other labels, so this class of bug can't recur.
- "across 4 axes" made true: **AEO** and **system** axis cards added to the fingerprint grid.
- Leaderboard CTA bug: "monitoring" linked to `privacy.md` — now routes to the real `/#monitor` section.

## 🔴 The conversion bridge (the missing funnel)
New **§04 "keep it clean"** section — *"A score is a snapshot. Drift is the disease."* — with a working monitor form (domain + email + **DESIGN.md drift** and **directory** opt-ins) that POSTs to `/api/watch` and renders the API's honest response (`note`, `verificationSent`, the `/report/<domain>` link). Honest fine print: double opt-in, privacy link, one-request deletion, MIT-forever engine.

Plus a **post-scan nudge** in every result card (`keep it clean → monitor <domain>`) that prefills the form — the scan-to-monitor funnel finally exists on the page itself. Topbar/footer now link Monitoring, Leaderboard, Directory, and **Privacy**; the odd `engagemii.com/aeo` hero example is now `linear.app`.

## 🟡 Brand unification
New `functions/_brand.js` — one source of truth for the forensic-instrument identity (Hanken Grotesk / Martian Mono, cold-blue accent, blue-tinted neutrals, §-registration marks). `/directory`, `/leaderboard`, and `/report/:domain` now wear the landing brand instead of generic system-font styling; the report keeps its `@media print` stylesheet.

## Tests
**+9 regression tests** (`landing.test.js`): staleness guards (no `0.5.1`/`2026.08` ever again), conversion-section presence + honesty assertions, nav links, fonts-stay-clean (no Inter/Geist in the Google Fonts request), and brand marks asserted on all three sub-pages. **156 total: 149 pass, 0 fail**, 7 browser-gated golden skips. All pre-existing sub-page contract tests (dofollow, JSON-LD, email-never-leaks, print, anti-slop) still green. Lint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly static HTML/CSS and marketing copy; monitor form calls an existing API with careful additive opt-ins, backed by new regression tests.
> 
> **Overview**
> Adds **`functions/_brand.js`** as shared fonts, CSS variables, and §-registration eyebrow styling, then wires **`directory`**, **`leaderboard`**, and **`report/:domain`** to import it—replacing inline system-font palettes with Hanken Grotesk / Martian Mono and matching the landing look (report keeps print CSS).
> 
> On **`index.html`**, JSON-LD and copy move to **0.6.0**, add **system axis**, **monitoring** FAQ, and **AEO/system** fingerprint cards; §01 defs labels sync from **`/api/patterns`**. New **§04 monitor** section posts domain + email to **`POST /api/watch`** with **additive** `system` / `list` flags only when checkboxes are checked; scan results get a **monitor nudge** that prefills the form. Nav/footer add Monitoring, Leaderboard, Directory, Privacy; leaderboard CTA fixes **`/#monitor`** (was privacy).
> 
> **`landing.test.js`** adds regression tests for staleness, conversion funnel, opt-in semantics, nav, fonts, and brand marks on sub-pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27e8b37020c4a0495586d69fd8fc282bafc74fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->