### PR TITLE
Agency dashboard with magic-link sign-in (Roadmap v2 P2b)

### DIFF
--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -74,6 +74,7 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
 | Pages env | `CRON_SECRET` | auth for `/api/cron/sweep` |
 | Pages env | `INTERNAL_API_KEY` | unlimited-tier key for sweep re-scans |
 | Pages env | `SWEEP_MAX` | domains re-scanned per sweep (default 50) |
+| Pages env | `SESSION_SECRET` | HMAC secret for dashboard magic-link sessions |
 | Repo secret | `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` | deploy |
 | Repo secret | `CRON_SECRET` | the `monitor-sweep` workflow auth (matches Pages) |
 | Repo setting | branch protection → require `test` + `lint` | merge gate |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Add `"system": true` and the daily sweep also checks the domain against its own
 `DESIGN.md`, emailing you when the page **drifts off its declared design
 system** — the check that catches what an agent or a non-designer quietly broke.
 Every monitored domain gets a print-friendly client report at
-`slop-detect.com/report/<domain>`.
+`slop-detect.com/report/<domain>`, and the [dashboard](https://slop-detect.com/dashboard)
+(magic-link sign-in, no password) shows every domain on your email in one view.
 
 `list: true` also opts the domain into the public, crawlable
 [**directory**](https://slop-detect.com/directory) of scored sites — an

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,7 +141,7 @@ DESIGN.md. Workflow lock-in is the only durable distribution.
 | P1 `system` axis (core + CLI + API) | ✅ Shipped |
 | P2a Drift alerts on `system` axis via existing sweep | ✅ Shipped (`watch { system:true }` → sweep checks DESIGN.md → drift email, once per event) |
 | P2b-lite Print-friendly client report (`/report/:domain`) | ✅ Shipped (the PDF-infra substitute) |
-| P2b Agency multi-site dashboard | Next quarter |
+| P2b Agency multi-site dashboard | ✅ Shipped (lite): magic-link sign-in → /dashboard, one view across every domain on an email. Team seats/roles later |
 | P2c Pricing live ($29–$149/mo) | With P2b (needs Stripe keys — operator task) |
 | P3 Community ruleset + calibration corpus growth | Ongoing |
 | P4 MCP design-system mode (`check_design_system` tool) | ✅ Shipped |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "web:deploy": "npm run --workspace slop-detect-web deploy",
     "calibrate": "node packages/cli/calibration/run.mjs",
     "test": "node --test packages/core/test/*.test.js packages/web/test/*.test.js packages/cli/test/*.test.js packages/mcp/test/*.test.js",
-    "lint": "node --check packages/core/src/*.js packages/cli/src/*.js packages/cli/bin/*.js packages/mcp/src/*.js packages/mcp/bin/*.js packages/web/functions/api/*.js packages/web/functions/api/cron/*.js packages/web/functions/api/watch/*.js packages/web/functions/*.js"
+    "lint": "node --check packages/core/src/*.js packages/cli/src/*.js packages/cli/bin/*.js packages/mcp/src/*.js packages/mcp/bin/*.js packages/web/functions/api/*.js packages/web/functions/api/cron/*.js packages/web/functions/api/watch/*.js packages/web/functions/api/dashboard/*.js packages/web/functions/*.js"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/web/API.md
+++ b/packages/web/API.md
@@ -273,6 +273,23 @@ Server-rendered, crawlable HTML page listing every opt-in site (grade · score �
 tier · dofollow link out · link to its scan). `?sort=slop` ranks sloppiest-first
 (default: cleanest-first). Emits `ItemList` JSON-LD and is in the sitemap. Public.
 
+### `POST /api/dashboard/link`
+
+Request a **magic sign-in link** for the agency dashboard. Body
+`{ "email": "you@company.com" }`. The response is identical whether or not the
+address monitors anything (anti-enumeration); a single-use, 15-minute link is
+only actually emailed when it does. `503 dashboard_unavailable` until the email
+provider **and** `SESSION_SECRET` are configured (safe-off, like alerts).
+
+### `GET /dashboard`
+
+One view across every domain monitored by the signed-in email: slop grade,
+design-system tier, drift/regression flags, verification state, and a link to
+each domain's client report. Auth = the magic link (`?token=` exchanges the
+single-use token for a 30-day HMAC-signed HttpOnly cookie; `?logout=1` clears
+it). Shows only the owner's own domains and email — never anyone else's.
+`noindex`.
+
 ### `GET /report/:domain`
 
 A **print-friendly client report** for a domain (the agency deliverable): latest

--- a/packages/web/functions/_alerts.js
+++ b/packages/web/functions/_alerts.js
@@ -77,3 +77,19 @@ export function buildDriftAlert(domain, baseline, current, driftItems = [], opts
   );
   return { subject, text: lines.join('\n') };
 }
+
+// Dashboard magic-link login email (P2b). Single-use, 15-minute link; ignoring
+// it is always safe.
+export function buildDashboardLinkEmail(loginUrl, domainCount) {
+  const subject = 'Your slop-detect dashboard link';
+  const text = [
+    `Sign in to your slop-detect dashboard (${domainCount} monitored domain${domainCount === 1 ? '' : 's'}):`,
+    '',
+    loginUrl,
+    '',
+    'The link is single-use and expires in 15 minutes. If you did not request',
+    'it, ignore this email — nothing happens without the click.',
+    'Privacy: https://slop-detect.com/privacy.md'
+  ].join('\n');
+  return { subject, text };
+}

--- a/packages/web/functions/_session.js
+++ b/packages/web/functions/_session.js
@@ -1,0 +1,85 @@
+// Magic-link sessions for the agency dashboard (Roadmap v2 P2b).
+//
+// Indie-lean auth: no passwords, no accounts table. A watch already carries the
+// owner's email; the dashboard is simply "every watch belonging to this email."
+// Login = click a single-use emailed link → we set an HMAC-signed, HttpOnly
+// cookie. The only server-side state is the short-lived link token (KV); the
+// session itself is stateless (signed payload), so there is nothing to clean up.
+//
+// Web Crypto only (crypto.subtle) — identical behavior in Cloudflare Workers
+// and Node ≥20 tests. Requires env.SESSION_SECRET; absent ⇒ the dashboard is
+// configured-off (same safe-off pattern as email alerts).
+
+const COOKIE_NAME = 'sd_session';
+const DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+const enc = new TextEncoder();
+
+async function hmacHex(data, secret) {
+  const key = await crypto.subtle.importKey(
+    'raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(data));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Constant-time-ish compare (same pattern as the cron sweep's secret check).
+function safeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function b64urlEncode(s) {
+  return btoa(unescape(encodeURIComponent(s)))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+function b64urlDecode(s) {
+  const pad = s.length % 4 === 2 ? '==' : s.length % 4 === 3 ? '=' : '';
+  return decodeURIComponent(escape(atob(s.replace(/-/g, '+').replace(/_/g, '/') + pad)));
+}
+
+// email → "payload.signature". Payload carries the email + absolute expiry.
+export async function signSession(email, secret, { ttlMs = DEFAULT_TTL_MS, now = Date.now() } = {}) {
+  if (!email || !secret) return null;
+  const payload = b64urlEncode(JSON.stringify({ e: email, x: now + ttlMs }));
+  const sig = await hmacHex(payload, secret);
+  return `${payload}.${sig}`;
+}
+
+// "payload.signature" → email, or null (bad shape / bad signature / expired).
+export async function verifySession(token, secret, { now = Date.now() } = {}) {
+  if (!token || !secret) return null;
+  const dot = token.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const payload = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  const expected = await hmacHex(payload, secret);
+  if (!safeEqual(sig, expected)) return null;
+  try {
+    const { e, x } = JSON.parse(b64urlDecode(payload));
+    if (typeof e !== 'string' || typeof x !== 'number' || now >= x) return null;
+    return e;
+  } catch { return null; }
+}
+
+// ── Cookie plumbing ──────────────────────────────────────────────────────────
+export function sessionCookie(token, { maxAgeSec = DEFAULT_TTL_MS / 1000 } = {}) {
+  return `${COOKIE_NAME}=${token}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${Math.floor(maxAgeSec)}`;
+}
+export function clearSessionCookie() {
+  return `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
+}
+export function readSessionToken(request) {
+  const header = request.headers && typeof request.headers.get === 'function'
+    ? (request.headers.get('Cookie') || '') : '';
+  const m = header.match(new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]+)`));
+  return m ? m[1] : null;
+}
+
+// Convenience: request → logged-in email (or null).
+export async function sessionEmail(request, secret) {
+  const token = readSessionToken(request);
+  return token ? verifySession(token, secret) : null;
+}

--- a/packages/web/functions/_shared.js
+++ b/packages/web/functions/_shared.js
@@ -269,6 +269,36 @@ export async function consumeWatchToken(kv, token) {
   return domain;
 }
 
+// ── Dashboard magic-link tokens (P2b) ────────────────────────────────────────
+// dt:<token> → email. Single-use and short-lived: the link only has to survive
+// the walk from inbox to browser; the durable credential is the signed session
+// cookie it mints (see _session.js).
+const DASHBOARD_TOKEN_TTL = 60 * 15; // 15 minutes
+
+export async function issueDashboardToken(kv, email) {
+  if (!kv || !email) return null;
+  const token = newId(32);
+  await kv.put(`dt:${token}`, email, { expirationTtl: DASHBOARD_TOKEN_TTL });
+  return token;
+}
+
+export async function consumeDashboardToken(kv, token) {
+  if (!kv || !token) return null;
+  const email = await kv.get(`dt:${token}`);
+  if (!email) return null;
+  await kv.delete(`dt:${token}`);
+  return email;
+}
+
+// All watches owned by one email — the agency dashboard's data. Case-normalized
+// the same way the watch API stores emails (trimmed, lowercased).
+export async function listWatchesByEmail(kv, email) {
+  if (!kv || !email) return [];
+  const want = String(email).trim().toLowerCase();
+  const all = await listWatches(kv, { limit: 1000 });
+  return all.filter((w) => w && w.email === want);
+}
+
 // Enumerate watches for the monitoring sweep. Returns parsed watch records.
 // `limit` caps work per sweep invocation (KV list is paginated; we keep it
 // simple and bounded — grow into cursor paging if the watch set gets large).

--- a/packages/web/functions/api/dashboard/link.js
+++ b/packages/web/functions/api/dashboard/link.js
@@ -1,0 +1,52 @@
+// POST /api/dashboard/link { email } — request a magic sign-in link for the
+// agency dashboard (Roadmap v2 P2b).
+//
+// Anti-enumeration: the response is IDENTICAL whether or not the email owns any
+// watches — a link is only actually sent when it does. Goes through the shared
+// middleware (cheap rate limit, CORS, foreign-origin rejection; no Turnstile).
+// Configured-off without an email provider + SESSION_SECRET, like alerts.
+
+import { isValidEmail, listWatchesByEmail, issueDashboardToken } from '../../_shared.js';
+import { emailConfigured, sendEmail } from '../../_email.js';
+import { buildDashboardLinkEmail } from '../../_alerts.js';
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+  });
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.RESULTS) return json({ error: 'dashboard_unavailable', message: 'Storage is offline.' }, 503);
+  if (!emailConfigured(env) || !env.SESSION_SECRET) {
+    return json({
+      error: 'dashboard_unavailable',
+      message: 'Dashboard sign-in requires the email provider and SESSION_SECRET to be configured.'
+    }, 503);
+  }
+
+  let body;
+  try { body = await request.json(); } catch { return json({ error: 'Invalid JSON body' }, 400); }
+  if (!isValidEmail(body?.email)) return json({ error: 'a valid `email` is required' }, 400);
+  const email = String(body.email).trim().toLowerCase();
+
+  // The one fixed response — composed before we know anything, returned in every
+  // non-error path, so timing/shape can't reveal whether an account exists.
+  const genericOk = {
+    ok: true,
+    message: 'If that address monitors any domains, a sign-in link is on its way. It expires in 15 minutes.'
+  };
+
+  try {
+    const watches = await listWatchesByEmail(env.RESULTS, email);
+    if (watches.length) {
+      const token = await issueDashboardToken(env.RESULTS, email);
+      const loginUrl = `${new URL(request.url).origin}/dashboard?token=${token}`;
+      const msg = buildDashboardLinkEmail(loginUrl, watches.length);
+      await sendEmail(env, { to: email, subject: msg.subject, text: msg.text });
+    }
+  } catch (_) { /* best-effort: still return the generic response */ }
+
+  return json(genericOk);
+}

--- a/packages/web/functions/dashboard.js
+++ b/packages/web/functions/dashboard.js
@@ -1,0 +1,198 @@
+// GET /dashboard — the agency multi-domain view (Roadmap v2 P2b).
+//
+// One email, many client domains: every watch owned by the signed-in address,
+// with slop grade, design-system tier, drift status, and a per-domain client
+// report link. Auth is the magic-link flow: /api/dashboard/link emails a
+// single-use token; landing here with ?token= exchanges it for an HMAC-signed
+// HttpOnly cookie (_session.js). No cookie → a login form. ?logout=1 → cookie
+// cleared. Configured-off without SESSION_SECRET.
+//
+// Privacy: the page shows only the signed-in owner's own email and domains —
+// never anyone else's. noindex.
+
+import { listWatchesByEmail, consumeDashboardToken, tierColors, escapeHtml } from './_shared.js';
+import { signSession, sessionEmail, sessionCookie, clearSessionCookie } from './_session.js';
+import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
+
+function sysColors(tier) {
+  if (tier === 'Aligned') return '#4ade80';
+  if (tier === 'Drifting') return '#fbbf24';
+  if (tier === 'Off-system') return '#f87171';
+  return '#6f7689';
+}
+
+function page(origin, title, inner, extraHeaders = {}) {
+  const html = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)} · slop-detect</title>
+<meta name="robots" content="noindex">${BRAND_FONTS_HEAD}
+<style>${BRAND_CSS}
+  body{padding:48px 20px 80px}
+  .wrap{max-width:860px;margin:0 auto}
+  h1{font-size:28px;font-weight:700;letter-spacing:-0.02em;margin:2px 0 6px}
+  .sub{color:var(--muted);font-size:15px;max-width:62ch;margin-bottom:22px}
+  .bar{display:flex;justify-content:space-between;align-items:center;gap:10px;
+       font-family:var(--mono);font-size:12px;color:var(--dim);margin-bottom:10px}
+  .bar a{color:var(--muted);text-decoration:none;border-bottom:1px solid var(--border-2)}
+  .bar a:hover{color:var(--text)}
+  table{border-collapse:collapse;width:100%}
+  th,td{text-align:left;padding:11px 14px 11px 0;border-bottom:1px solid var(--bg-2);font-size:14px}
+  th{color:var(--dim);font-weight:500;font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+  td.mono{font-family:var(--mono);font-size:13px}
+  .dom{font-weight:600;text-decoration:none;border-bottom:1px solid var(--border-2);padding-bottom:1px}
+  .dom:hover{border-color:var(--text)}
+  .g{font-family:var(--mono);font-weight:700;font-size:13px;border:1px solid;border-radius:5px;padding:1px 8px}
+  .pill{font-family:var(--mono);font-size:11.5px;border:1px solid;border-radius:999px;padding:2px 10px;white-space:nowrap}
+  .flag{font-family:var(--mono);font-size:11px;color:var(--dim)}
+  .flag.bad{color:var(--red)}
+  .rep{font-family:var(--mono);font-size:11.5px;color:var(--dim);text-decoration:none;white-space:nowrap}
+  .rep:hover{color:var(--text)}
+  .empty{padding:26px 0;color:var(--muted)}
+  .empty a{color:var(--text)}
+  .login{max-width:440px;background:var(--panel);border:1px solid var(--border-2);border-radius:12px;padding:18px;margin-top:8px}
+  .login:focus-within{border-color:var(--accent)}
+  .login .row{display:flex;gap:8px}
+  .login input{flex:1;background:var(--bg);border:1px solid var(--border);border-radius:8px;
+    color:var(--text);font-size:15px;padding:10px 12px;outline:none;font-family:var(--mono)}
+  .login input::placeholder{color:var(--dim)}
+  .login button{background:var(--accent);color:var(--accent-ink);border:0;border-radius:8px;
+    padding:10px 20px;font-size:15px;font-weight:600;cursor:pointer;font-family:inherit}
+  .login button:disabled{opacity:.5;cursor:wait}
+  .msg{display:none;margin-top:10px;padding:10px 12px;border-radius:8px;border:1px solid var(--border);
+    background:var(--bg);font-size:13.5px;color:var(--text-2);line-height:1.5}
+  .msg.show{display:block}
+  .msg.err{border-color:var(--red);color:var(--red)}
+  .fine{margin-top:14px;font-size:12.5px;color:var(--dim);line-height:1.55;max-width:60ch}
+  .fine a{color:var(--muted)}
+  footer{margin-top:34px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  footer a{color:var(--muted)}
+  @media(max-width:640px){.hide-sm{display:none}}
+</style></head><body><div class="wrap">
+  <div class="eyebrow"><span class="reg">&sect;dash</span><span class="reg-label">the dashboard</span></div>
+  ${inner}
+  <footer><a href="${origin}/">scan</a> &middot; <a href="${origin}/#monitor">add a domain</a> &middot;
+    <a href="${origin}/directory">directory</a> &middot; <a href="${origin}/privacy.md">privacy</a></footer>
+</div></body></html>`;
+  return new Response(html, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store', ...extraHeaders }
+  });
+}
+
+function loginView(origin, note) {
+  return `
+  <h1>Sign in to your dashboard</h1>
+  <p class="sub">One view across every domain you monitor: slop grade, design-system
+    drift, and client reports. We email you a single-use link — no password.</p>
+  ${note ? `<div class="msg show err" style="max-width:440px">${escapeHtml(note)}</div>` : ''}
+  <form class="login" id="loginForm">
+    <div class="row">
+      <input id="loginEmail" type="email" placeholder="you@company.com" autocomplete="email" required>
+      <button type="submit" id="loginGo">Email me a link</button>
+    </div>
+    <div class="msg" id="loginMsg"></div>
+  </form>
+  <p class="fine">Not monitoring anything yet? <a href="${origin}/#monitor">Start with one domain</a> —
+    it takes an email and a domain name.</p>
+  <script>
+  const f=document.getElementById('loginForm'),b=document.getElementById('loginGo'),m=document.getElementById('loginMsg');
+  f.addEventListener('submit',async(e)=>{e.preventDefault();
+    b.disabled=true;b.textContent='Sending…';m.className='msg show';m.textContent='Requesting link…';
+    try{
+      const r=await fetch('/api/dashboard/link',{method:'POST',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({email:document.getElementById('loginEmail').value.trim()})});
+      const d=await r.json();
+      if(!r.ok)throw new Error(d.message||d.error||('HTTP '+r.status));
+      m.className='msg show';m.textContent=d.message;
+    }catch(err){m.className='msg show err';m.textContent='✗ '+err.message;}
+    finally{b.disabled=false;b.textContent='Email me a link';}
+  });
+  </script>`;
+}
+
+function row(w, origin) {
+  const c = tierColors(w.lastTier);
+  const sc = sysColors(w.lastSystemTier);
+  const slop = w.lastScore == null
+    ? '<span class="flag">no scan yet</span>'
+    : `<span class="g" style="color:${c.fg};border-color:${c.fg}">${escapeHtml(w.lastGrade || '—')}</span>
+       <span class="mono" style="color:${c.fg}"> ${w.lastScore}/100</span>`;
+  const sys = w.lastSystemTier
+    ? `<span class="pill" style="color:${sc};border-color:${sc}">${escapeHtml(w.lastSystemTier)}</span>`
+    : `<span class="flag">${w.system ? 'awaiting sweep' : 'off'}</span>`;
+  const flags = [
+    w.regressed ? '<span class="flag bad">regressed</span>' : '',
+    w.systemRegressed ? '<span class="flag bad">drifted</span>' : '',
+    !w.verified ? '<span class="flag">unconfirmed</span>' : '',
+    w.listed ? '<span class="flag">listed</span>' : ''
+  ].filter(Boolean).join(' ');
+  const checked = w.lastCheckedAt ? String(w.lastCheckedAt).slice(0, 10) : '—';
+  return `<tr>
+    <td><a class="dom" href="https://${escapeHtml(w.domain)}">${escapeHtml(w.domain)}</a></td>
+    <td>${slop}</td>
+    <td>${sys}</td>
+    <td>${flags || '<span class="flag">ok</span>'}</td>
+    <td class="mono hide-sm">${escapeHtml(checked)}</td>
+    <td><a class="rep" href="${origin}/report/${encodeURIComponent(w.domain)}">report&nbsp;&rarr;</a></td>
+  </tr>`;
+}
+
+function dashboardView(origin, email, watches) {
+  const drifted = watches.filter((w) => w.regressed || w.systemRegressed).length;
+  const rows = watches.length
+    ? `<table>
+        <thead><tr><th>domain</th><th>slop</th><th>system</th><th>status</th><th class="hide-sm">last check</th><th></th></tr></thead>
+        <tbody>${watches.map((w) => row(w, origin)).join('')}</tbody>
+      </table>`
+    : `<p class="empty">No monitored domains on this address yet.
+        <a href="${origin}/#monitor">Add the first one</a>.</p>`;
+  return `
+  <h1>Your domains</h1>
+  <div class="bar">
+    <span>${escapeHtml(email)} &middot; ${watches.length} domain${watches.length === 1 ? '' : 's'}${drifted ? ` &middot; ${drifted} needing attention` : ''}</span>
+    <a href="${origin}/dashboard?logout=1">sign out</a>
+  </div>
+  ${rows}
+  <p class="fine">Daily sweeps re-scan each verified domain; drift and regression email
+    you once per event. Print any client report straight from its page.</p>`;
+}
+
+export async function onRequestGet({ request, env }) {
+  const url = new URL(request.url);
+  const origin = url.origin;
+
+  if (!env.SESSION_SECRET) {
+    return page(origin, 'Dashboard', `
+      <h1>Dashboard not configured</h1>
+      <p class="sub">Sign-in requires SESSION_SECRET (and the email provider) to be set —
+        see PRODUCTION.md. Monitoring itself works without it.</p>`);
+  }
+
+  // Sign out.
+  if (url.searchParams.get('logout') === '1') {
+    return page(origin, 'Signed out', loginView(origin, ''), { 'Set-Cookie': clearSessionCookie() });
+  }
+
+  // Magic-link exchange: burn the token, mint the session, land clean (the
+  // redirect strips the token from the URL/history).
+  const token = url.searchParams.get('token');
+  if (token) {
+    const email = env.RESULTS ? await consumeDashboardToken(env.RESULTS, token) : null;
+    if (!email) {
+      return page(origin, 'Link expired', loginView(origin,
+        'That sign-in link has expired or was already used. Request a fresh one.'));
+    }
+    const session = await signSession(email, env.SESSION_SECRET);
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${origin}/dashboard`, 'Set-Cookie': sessionCookie(session) }
+    });
+  }
+
+  // Cookie session.
+  const email = await sessionEmail(request, env.SESSION_SECRET);
+  if (!email) return page(origin, 'Sign in', loginView(origin, ''));
+
+  const watches = env.RESULTS ? await listWatchesByEmail(env.RESULTS, email) : [];
+  watches.sort((a, b) => String(a.domain).localeCompare(String(b.domain)));
+  return page(origin, 'Dashboard', dashboardView(origin, email, watches));
+}

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -1310,6 +1310,7 @@
           <a href="#how">How it works</a>
           <a href="#fingerprint">The fingerprint</a>
           <a href="#monitor">Monitor a domain</a>
+          <a href="/dashboard">Dashboard</a>
           <a href="/leaderboard">Leaderboard</a>
           <a href="/directory">Directory</a>
         </div>
@@ -1548,6 +1549,7 @@ if (watchForm) watchForm.addEventListener('submit', async (e) => {
     if (data.note) bits.push(escapeHtml(data.note));
     if (data.verificationSent) bits.push('Check your inbox to confirm and switch alerts on.');
     bits.push(`Client report: <a href="/report/${encodeURIComponent(dom)}">/report/${escapeHtml(dom)}</a>` +
+      ` &middot; <a href="/dashboard">all your domains</a>` +
       (data.directoryUrl ? ` &middot; <a href="${escapeHtml(data.directoryUrl)}">directory</a>` : ''));
     msg.className = 'watch-msg show ok';
     msg.innerHTML = bits.join(' ');

--- a/packages/web/test/dashboard.test.js
+++ b/packages/web/test/dashboard.test.js
@@ -1,0 +1,193 @@
+// Agency dashboard (P2b): HMAC sessions, magic-link tokens, the link endpoint's
+// anti-enumeration guarantee, and the /dashboard page's auth + isolation.
+
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  signSession, verifySession, sessionCookie, clearSessionCookie, readSessionToken
+} from '../functions/_session.js';
+import {
+  issueDashboardToken, consumeDashboardToken, listWatchesByEmail
+} from '../functions/_shared.js';
+import { buildDashboardLinkEmail } from '../functions/_alerts.js';
+import { onRequestPost as linkPost } from '../functions/api/dashboard/link.js';
+import { onRequestGet as dashGet } from '../functions/dashboard.js';
+
+const SECRET = 'test-secret-0123456789';
+
+function makeKv(seed = {}) {
+  const store = new Map(Object.entries(seed).map(([k, v]) => [k, typeof v === 'string' ? { value: v } : v]));
+  return {
+    store,
+    async get(k) { return store.has(k) ? store.get(k).value : null; },
+    async put(k, v, o = {}) { store.set(k, { value: v, metadata: o.metadata }); },
+    async delete(k) { store.delete(k); },
+    async list({ prefix = '', limit = 1000 } = {}) {
+      const keys = [...store.keys()].filter(n => n.startsWith(prefix)).slice(0, limit)
+        .map(n => ({ name: n, metadata: store.get(n).metadata }));
+      return { keys, list_complete: true };
+    }
+  };
+}
+
+const watch = (domain, email, over = {}) =>
+  JSON.stringify({ domain, email, verified: true, lastScore: 8, lastGrade: 'A-', lastTier: 'Clean', ...over });
+
+function getReq(url, cookie) {
+  return { url, headers: { get: (k) => (k.toLowerCase() === 'cookie' ? (cookie || null) : null) } };
+}
+function postReq(body) {
+  return { url: 'https://slop-detect.com/api/dashboard/link', json: async () => body };
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+// ── sessions ─────────────────────────────────────────────────────────────────
+test('session round-trips; tampering, expiry, and wrong secret all reject', async () => {
+  const tok = await signSession('a@x.io', SECRET);
+  assert.equal(await verifySession(tok, SECRET), 'a@x.io');
+
+  // Tampered signature.
+  assert.equal(await verifySession(tok.slice(0, -2) + 'ff', SECRET), null);
+  // Tampered payload (forge a different email, keep the old signature).
+  const [, sig] = [tok.slice(0, tok.lastIndexOf('.')), tok.slice(tok.lastIndexOf('.') + 1)];
+  const forged = btoa(JSON.stringify({ e: 'evil@x.io', x: Date.now() + 9e9 })).replace(/=+$/, '') + '.' + sig;
+  assert.equal(await verifySession(forged, SECRET), null);
+  // Expired.
+  const old = await signSession('a@x.io', SECRET, { ttlMs: 1000, now: Date.now() - 5000 });
+  assert.equal(await verifySession(old, SECRET), null);
+  // Wrong secret.
+  assert.equal(await verifySession(tok, 'other-secret'), null);
+});
+
+test('session cookie is HttpOnly+Secure and readable back off the request', async () => {
+  const tok = await signSession('a@x.io', SECRET);
+  const cookie = sessionCookie(tok);
+  assert.match(cookie, /HttpOnly/);
+  assert.match(cookie, /Secure/);
+  assert.match(cookie, /SameSite=Lax/);
+  assert.equal(readSessionToken(getReq('https://x/', cookie.split(';')[0])), tok);
+  assert.match(clearSessionCookie(), /Max-Age=0/);
+});
+
+// ── tokens + per-email listing ───────────────────────────────────────────────
+test('dashboard tokens are single-use', async () => {
+  const kv = makeKv();
+  const t = await issueDashboardToken(kv, 'a@x.io');
+  assert.equal(await consumeDashboardToken(kv, t), 'a@x.io');
+  assert.equal(await consumeDashboardToken(kv, t), null);
+});
+
+test('listWatchesByEmail returns only that owner, case-normalized', async () => {
+  const kv = makeKv({
+    'w:a.com': watch('a.com', 'agency@x.io'),
+    'w:b.com': watch('b.com', 'agency@x.io'),
+    'w:c.com': watch('c.com', 'other@y.io')
+  });
+  const mine = await listWatchesByEmail(kv, '  Agency@X.io ');
+  assert.deepEqual(mine.map(w => w.domain).sort(), ['a.com', 'b.com']);
+});
+
+// ── /api/dashboard/link ──────────────────────────────────────────────────────
+const LIVE_ENV = { RESEND_API_KEY: 'k', ALERT_FROM: 'a@slop-detect.com', SESSION_SECRET: SECRET };
+
+test('link endpoint is configured-off without provider/secret', async () => {
+  const res = await linkPost({ request: postReq({ email: 'a@x.io' }), env: { RESULTS: makeKv() } });
+  assert.equal(res.status, 503);
+});
+
+test('link endpoint never reveals whether an email has watches (anti-enumeration)', async () => {
+  const sent = [];
+  globalThis.fetch = async (url, opts) => { sent.push(JSON.parse(opts.body)); return new Response('{}', { status: 200 }); };
+  const kv = makeKv({ 'w:a.com': watch('a.com', 'known@x.io') });
+  const env = { RESULTS: kv, ...LIVE_ENV };
+
+  const r1 = await linkPost({ request: postReq({ email: 'known@x.io' }), env });
+  const r2 = await linkPost({ request: postReq({ email: 'unknown@x.io' }), env });
+  const [b1, b2] = [await r1.json(), await r2.json()];
+  assert.equal(r1.status, r2.status);
+  assert.deepEqual(b1, b2, 'identical bodies for known and unknown emails');
+
+  // …but only the known email actually got a message, with a token link in it.
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].to[0], 'known@x.io');
+  assert.match(sent[0].text, /\/dashboard\?token=/);
+});
+
+test('dashboard link email copy: single-use, 15 minutes, privacy', () => {
+  const m = buildDashboardLinkEmail('https://slop-detect.com/dashboard?token=abc', 3);
+  assert.match(m.text, /token=abc/);
+  assert.match(m.text, /single-use/);
+  assert.match(m.text, /15 minutes/);
+  assert.match(m.text, /privacy/i);
+});
+
+// ── /dashboard page ──────────────────────────────────────────────────────────
+test('/dashboard is configured-off without SESSION_SECRET', async () => {
+  const res = await dashGet({ request: getReq('https://slop-detect.com/dashboard'), env: { RESULTS: makeKv() } });
+  assert.match(await res.text(), /not configured/i);
+});
+
+test('/dashboard without a cookie shows the login form, no domains', async () => {
+  const kv = makeKv({ 'w:a.com': watch('a.com', 'agency@x.io') });
+  const res = await dashGet({ request: getReq('https://slop-detect.com/dashboard'), env: { RESULTS: kv, SESSION_SECRET: SECRET } });
+  const html = await res.text();
+  assert.match(html, /Sign in to your dashboard/);
+  assert.ok(!html.includes('a.com'), 'no domains before auth');
+});
+
+test('a valid magic-link token mints a session cookie and redirects clean', async () => {
+  const kv = makeKv({ 'w:a.com': watch('a.com', 'agency@x.io') });
+  const t = await issueDashboardToken(kv, 'agency@x.io');
+  const res = await dashGet({
+    request: getReq(`https://slop-detect.com/dashboard?token=${t}`),
+    env: { RESULTS: kv, SESSION_SECRET: SECRET }
+  });
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get('Location'), 'https://slop-detect.com/dashboard');
+  const setCookie = res.headers.get('Set-Cookie');
+  assert.match(setCookie, /sd_session=/);
+  // The minted cookie verifies back to the email.
+  const minted = setCookie.match(/sd_session=([^;]+)/)[1];
+  assert.equal(await verifySession(minted, SECRET), 'agency@x.io');
+  // And the token burned.
+  assert.equal(await consumeDashboardToken(kv, t), null);
+});
+
+test('a bad/expired token falls back to login with an expiry note', async () => {
+  const res = await dashGet({
+    request: getReq('https://slop-detect.com/dashboard?token=nope'),
+    env: { RESULTS: makeKv(), SESSION_SECRET: SECRET }
+  });
+  assert.match(await res.text(), /expired or was already used/i);
+});
+
+test('a signed-in agency sees ONLY its own domains — never another owner’s', async () => {
+  const kv = makeKv({
+    'w:a.com': watch('a.com', 'agency@x.io', { systemRegressed: true, lastSystemTier: 'Drifting' }),
+    'w:b.com': watch('b.com', 'agency@x.io'),
+    'w:secret.com': watch('secret.com', 'other@y.io')
+  });
+  const tok = await signSession('agency@x.io', SECRET);
+  const res = await dashGet({
+    request: getReq('https://slop-detect.com/dashboard', `sd_session=${tok}`),
+    env: { RESULTS: kv, SESSION_SECRET: SECRET }
+  });
+  const html = await res.text();
+  assert.match(html, /a\.com/);
+  assert.match(html, /b\.com/);
+  assert.match(html, /drifted/, 'drift flag surfaced');
+  assert.match(html, /\/report\/a\.com/, 'per-domain report linked');
+  assert.ok(!html.includes('secret.com'), 'another owner’s domain must never render');
+  assert.ok(!html.includes('other@y.io'), 'another owner’s email must never render');
+});
+
+test('?logout=1 clears the cookie and returns to login', async () => {
+  const res = await dashGet({
+    request: getReq('https://slop-detect.com/dashboard?logout=1'),
+    env: { RESULTS: makeKv(), SESSION_SECRET: SECRET }
+  });
+  assert.match(res.headers.get('Set-Cookie'), /Max-Age=0/);
+  assert.match(await res.text(), /Sign in to your dashboard/);
+});

--- a/packages/web/wrangler.toml
+++ b/packages/web/wrangler.toml
@@ -41,4 +41,6 @@ TURNSTILE_SITEKEY = "0x4AAAAAADWirXpm1gXBhB5E"
 #   CRON_SECRET       Bearer secret for POST /api/cron/sweep
 #   INTERNAL_API_KEY  an `unlimited`-tier API key for the sweep's internal re-scans
 #   SWEEP_MAX         domains re-scanned per sweep (default 50)
+# Dashboard (P2b; needs the email provider too):
+#   SESSION_SECRET    HMAC secret for magic-link dashboard sessions
 # See PRODUCTION.md for the full launch checklist.


### PR DESCRIPTION
Ships the last substantial roadmap feature: **one view across every domain an agency monitors** — slop grade, design-system tier, drift/regression flags, verification state, and per-domain client-report links.

## The auth decision (made per the autonomous mandate)

**Magic-link sign-in** — no passwords, no accounts table. A watch already carries its owner's email, so "the dashboard" is simply *every watch on the signed-in address*. Login = single-use emailed link → 30-day **HMAC-signed, HttpOnly, stateless** session cookie. The only server-side state is the 15-minute link token. Reuses the exact primitives already shipped (email-keyed watches, the KV token pattern, the Resend sender) and stays **safe-off** without `SESSION_SECRET` + the email provider — the same pattern as alerts.

## Pieces
- **`_session.js`** — Web Crypto HMAC-SHA256 sessions (identical in Workers and Node), constant-time signature compare, `HttpOnly; Secure; SameSite=Lax`.
- **`POST /api/dashboard/link`** — anti-enumeration by construction: the response body is *identical* for known and unknown emails (asserted byte-for-byte in tests); a link is only actually sent when watches exist. Rides the shared middleware (cheap rate limit, CORS, foreign-origin guard).
- **`GET /dashboard`** — `?token=` burns the link token, mints the cookie, and 302s clean so the token never lingers in URL/history; the cookie renders the multi-domain table; `?logout=1` clears. Brand-unified (forensic-instrument identity), `noindex`.
- **Isolation tested**: a signed-in agency can *never* see another owner's domains or email.
- Discoverability: footer **Dashboard** link + "all your domains" in the monitor-form success message. Docs: API.md, PRODUCTION.md + wrangler env (`SESSION_SECRET`), ROADMAP P2b → shipped (lite), README.

## Tests
**+13** (session round-trip / tamper / expiry / wrong-secret, cookie flags, token single-use, per-email isolation, anti-enumeration with a send-spy, the token→cookie 302 flow, configured-off states, logout). **172 total: 165 pass, 0 fail**, 7 browser-gated golden skips. Lint clean.

## To switch it on (operator)
Set `SESSION_SECRET` (any long random string) in Pages env alongside the existing email-provider keys — one more row in `PRODUCTION.md`'s table.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces session auth (`SESSION_SECRET`, cookies, magic links); behavior is well-tested for tampering, enumeration, and tenant isolation, but misconfiguration or secret leakage would affect dashboard access.
> 
> **Overview**
> Adds the **agency multi-domain dashboard** (Roadmap P2b): passwordless **magic-link** sign-in and a single **`/dashboard`** view of every monitored domain for one email.
> 
> **Auth:** `POST /api/dashboard/link` emails a **15-minute, single-use** KV token; visiting `/dashboard?token=` burns it and sets a **30-day HMAC-signed** `HttpOnly` session (`SESSION_SECRET`, new `_session.js`). No accounts table—sessions are keyed off existing watch emails. **Safe-off** when email + `SESSION_SECRET` are unset (503), same pattern as alerts. The link API returns the **same JSON** for known and unknown emails; mail only sends when watches exist.
> 
> **UI:** Signed-in users see a table of their domains (slop grade, system tier, regression/drift flags, `/report` links); `?logout=1` clears the cookie. **`noindex`**, owner isolation covered in tests.
> 
> Docs/env: `PRODUCTION.md`, `API.md`, `ROADMAP` (P2b shipped), README; footer and monitor success link to `/dashboard`. Lint includes new dashboard handlers; **`dashboard.test.js`** covers sessions, tokens, anti-enumeration, and cross-owner isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef740b4782ba4fcc65eef90b7394e52eba0e4811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->