### PR TITLE
v0.7.0: sync every doc, discovery surface, and the landing page with the shipped product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.7.0 — the system axis & the continuity product
+
+Strategy v2 implemented end to end ("slop is the hook, not the product").
+
+### Added
+- **System axis** — DESIGN.md compliance: core parser/scorer (zero-dep), CLI
+  `--design-md`, API `designMd`, MCP `check_design_system`. Relative,
+  higher-is-better, named drift; structurally immune to the premium-site
+  false-positive class.
+- **Drift alerts** — `watch { system: true }`: the daily sweep checks each
+  domain against its own DESIGN.md and emails once per drift event.
+- **Agency dashboard** (`/dashboard`) — magic-link sign-in (HMAC sessions,
+  anti-enumeration link endpoint), one view across every domain on an email.
+- **Client report** (`/report/<domain>`) — print-friendly (PDF via print).
+- **Leaderboard** (`/leaderboard`) + opt-in **directory** (`/directory`,
+  dofollow backlinks) + monitor conversion section on the landing page.
+- Calibration harness: golden fixtures, labeled corpus, `npm run calibrate`.
+
+### Changed
+- Landing page: §04 monitoring conversion bridge, post-scan nudge, nav/footer
+  to all surfaces; sub-pages unified on the forensic-instrument brand.
+- All discovery surfaces (openapi.json — incl. fixing a wrong `preset` enum —
+  llms.txt family, .well-known cards, agent view) synced to the full tool
+  surface and version.
+
+### Fixed
+- Detector calibration: eyebrow-pill no longer fires on CTA/nav buttons;
+  glassmorphism requires >=2 elements (evidence: Stripe/Linear/Vercel scans).
+- Monitor form could silently delist a domain on resubmit (opt-ins now additive).
+
+
 ## definitions@2026.09 — calibration: fewer premium-site false positives
 
 Driven by real evidence from the `/leaderboard` corpus scan (linear.app scored

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slop-detect-monorepo",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slop-detect-monorepo",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/core",
@@ -3585,11 +3585,11 @@
     },
     "packages/cli": {
       "name": "slop-detect",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.49.0",
-        "slop-detect-core": "0.6.0"
+        "slop-detect-core": "0.7.0"
       },
       "bin": {
         "slop": "bin/slop.js",
@@ -3601,7 +3601,7 @@
     },
     "packages/core": {
       "name": "slop-detect-core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -3609,7 +3609,7 @@
     },
     "packages/mcp": {
       "name": "slop-detect-mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"
@@ -3623,11 +3623,11 @@
     },
     "packages/web": {
       "name": "slop-detect-web",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.1.0",
-        "slop-detect-core": "0.6.0"
+        "slop-detect-core": "0.7.0"
       },
       "devDependencies": {
         "wrangler": "^4.86.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slop-detect-monorepo",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Score any landing page against the multi-axis (design + copy) AI-slop fingerprint. Detect Cursor/v0/Lovable templates and GPT-default copy in the wild.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slop-detect",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Score any landing page against the AI-design-slop fingerprint from your terminal. Playwright-based, deterministic, zero-config.",
   "type": "module",
   "license": "MIT",
@@ -29,7 +29,7 @@
     "demo": "node bin/slop.js https://news.ycombinator.com https://www.aura.build https://lovable.dev"
   },
   "dependencies": {
-    "slop-detect-core": "0.6.0",
+    "slop-detect-core": "0.7.0",
     "playwright": "^1.49.0"
   },
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slop-detect-core",
-  "version": "0.6.0",
-  "description": "Pure detection engine for AI-design-slop patterns. Runtime-agnostic — runs in Node, Cloudflare Workers, or the browser.",
+  "version": "0.7.0",
+  "description": "Pure detection engine for AI-design-slop patterns. Runtime-agnostic \u2014 runs in Node, Cloudflare Workers, or the browser.",
   "type": "module",
   "license": "MIT",
   "homepage": "https://slop-detect.com",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slop-detect-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "MCP server that lets AI coding agents (Cursor, Claude Code, Windsurf) scan landing pages for AI-design-slop and pull a fix prompt.",
   "type": "module",
   "license": "MIT",

--- a/packages/web/functions/index.js
+++ b/packages/web/functions/index.js
@@ -19,7 +19,7 @@ function agentView() {
     url: ORIGIN,
     license: 'MIT',
     repository: 'https://github.com/ravidsrk/slop-detect',
-    version: '0.5.1',
+    version: '0.7.0',
     catalogue: {
       definitionsVersion: DEFINITIONS_VERSION,
       patternCount: PATTERNS.length,
@@ -45,6 +45,20 @@ function agentView() {
         method: 'GET',
         endpoint: `${ORIGIN}/api/patterns`,
         description: 'Read the live pattern catalogue.'
+      },
+      {
+        name: 'check_design_system',
+        method: 'POST',
+        endpoint: `${ORIGIN}/api/scan`,
+        body: { url: 'https://example.com', designMd: true },
+        description: 'System axis: does the page honor its own DESIGN.md? 0-100 compliance (higher is better) + named drift.'
+      },
+      {
+        name: 'monitor_domain',
+        method: 'POST',
+        endpoint: `${ORIGIN}/api/watch`,
+        body: { domain: 'example.com', email: 'you@company.com', system: true },
+        description: 'Monitor a domain: daily re-scans, regression + design-drift email alerts (double opt-in).'
       },
       {
         name: 'fix_prompt',
@@ -74,6 +88,9 @@ function agentView() {
       markdownTwin: `${ORIGIN}/index.md`,
       pricing: `${ORIGIN}/pricing.md`,
       privacy: `${ORIGIN}/privacy.md`,
+      dashboard: `${ORIGIN}/dashboard`,
+      directory: `${ORIGIN}/directory`,
+      leaderboard: `${ORIGIN}/leaderboard`,
       sitemap: `${ORIGIN}/sitemap.xml`,
       schemaMap: `${ORIGIN}/schema-map.xml`
     }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,8 +1,8 @@
 {
   "name": "slop-detect-web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
-  "description": "Cloudflare Pages app for slop-detect.com — web UI + /api/scan + /api/fix-prompt.",
+  "description": "Cloudflare Pages app for slop-detect.com \u2014 web UI + /api/scan + /api/fix-prompt.",
   "type": "module",
   "license": "MIT",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@cloudflare/puppeteer": "^1.1.0",
-    "slop-detect-core": "0.6.0"
+    "slop-detect-core": "0.7.0"
   },
   "devDependencies": {
     "wrangler": "^4.86.0"

--- a/packages/web/public/.well-known/agent-card.json
+++ b/packages/web/public/.well-known/agent-card.json
@@ -4,7 +4,7 @@
   "description": "Score any landing page against the AI-design-slop fingerprint. Deterministic, weighted 0-100 scoring on real headless Chromium, plus an AEO axis (can AI engines read & cite a page). Open source, MIT.",
   "url": "https://slop-detect.com",
   "preferredTransport": "JSONRPC",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "documentationUrl": "https://slop-detect.com/llms.txt",
   "provider": {
     "organization": "Slop Detector",

--- a/packages/web/public/.well-known/mcp/server-card.json
+++ b/packages/web/public/.well-known/mcp/server-card.json
@@ -3,7 +3,7 @@
   "name": "slop-detect-mcp",
   "displayName": "Slop Detector",
   "description": "MCP server that scores any landing page against the AI-design-slop fingerprint (deterministic 0-100, real Chromium) and an AEO axis, and builds fix prompts.",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "vendor": {
     "name": "Slop Detector",
     "url": "https://slop-detect.com"

--- a/packages/web/public/api/llms.txt
+++ b/packages/web/public/api/llms.txt
@@ -33,6 +33,17 @@ curl -X POST https://slop-detect.com/api/scan \
   -d '{"url":"https://example.com"}'
 ```
 
+## Monitoring & directory endpoints
+
+- `POST /api/watch` — `{ domain, email, system?, list? }`: monitor a domain (daily
+  re-scans; regression + DESIGN.md-drift email alerts, double opt-in). Flags are
+  omit-preserves; `unsubscribe: true` stops + delists.
+- `GET /api/watch?domain=` — public monitoring status + history (never the email).
+- `GET /api/sites` — the opt-in public directory (JSON; `sort=clean|slop`).
+- `POST /api/dashboard/link` — magic sign-in link for /dashboard (anti-enumeration).
+- `designMd: true | "<url>"` on `POST /api/scan` — the system axis: DESIGN.md
+  compliance, higher is better, named drift items.
+
 ## Links
 
 - OpenAPI: https://slop-detect.com/openapi.json

--- a/packages/web/public/developers/llms.txt
+++ b/packages/web/public/developers/llms.txt
@@ -47,4 +47,7 @@ the score is deterministic and sourced.
 
 - Source: https://github.com/ravidsrk/slop-detect
 - Pattern catalogue: https://slop-detect.com/api/patterns
+- Monitoring & system axis (DESIGN.md drift): https://slop-detect.com/#monitor
+- Dashboard (magic-link): https://slop-detect.com/dashboard
+- Directory: https://slop-detect.com/directory · Leaderboard: https://slop-detect.com/leaderboard
 - Agent skill: https://slop-detect.com/.well-known/agent-skills/index.json

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -88,7 +88,7 @@
       "operatingSystem": "Web, Node.js (CLI), MCP",
       "url": "https://slop-detect.com",
       "downloadUrl": "https://www.npmjs.com/package/slop-detect",
-      "softwareVersion": "0.6.0",
+      "softwareVersion": "0.7.0",
       "license": "https://opensource.org/licenses/MIT",
       "isAccessibleForFree": true,
       "publisher": { "@id": "https://slop-detect.com/#org" },
@@ -151,7 +151,7 @@
           "name": "Can it monitor a domain over time?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes. POST /api/watch with a domain and email to monitor it: the daily sweep re-scans the domain and emails you (double opt-in) when the slop score regresses. Add system: true and it also checks the page against the site's own DESIGN.md, alerting when the design drifts off its declared system. Every monitored domain gets a print-friendly client report at slop-detect.com/report/<domain>."
+            "text": "Yes. POST /api/watch with a domain and email to monitor it: the daily sweep re-scans the domain and emails you (double opt-in) when the slop score regresses. Add system: true and it also checks the page against the site's own DESIGN.md, alerting when the design drifts off its declared system. Every monitored domain gets a print-friendly client report at slop-detect.com/report/<domain>, and the dashboard at slop-detect.com/dashboard (magic-link sign-in) shows every domain on your email in one view."
           }
         },
         {
@@ -1081,6 +1081,7 @@
       <nav class="topbar-links">
         <a href="#fingerprint" class="hide-sm">The fingerprint</a>
         <a href="#monitor" class="hide-sm">Monitoring</a>
+        <a href="/dashboard" class="hide-sm">Dashboard</a>
         <a href="/leaderboard" class="hide-sm">Leaderboard</a>
         <a href="/directory" class="hide-sm">Directory</a>
         <a href="https://github.com/ravidsrk/slop-detect" target="_blank" rel="noopener">GitHub</a>

--- a/packages/web/public/index.md
+++ b/packages/web/public/index.md
@@ -44,11 +44,32 @@ score polarity is inverted relative to the slop score: higher AEO is better.
    Same page in, same score out. No model, no randomness.
 4. **Clean / Mild / Heavy.** Clean 0–9, Mild 10–27, Heavy 28+.
 
+## System axis — does the page honor its own design system?
+
+The relative axis: declare your tokens in a DESIGN.md (Google Labs' open spec —
+colors, typography, radii, components) and Slop Detector reports **drift**
+against *your own* system: fonts in use that aren't declared, CTA or surface
+colors off the palette, radii off the scale. Higher is better (Aligned ≥80 ·
+Drifting ≥50 · Off-system <50). A bespoke site checked against its own tokens
+can never false-positive as "slop."
+
+## Keep it clean — monitoring
+
+A score is a snapshot; drift is the disease. Monitor a domain
+(`POST /api/watch` with a domain and email, or the form at
+https://slop-detect.com/#monitor) and the daily sweep re-scans it, emailing you
+on slop regression — and, with `system: true`, on design-system drift. Double
+opt-in: nothing is emailed until you confirm. Every monitored domain gets a
+print-friendly client report at `https://slop-detect.com/report/<domain>`, and
+the dashboard (https://slop-detect.com/dashboard, magic-link sign-in) shows
+every domain on your email in one view.
+
 ## Use it
 
 - Web: paste a URL at https://slop-detect.com
 - CLI: `npx slop-detect <url>` — gate CI with `--fail-on heavy`, add `--aeo` for
-  the AEO axis.
+  the AEO axis, `--design-md auto` for the system axis, `--remote` to scan via
+  the API with no local browser.
 - MCP: the `slop-detect-mcp` server exposes `scan_page`, `check_aeo`,
   `check_design_system` and `fix_prompt` tools to any MCP client (Claude Code,
   Cursor, Windsurf).
@@ -58,3 +79,6 @@ score polarity is inverted relative to the slop score: higher AEO is better.
 - Web app: https://slop-detect.com
 - Source: https://github.com/ravidsrk/slop-detect
 - Pattern catalogue: https://slop-detect.com/api/patterns
+- Directory of scored sites (opt-in): https://slop-detect.com/directory
+- The State of AI Design Slop: https://slop-detect.com/leaderboard
+- Privacy: https://slop-detect.com/privacy.md

--- a/packages/web/public/llms-full.txt
+++ b/packages/web/public/llms-full.txt
@@ -137,6 +137,20 @@ Exposes `scan_page`, `check_aeo`, `fix_prompt` to any MCP client (Claude Code,
 Cursor, Windsurf). Server card:
 https://slop-detect.com/.well-known/mcp/server-card.json
 
+## Monitoring, system axis & dashboard
+
+A score is a snapshot; monitoring is the continuity layer. `POST /api/watch`
+`{ domain, email }` re-scans the domain daily and emails on slop regression
+(double opt-in — nothing is sent until the address confirms). `system: true`
+also checks each scan against the site's own DESIGN.md (Google Labs spec) and
+alerts on design drift: undeclared fonts, off-palette CTA/surface colors,
+off-scale radii. The system axis is relative and higher-is-better (Aligned >=80,
+Drifting >=50, Off-system <50) and is never folded into the slop score.
+`list: true` opts the domain into the public directory (dofollow backlink).
+Each monitored domain gets a print-friendly client report at /report/<domain>;
+the dashboard at /dashboard (magic-link sign-in via POST /api/dashboard/link)
+shows every domain on one email. Privacy: /privacy.md.
+
 ## Use cases
 
 - Pre-launch landing-page audits.

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -28,9 +28,11 @@ page looks machine-generated, not that it is bad.
 
 ## Tools for agents
 
-- CLI: `npx slop-detect <url>`; add `--aeo` for the AEO axis, `--fail-on heavy`
-  to gate CI.
-- MCP server `slop-detect-mcp`: tools `scan_page`, `check_aeo`, `fix_prompt`.
+- CLI: `npx slop-detect <url>`; add `--aeo` for the AEO axis, `--design-md auto`
+  for the system axis, `--fail-on heavy` to gate CI, `--remote` to scan via the
+  API with no local browser.
+- MCP server `slop-detect-mcp`: tools `scan_page`, `check_aeo`,
+  `check_design_system`, `fix_prompt`.
 
 ## Axes
 
@@ -38,6 +40,24 @@ page looks machine-generated, not that it is bad.
 - Copy slop: hedge-y, em-dash-heavy LLM phrasing (optional second axis).
 - AEO: AI-crawler access, robots.txt, indexability, markdown twin, llms.txt,
   content-negotiation. Higher is better (inverse of the slop score).
+- System: DESIGN.md compliance — does the page honor its OWN declared design
+  system? Relative, per-site; higher is better; reports named drift (undeclared
+  fonts, off-palette colors, off-scale radii). Opt in via `designMd` on
+  `POST /api/scan`.
+
+## Keep it clean (monitoring)
+
+- [Monitor a domain](https://slop-detect.com/#monitor): `POST /api/watch`
+  `{ domain, email, system?, list? }` — daily re-scans, regression + design-drift
+  email alerts (double opt-in; nothing sent until confirmed).
+- [Dashboard](https://slop-detect.com/dashboard): every monitored domain on one
+  email, magic-link sign-in (`POST /api/dashboard/link`).
+- Client report per domain: `https://slop-detect.com/report/<domain>`
+  (print-friendly).
+- [Directory](https://slop-detect.com/directory): opt-in catalogue of scored
+  sites (`GET /api/sites` for JSON).
+- [Leaderboard](https://slop-detect.com/leaderboard): "The State of AI Design
+  Slop" — a reproducible scan of well-known landing pages.
 
 ## Use cases
 

--- a/packages/web/public/openapi.json
+++ b/packages/web/public/openapi.json
@@ -2,41 +2,98 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Slop Detector API",
-    "version": "0.5.1",
+    "version": "0.7.0",
     "summary": "Deterministic AI-design-slop scoring for landing pages, plus an AEO axis.",
     "description": "Score any landing page against the AI-design fingerprint. The API runs the same deterministic, weighted 0-100 engine as the web app and CLI, on real headless Chromium (Cloudflare Browser Rendering). No API key is required for normal use; requests are rate-limited per IP and the browser-driving routes (/api/scan, /api/aeo) are protected by a Turnstile challenge for browser origins. Foreign browser origins must present an API key. CLI / server-to-server callers (no Origin header) are allowed but rate-limited harder.",
-    "license": { "name": "MIT", "url": "https://opensource.org/licenses/MIT" },
-    "contact": { "name": "Ravindra Kumar", "url": "https://github.com/ravidsrk/slop-detect/issues", "email": "ravidsrk@gmail.com" }
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "contact": {
+      "name": "Ravindra Kumar",
+      "url": "https://github.com/ravidsrk/slop-detect/issues",
+      "email": "ravidsrk@gmail.com"
+    }
   },
   "servers": [
-    { "url": "https://slop-detect.com", "description": "Production" }
+    {
+      "url": "https://slop-detect.com",
+      "description": "Production"
+    }
   ],
   "externalDocs": {
     "description": "Source, CLI, and MCP server",
     "url": "https://github.com/ravidsrk/slop-detect"
   },
   "tags": [
-    { "name": "scan", "description": "Run the slop engine against a URL." },
-    { "name": "aeo", "description": "Score whether AI engines can read & cite a page." },
-    { "name": "catalogue", "description": "Read the live pattern catalogue." },
-    { "name": "fix", "description": "Generate an LLM fix-prompt from a scan." }
+    {
+      "name": "scan",
+      "description": "Run the slop engine against a URL."
+    },
+    {
+      "name": "aeo",
+      "description": "Score whether AI engines can read & cite a page."
+    },
+    {
+      "name": "catalogue",
+      "description": "Read the live pattern catalogue."
+    },
+    {
+      "name": "fix",
+      "description": "Generate an LLM fix-prompt from a scan."
+    },
+    {
+      "name": "monitor",
+      "description": "Monitor a domain: daily re-scans, regression + design-drift email alerts (double opt-in)."
+    },
+    {
+      "name": "directory",
+      "description": "Opt-in public catalogue of scored sites."
+    },
+    {
+      "name": "dashboard",
+      "description": "Magic-link sign-in to the multi-domain dashboard."
+    }
   ],
   "paths": {
     "/api/scan": {
       "post": {
         "operationId": "scanPage",
-        "tags": ["scan"],
+        "tags": [
+          "scan"
+        ],
         "summary": "Score a URL against the AI-design slop fingerprint.",
         "description": "Opens the URL in headless Chromium, inspects up to 4,000 visible DOM nodes against the deterministic pattern catalogue, and returns a weighted 0-100 score plus the patterns that fired. Opt into the copy axis with `axes: ['design','copy']`.",
-        "security": [{}, { "apiKey": [] }],
+        "security": [
+          {},
+          {
+            "apiKey": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ScanRequest" },
+              "schema": {
+                "$ref": "#/components/schemas/ScanRequest"
+              },
               "examples": {
-                "default": { "summary": "Design axis only", "value": { "url": "https://example.com" } },
-                "multiAxis": { "summary": "Design + copy axes", "value": { "url": "https://example.com", "axes": ["design", "copy"] } }
+                "default": {
+                  "summary": "Design axis only",
+                  "value": {
+                    "url": "https://example.com"
+                  }
+                },
+                "multiAxis": {
+                  "summary": "Design + copy axes",
+                  "value": {
+                    "url": "https://example.com",
+                    "axes": [
+                      "design",
+                      "copy"
+                    ]
+                  }
+                }
               }
             }
           }
@@ -44,73 +101,407 @@
         "responses": {
           "200": {
             "description": "Scan result.",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScanResult" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScanResult"
+                }
+              }
+            }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "502": { "$ref": "#/components/responses/UpstreamError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "502": {
+            "$ref": "#/components/responses/UpstreamError"
+          }
         }
       }
     },
     "/api/aeo": {
       "post": {
         "operationId": "checkAeo",
-        "tags": ["aeo"],
+        "tags": [
+          "aeo"
+        ],
         "summary": "Score whether AI engines can fetch, read & cite a page.",
         "description": "Runs the AEO axis: a handful of plain edge fetches (HTML, GPTBot UA, robots.txt, markdown twin, llms.txt) scored against the AEO check catalogue. Higher is better — inverse polarity of the slop score. No browser needed.",
-        "security": [{}, { "apiKey": [] }],
+        "security": [
+          {},
+          {
+            "apiKey": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AeoRequest" },
-              "examples": { "default": { "value": { "url": "https://example.com" } } }
+              "schema": {
+                "$ref": "#/components/schemas/AeoRequest"
+              },
+              "examples": {
+                "default": {
+                  "value": {
+                    "url": "https://example.com"
+                  }
+                }
+              }
             }
           }
         },
         "responses": {
-          "200": { "description": "AEO conformance report.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AeoResult" } } } },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "429": { "$ref": "#/components/responses/RateLimited" }
+          "200": {
+            "description": "AEO conformance report.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AeoResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
         }
       }
     },
     "/api/patterns": {
       "get": {
         "operationId": "listPatterns",
-        "tags": ["catalogue"],
+        "tags": [
+          "catalogue"
+        ],
         "summary": "The live pattern catalogue.",
         "description": "Returns every design-slop pattern the engine checks, with id, label, category, weight, and the version it was added in. The count is derived from the engine — never hardcode it.",
         "responses": {
-          "200": { "description": "Pattern catalogue.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PatternCatalogue" } } } }
+          "200": {
+            "description": "Pattern catalogue.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PatternCatalogue"
+                }
+              }
+            }
+          }
         }
       }
     },
     "/api/fix-prompt": {
       "post": {
         "operationId": "buildFixPrompt",
-        "tags": ["fix"],
+        "tags": [
+          "fix"
+        ],
         "summary": "Build an LLM fix-prompt from a scan.",
         "description": "Two modes: pass `{ result }` to assemble a prompt from a scan you already have (cheap), or `{ url }` to re-run a scan first (gated as a scan). Returns a ready-to-paste prompt that tells a coding agent how to de-slop the page.",
-        "security": [{}, { "apiKey": [] }],
+        "security": [
+          {},
+          {
+            "apiKey": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/FixPromptRequest" },
+              "schema": {
+                "$ref": "#/components/schemas/FixPromptRequest"
+              },
               "examples": {
-                "fromResult": { "summary": "Assemble from an existing result", "value": { "result": { "score": 34, "tier": "Heavy", "patterns": [] } } },
-                "fromUrl": { "summary": "Re-scan then assemble", "value": { "url": "https://example.com" } }
+                "fromResult": {
+                  "summary": "Assemble from an existing result",
+                  "value": {
+                    "result": {
+                      "score": 34,
+                      "tier": "Heavy",
+                      "patterns": []
+                    }
+                  }
+                },
+                "fromUrl": {
+                  "summary": "Re-scan then assemble",
+                  "value": {
+                    "url": "https://example.com"
+                  }
+                }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Fix prompt.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FixPromptResult" } } } },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "429": { "$ref": "#/components/responses/RateLimited" }
+          "200": {
+            "description": "Fix prompt.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FixPromptResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/api/watch": {
+      "post": {
+        "operationId": "watchDomain",
+        "tags": [
+          "monitor"
+        ],
+        "summary": "Start (or stop) monitoring a domain.",
+        "description": "Subscribe a domain to daily re-scans with regression alerts (double opt-in: no email is sent until the address confirms). `system: true` also checks the domain against its <origin>/DESIGN.md and alerts on design drift. `list: true` opts into the public directory (dofollow backlink). Flags are omit-preserves: only send a flag to change it. `unsubscribe: true` (with the matching email) stops monitoring and delists. Once claimed, only the same email may modify a domain (403 otherwise).",
+        "security": [
+          {},
+          {
+            "apiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "domain",
+                  "email"
+                ],
+                "properties": {
+                  "domain": {
+                    "type": "string",
+                    "example": "example.com"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "system": {
+                    "type": "boolean",
+                    "description": "Enable DESIGN.md drift monitoring."
+                  },
+                  "list": {
+                    "type": "boolean",
+                    "description": "List in the public directory."
+                  },
+                  "unsubscribe": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated (or unsubscribed)."
+          },
+          "201": {
+            "description": "Monitoring registered."
+          },
+          "400": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Domain claimed by a different email."
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      },
+      "get": {
+        "operationId": "watchStatus",
+        "tags": [
+          "monitor"
+        ],
+        "summary": "Public monitoring status + score history for a domain.",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status (never includes the subscriber email)."
+          },
+          "400": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/watch/confirm": {
+      "get": {
+        "operationId": "confirmWatch",
+        "tags": [
+          "monitor"
+        ],
+        "summary": "Double-opt-in confirmation (link from the verification email).",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Confirmed (HTML)."
+          },
+          "410": {
+            "description": "Link expired or already used (HTML)."
+          }
+        }
+      }
+    },
+    "/api/sites": {
+      "get": {
+        "operationId": "listSites",
+        "tags": [
+          "directory"
+        ],
+        "summary": "The opt-in public directory of scored sites (JSON).",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "clean",
+                "slop"
+              ],
+              "default": "clean"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 500
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Globally sorted listings; matches /directory."
+          }
+        }
+      }
+    },
+    "/api/dashboard/link": {
+      "post": {
+        "operationId": "dashboardLink",
+        "tags": [
+          "dashboard"
+        ],
+        "summary": "Request a magic sign-in link for the multi-domain dashboard.",
+        "description": "The response is identical whether or not the email monitors anything (anti-enumeration); a single-use, 15-minute link is only actually emailed when it does. 503 until the email provider and SESSION_SECRET are configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "email"
+                ],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generic acknowledgement."
+          },
+          "400": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Dashboard sign-in not configured."
+          }
         }
       }
     }
@@ -125,107 +516,347 @@
       }
     },
     "responses": {
-      "BadRequest": { "description": "Invalid JSON body or invalid/blocked URL (SSRF guard).", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
-      "Forbidden": { "description": "Foreign browser origin without a valid API key.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
-      "RateLimited": { "description": "Per-IP rate limit exceeded. The scan route fails closed under load.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
-      "UpstreamError": { "description": "The target page could not be loaded/scored (timeout, anti-bot wall, dead page).", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+      "BadRequest": {
+        "description": "Invalid JSON body or invalid/blocked URL (SSRF guard).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Foreign browser origin without a valid API key.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Per-IP rate limit exceeded. The scan route fails closed under load.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "UpstreamError": {
+        "description": "The target page could not be loaded/scored (timeout, anti-bot wall, dead page).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
     },
     "schemas": {
       "ScanRequest": {
         "type": "object",
-        "required": ["url"],
+        "required": [
+          "url"
+        ],
         "properties": {
-          "url": { "type": "string", "format": "uri", "description": "Public http(s) URL to scan. Private/loopback/metadata hosts are rejected.", "example": "https://example.com" },
-          "preset": { "type": "string", "enum": ["full", "design", "layout", "type", "color"], "default": "full", "description": "Which pattern subset to score. `full` scores everything." },
-          "axes": { "type": "array", "items": { "type": "string", "enum": ["design", "copy"] }, "description": "Axes to score. Omit for design only; use ['design','copy'] or 'all' for both." },
-          "screenshot": { "type": "boolean", "default": false, "description": "Include a base64 screenshot in the response." },
-          "share": { "type": "boolean", "default": true, "description": "Persist a shareable permalink (/r/:id). Set false for CI dry-runs." }
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Public http(s) URL to scan. Private/loopback/metadata hosts are rejected.",
+            "example": "https://example.com"
+          },
+          "preset": {
+            "type": "string",
+            "enum": [
+              "full",
+              "strict",
+              "marketing",
+              "minimal"
+            ],
+            "default": "full",
+            "description": "Scoring preset. `full` scores everything; `strict` only weight>=5 smoking guns; `marketing` brand-surface tells; `minimal` the three dead-giveaways."
+          },
+          "axes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "design",
+                "copy"
+              ]
+            },
+            "description": "Axes to score. Omit for design only; use ['design','copy'] or 'all' for both."
+          },
+          "screenshot": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include a base64 screenshot in the response."
+          },
+          "share": {
+            "type": "boolean",
+            "default": true,
+            "description": "Persist a shareable permalink (/r/:id). Set false for CI dry-runs."
+          },
+          "designMd": {
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string",
+                "format": "uri"
+              }
+            ],
+            "description": "System axis - check the page against its declared design system (DESIGN.md spec). `true` looks for <origin>/DESIGN.md; a URL fetches that file (SSRF-guarded). Adds a `system` block to the response: 0-100 compliance score (HIGHER is better), tier Aligned/Drifting/Off-system, and named drift items."
+          }
         }
       },
       "ScanResult": {
         "type": "object",
         "description": "Top-level fields are the DESIGN axis (backward-compatible). When the copy axis is requested, an `axes` object and combined summary are added.",
         "properties": {
-          "url": { "type": "string", "format": "uri" },
-          "finalUrl": { "type": "string", "format": "uri", "description": "URL after redirects." },
-          "title": { "type": "string" },
-          "h1": { "type": "string" },
-          "h1Font": { "type": "string" },
-          "preset": { "type": "string" },
-          "score": { "type": "integer", "minimum": 0, "maximum": 100, "description": "Weighted design-slop score. Higher = more machine-made." },
-          "tier": { "type": "string", "enum": ["Clean", "Mild", "Heavy"], "description": "Clean 0-9, Mild 10-27, Heavy 28+." },
-          "grade": { "type": "string", "description": "Letter grade A-F." },
-          "patternsFlagged": { "type": "integer" },
-          "patternsTotal": { "type": "integer" },
-          "patterns": { "type": "array", "items": { "$ref": "#/components/schemas/Pattern" } },
-          "navMs": { "type": "integer", "description": "Page navigation time in ms." },
-          "id": { "type": "string", "description": "Present when shared. Permalink id." },
-          "resultUrl": { "type": "string", "format": "uri", "description": "Shareable permalink, present when shared." },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "finalUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL after redirects."
+          },
+          "title": {
+            "type": "string"
+          },
+          "h1": {
+            "type": "string"
+          },
+          "h1Font": {
+            "type": "string"
+          },
+          "preset": {
+            "type": "string"
+          },
+          "score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Weighted design-slop score. Higher = more machine-made."
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "Clean",
+              "Mild",
+              "Heavy"
+            ],
+            "description": "Clean 0-9, Mild 10-27, Heavy 28+."
+          },
+          "grade": {
+            "type": "string",
+            "description": "Letter grade A-F."
+          },
+          "patternsFlagged": {
+            "type": "integer"
+          },
+          "patternsTotal": {
+            "type": "integer"
+          },
+          "patterns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Pattern"
+            }
+          },
+          "navMs": {
+            "type": "integer",
+            "description": "Page navigation time in ms."
+          },
+          "id": {
+            "type": "string",
+            "description": "Present when shared. Permalink id."
+          },
+          "resultUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Shareable permalink, present when shared."
+          },
           "axes": {
             "type": "object",
             "description": "Present only when the copy axis is requested.",
             "properties": {
-              "design": { "$ref": "#/components/schemas/AxisSummary" },
-              "copy": { "$ref": "#/components/schemas/AxisSummary" }
+              "design": {
+                "$ref": "#/components/schemas/AxisSummary"
+              },
+              "copy": {
+                "$ref": "#/components/schemas/AxisSummary"
+              }
             }
+          },
+          "system": {
+            "type": "object",
+            "description": "Present when designMd was set. Alignment with the site's OWN design system - higher is better; NOT folded into the slop score. Keys: declared, score, tier, checks, drift[], source."
           }
         }
       },
       "AxisSummary": {
         "type": "object",
         "properties": {
-          "axis": { "type": "string", "enum": ["design", "copy"] },
-          "score": { "type": "integer" },
-          "tier": { "type": "string" },
-          "grade": { "type": "string" },
-          "patternsFlagged": { "type": "integer" },
-          "patternsTotal": { "type": "integer" },
-          "patterns": { "type": "array", "items": { "$ref": "#/components/schemas/Pattern" } }
+          "axis": {
+            "type": "string",
+            "enum": [
+              "design",
+              "copy"
+            ]
+          },
+          "score": {
+            "type": "integer"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "grade": {
+            "type": "string"
+          },
+          "patternsFlagged": {
+            "type": "integer"
+          },
+          "patternsTotal": {
+            "type": "integer"
+          },
+          "patterns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Pattern"
+            }
+          }
         }
       },
       "Pattern": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "example": "gradient_hero_text" },
-          "label": { "type": "string" },
-          "short": { "type": "string" },
-          "category": { "type": "string", "nullable": true, "enum": ["type", "color", "layout", "copy", null] },
-          "weight": { "type": "number" },
-          "since": { "type": "string", "description": "Version a pattern was added.", "example": "baseline" },
-          "hit": { "type": "boolean", "description": "Whether this pattern fired on the scanned page." }
+          "id": {
+            "type": "string",
+            "example": "gradient_hero_text"
+          },
+          "label": {
+            "type": "string"
+          },
+          "short": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "type",
+              "color",
+              "layout",
+              "copy",
+              null
+            ]
+          },
+          "weight": {
+            "type": "number"
+          },
+          "since": {
+            "type": "string",
+            "description": "Version a pattern was added.",
+            "example": "baseline"
+          },
+          "hit": {
+            "type": "boolean",
+            "description": "Whether this pattern fired on the scanned page."
+          }
         }
       },
       "PatternCatalogue": {
         "type": "object",
         "properties": {
-          "version": { "type": "string", "example": "2026.08", "description": "DEFINITIONS_VERSION of the catalogue." },
-          "count": { "type": "integer", "description": "Number of patterns. Derived from the engine.", "example": 27 },
-          "patterns": { "type": "array", "items": { "$ref": "#/components/schemas/Pattern" } }
+          "version": {
+            "type": "string",
+            "example": "2026.08",
+            "description": "DEFINITIONS_VERSION of the catalogue."
+          },
+          "count": {
+            "type": "integer",
+            "description": "Number of patterns. Derived from the engine.",
+            "example": 27
+          },
+          "patterns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Pattern"
+            }
+          }
         }
       },
       "AeoRequest": {
         "type": "object",
-        "required": ["url"],
-        "properties": { "url": { "type": "string", "format": "uri", "example": "https://example.com" } }
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "example": "https://example.com"
+          }
+        }
       },
       "AeoResult": {
         "type": "object",
         "description": "AEO conformance report. Score polarity is INVERTED vs the slop score — higher is better.",
         "properties": {
-          "url": { "type": "string", "format": "uri" },
-          "score": { "type": "integer", "minimum": 0, "maximum": 100, "description": "0-100. Higher = more AI-readable." },
-          "tier": { "type": "string", "enum": ["AI-Ready", "Partial", "Invisible"], "description": "AI-Ready >=80, Partial >=50, Invisible <50." },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "0-100. Higher = more AI-readable."
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "AI-Ready",
+              "Partial",
+              "Invisible"
+            ],
+            "description": "AI-Ready >=80, Partial >=50, Invisible <50."
+          },
           "checks": {
             "type": "array",
             "description": "Per-check results (required + recommended).",
             "items": {
               "type": "object",
               "properties": {
-                "id": { "type": "string", "example": "bot.notBlocked" },
-                "label": { "type": "string" },
-                "tier": { "type": "string", "enum": ["required", "recommended"] },
-                "pass": { "type": "boolean" },
-                "weight": { "type": "number" }
+                "id": {
+                  "type": "string",
+                  "example": "bot.notBlocked"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "tier": {
+                  "type": "string",
+                  "enum": [
+                    "required",
+                    "recommended"
+                  ]
+                },
+                "pass": {
+                  "type": "boolean"
+                },
+                "weight": {
+                  "type": "number"
+                }
               }
             }
           }
@@ -235,19 +866,32 @@
         "type": "object",
         "description": "Provide exactly one of `result` or `url`.",
         "properties": {
-          "result": { "$ref": "#/components/schemas/ScanResult" },
-          "url": { "type": "string", "format": "uri" }
+          "result": {
+            "$ref": "#/components/schemas/ScanResult"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
         }
       },
       "FixPromptResult": {
         "type": "object",
         "properties": {
-          "prompt": { "type": "string", "description": "Ready-to-paste prompt instructing a coding agent how to de-slop the page." }
+          "prompt": {
+            "type": "string",
+            "description": "Ready-to-paste prompt instructing a coding agent how to de-slop the page."
+          }
         }
       },
       "Error": {
         "type": "object",
-        "properties": { "error": { "type": "string", "description": "Human-readable error message." } }
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          }
+        }
       }
     }
   }

--- a/packages/web/public/pricing.md
+++ b/packages/web/public/pricing.md
@@ -23,7 +23,11 @@ A one-off scan tells you the score today. **Monitoring remembers it.** Register 
 domain (`POST /api/watch`) and slop-detect keeps a score history and flags a
 **regression** — when the score gets meaningfully worse or the tier drops a band
 (Clean → Mild → Heavy) — so a redesign or an agent-written page can't quietly
-drag your site back into slop without anyone noticing.
+drag your site back into slop without anyone noticing. Add `system: true` and the
+daily sweep also checks the domain against its own `DESIGN.md`, alerting on design
+drift. The [dashboard](https://slop-detect.com/dashboard) (magic-link sign-in)
+shows every monitored domain on your email in one view, and each domain gets a
+print-friendly client report at `/report/<domain>`.
 
 This is **not** feature-gating detection. Detection is and stays free. Monitoring
 charges for *continuity* — the same model as Snyk / Sentry / semgrep (free engine,
@@ -36,6 +40,7 @@ for why and what we're measuring.
 - Full 27-pattern deterministic design-slop fingerprint
 - Copy-slop axis (LLM phrasing tells)
 - AEO axis — can AI engines read & cite a page
+- System axis — DESIGN.md compliance ("does the page honor its own design system?")
 - Real headless Chromium scoring
 - Shareable result permalinks + per-domain badges
 - Fix-prompt generation

--- a/packages/web/test/landing.test.js
+++ b/packages/web/test/landing.test.js
@@ -17,6 +17,18 @@ test('landing page carries no stale version or definitions strings', () => {
   assert.ok(!html.includes('2026.08'), 'defs label must not lag DEFINITIONS_VERSION');
 });
 
+test('JSON-LD softwareVersion matches the released package version', () => {
+  // Kills the drift class for good: the landing page can never again claim an
+  // old version once package.json moves.
+  const pkg = JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'));
+  assert.match(html, new RegExp(`"softwareVersion":\\s*"${pkg.version.replace(/\./g, '\\.')}"`),
+    `landing must advertise v${pkg.version}`);
+});
+
+test('the dashboard is reachable from nav and footer', () => {
+  assert.ok((html.match(/href="\/dashboard"/g) || []).length >= 2, 'topbar + footer dashboard links');
+});
+
 test('landing page mentions the full current tool surface', () => {
   assert.ok(html.includes('check_design_system'), 'MCP tool list must include the system-axis tool');
   assert.match(html, /DESIGN\.md/, 'the system axis must be presented');


### PR DESCRIPTION
The feature arc since 0.6.0 (system axis, drift alerts, dashboard, directory, leaderboard, client report, landing conversion) had outrun the documentation. One consistency pass so **every surface tells the same story at the same version** — which, for a project whose own pitch is agent-readability, is product work, not housekeeping.

## Version → 0.7.0 everywhere
Five `package.json` + lockfile, landing JSON-LD, `openapi.json`, both `.well-known` cards, and the `?mode=agent` view — **four of which still said 0.5.1**.

## Real correctness fixes found along the way
- **`openapi.json` documented a wrong `preset` enum** (`full/design/layout/type/color` — the engine's actual presets are `full/strict/marketing/minimal`). An agent following the spec would have sent invalid presets.
- `openapi.json` was missing **five live endpoints** — now documents `/api/watch` (POST+GET), `/api/watch/confirm`, `/api/sites`, `/api/dashboard/link`, plus the `designMd` request param and `system` response block on `/api/scan`.

## Surfaces synced
- **`?mode=agent` view**: + `check_design_system` and `monitor_domain` capabilities; discovery gains dashboard/directory/leaderboard.
- **`llms.txt` / `llms-full.txt` / `api/llms.txt` / `developers/llms.txt`**: monitoring, the system axis, the dashboard, directory and leaderboard are now visible to AI readers.
- **`index.md`** (markdown twin): system-axis + monitoring sections, full link set.
- **`pricing.md`**: system axis listed in every plan; dashboard + drift alerts in the continuity section.
- **Landing page**: topbar **Dashboard** link; JSON-LD `featureList` + FAQ cover the dashboard; `softwareVersion` 0.7.0.
- **CHANGELOG**: v0.7.0 entry narrating the whole arc.

## Anti-drift, made permanent
+2 tests: the landing JSON-LD `softwareVersion` must **equal** the root `package.json` version (this drift class can never recur silently), and `/dashboard` must stay reachable from nav + footer.

**174 tests: 167 pass, 0 fail**, 7 browser-gated golden skips. Lint clean; all edited JSON validated.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRo99NAMFmUKeRWrpx42m8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, version bumps, and contract fixes only; no runtime API or auth logic changes in this diff.
> 
> **Overview**
> **v0.7.0 consistency pass** — bumps version across the monorepo (`package.json` / lockfile) and every public surface so agents, humans, and JSON-LD all advertise the same release.
> 
> **OpenAPI and agent discovery** — `openapi.json` moves to **0.7.0**, documents monitoring (`/api/watch`, confirm), directory (`/api/sites`), dashboard (`/api/dashboard/link`), and scan **`designMd`** / **`system`** response; fixes the **`preset`** enum to match the engine (`full` / `strict` / `marketing` / `minimal`). The `?mode=agent` handler adds **`check_design_system`** and **`monitor_domain`** capabilities plus dashboard/directory/leaderboard discovery links; `.well-known` cards and **CHANGELOG v0.7.0** follow.
> 
> **Docs and landing** — `llms.txt` family, `index.md`, and `pricing.md` now describe the system axis, monitoring, dashboard, directory, and leaderboard. Landing gets a **Dashboard** nav link, JSON-LD **`softwareVersion` 0.7.0**, and FAQ copy for the dashboard; **`landing.test.js`** asserts JSON-LD version matches root `package.json` and `/dashboard` stays in nav + footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6a836104a7733e7dc9ecd72c825b7212220082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->