### PR TITLE
docs: sync MCP tool surface across README + agent-discovery files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ curl -X POST https://slop-detect.com/api/scan \
   -H 'content-type: application/json' -d '{"url":"https://example.com"}'
 ```
 
-Or the MCP server (`npx -y slop-detect-mcp`): tools `scan_page`, `check_aeo`, `fix_prompt`.
+Or the MCP server (`npx -y slop-detect-mcp`): tools `scan_page`, `check_aeo`, `check_design_system`, `fix_prompt`.
 
 - Read the pattern count from `GET /api/patterns` — **never hardcode it.**
 - OpenAPI spec: https://slop-detect.com/openapi.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # slop-detect
 
-> **Score any landing page against the 27-rule AI-design-slop fingerprint.**
-> Detect Cursor / v0 / Lovable / Bolt templates in the wild — and get a copy-pasteable fix prompt to clean them up.
+> **Score any landing page against the 27-rule AI-design-slop fingerprint — then keep it clean.**
+> Detect Cursor / v0 / Lovable / Bolt templates in the wild, check a page against its own `DESIGN.md`, and get a copy-pasteable fix prompt. Monitor a domain and get emailed when it drifts.
 
 <p>
   <a href="https://github.com/ravidsrk/slop-detect/actions"><img alt="CI" src="https://github.com/ravidsrk/slop-detect/workflows/ci/badge.svg" /></a>
@@ -93,8 +93,9 @@ plus an `id` and `resultUrl` for the shareable permalink.
 
 [`slop-detect-mcp`](packages/mcp) is a Model Context Protocol server that lets
 Cursor / Claude Code / Windsurf agents scan a page **before** they ship it — and
-pull the fix prompt back into the editing loop. Two tools: `scan_page` and
-`fix_prompt`.
+pull the fix prompt back into the editing loop. Four tools: `scan_page`,
+`check_aeo` (can AI engines read & cite the page?), `check_design_system`
+(does the page honor its own `DESIGN.md`?), and `fix_prompt`.
 
 ```json
 {

--- a/packages/web/public/.well-known/agent-card.json
+++ b/packages/web/public/.well-known/agent-card.json
@@ -40,6 +40,15 @@
       "outputModes": ["application/json"]
     },
     {
+      "id": "check_design_system",
+      "name": "Check design-system compliance",
+      "description": "Check whether a page honors its own declared design system (a DESIGN.md file). Returns a 0-100 compliance score (higher is better) plus named drift: undeclared fonts, off-palette CTA colors, off-scale corner radii.",
+      "tags": ["design-system", "design.md", "brand", "drift", "compliance"],
+      "examples": ["Does https://example.com still match its DESIGN.md?"],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    },
+    {
       "id": "fix_prompt",
       "name": "Build a de-slop fix prompt",
       "description": "Generate a ready-to-paste prompt that tells a coding agent how to fix the slop patterns found on a page.",

--- a/packages/web/public/.well-known/agent.json
+++ b/packages/web/public/.well-known/agent.json
@@ -22,6 +22,12 @@
       "method": "POST"
     },
     {
+      "name": "check_design_system",
+      "description": "Check whether a page honors its own declared design system (DESIGN.md). Returns a 0-100 compliance score (higher is better) plus named drift.",
+      "endpoint": "https://slop-detect.com/api/scan",
+      "method": "POST"
+    },
+    {
       "name": "list_patterns",
       "description": "Read the live pattern catalogue (id, label, category, weight).",
       "endpoint": "https://slop-detect.com/api/patterns",

--- a/packages/web/public/.well-known/mcp/server-card.json
+++ b/packages/web/public/.well-known/mcp/server-card.json
@@ -27,6 +27,10 @@
       "description": "Score whether AI engines (ChatGPT/Claude/Perplexity) can fetch, read and cite a page. Higher is better."
     },
     {
+      "name": "check_design_system",
+      "description": "Check whether a page honors its own declared design system (a DESIGN.md file). Returns a 0-100 compliance score (higher is better) plus named drift: undeclared fonts, off-palette CTA colors, off-scale radii."
+    },
+    {
       "name": "fix_prompt",
       "description": "Build a ready-to-paste prompt instructing a coding agent how to de-slop a page from a scan result or URL."
     }

--- a/packages/web/public/index.md
+++ b/packages/web/public/index.md
@@ -49,8 +49,9 @@ score polarity is inverted relative to the slop score: higher AEO is better.
 - Web: paste a URL at https://slop-detect.com
 - CLI: `npx slop-detect <url>` — gate CI with `--fail-on heavy`, add `--aeo` for
   the AEO axis.
-- MCP: the `slop-detect-mcp` server exposes `scan_page`, `check_aeo` and
-  `fix_prompt` tools to any MCP client (Claude Code, Cursor, Windsurf).
+- MCP: the `slop-detect-mcp` server exposes `scan_page`, `check_aeo`,
+  `check_design_system` and `fix_prompt` tools to any MCP client (Claude Code,
+  Cursor, Windsurf).
 
 ## Links
 

--- a/packages/web/test/landing.test.js
+++ b/packages/web/test/landing.test.js
@@ -53,6 +53,21 @@ test('exactly one domainOf helper (no shadowed duplicate)', () => {
   assert.equal((html.match(/function domainOf/g) || []).length, 1);
 });
 
+// ── agent-discovery files list the full tool surface ─────────────────────────
+test('every agent-discovery surface advertises check_design_system', () => {
+  const files = [
+    '../public/.well-known/agent-card.json',
+    '../public/.well-known/agent.json',
+    '../public/.well-known/mcp/server-card.json',
+    '../public/index.md'
+  ];
+  for (const f of files) {
+    const txt = readFileSync(new URL(f, import.meta.url), 'utf8');
+    assert.ok(txt.includes('scan_page') && txt.includes('check_aeo'), `${f}: base tools present`);
+    assert.ok(txt.includes('check_design_system'), `${f}: must list the system-axis tool`);
+  }
+});
+
 // ── navigation to the product surfaces ───────────────────────────────────────
 test('nav/footer link the directory, leaderboard, monitor, and privacy', () => {
   assert.match(html, /href="\/directory"/);


### PR DESCRIPTION
Continuation of the landing-page review: the **same staleness class** existed across every doc and agent-discovery surface — they advertised only 2–3 MCP tools, all missing `check_design_system` (the system axis shipped in #10/#11).

- **README** — "Two tools" → four (`scan_page`, `check_aeo`, `check_design_system`, `fix_prompt`); tagline now reflects DESIGN.md + monitoring, not just slop detection.
- **`.well-known/agent-card.json`, `agent.json`, `mcp/server-card.json`** — add the `check_design_system` capability. These drive AEO/agent discovery, which is the project's own pitch, so leaving them stale is self-undermining.
- **`index.md`** (markdown twin) + **`AGENTS.md`** — same.
- **+1 test** asserts all four discovery surfaces advertise `scan_page` + `check_aeo` + `check_design_system`, so a future tool can't silently go unlisted again.

Docs/JSON only (all `.well-known` JSON validated). **159 tests, 152 pass, 0 fail**, 7 browser-gated golden skips. Lint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static JSON only; no scoring, API, or MCP runtime behavior changes.
> 
> **Overview**
> Docs and agent-discovery surfaces were **out of date** relative to the shipped MCP server: they listed only two or three tools and omitted **`check_design_system`**.
> 
> **README** and **AGENTS.md** now describe **four** MCP tools (`scan_page`, `check_aeo`, `check_design_system`, `fix_prompt`). The README tagline also mentions **DESIGN.md** compliance and **domain monitoring**, not only the slop fingerprint.
> 
> **Agent-discovery JSON** (`.well-known/agent-card.json`, `agent.json`, `mcp/server-card.json`) and **`index.md`** each add a **`check_design_system`** capability with descriptions aligned to the system axis (DESIGN.md drift: fonts, palette, radii).
> 
> A new **`landing.test.js`** test asserts all four discovery files still advertise `scan_page`, `check_aeo`, and **`check_design_system`**, so a future tool cannot disappear from listings silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d860b14780a6863671f91fc59272368aa078ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->