### PR TITLE
Adversarial production review: de-slop our own surfaces + close the npm funnel gap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,83 @@
+name: publish
+
+# Publishes the npm packages (slop-detect-core, slop-detect, slop-detect-mcp)
+# on a release tag. This is the funnel: `npx slop-detect` only ever resolves to
+# what is on npm, so a merged-but-unpublished version is invisible to users.
+#
+# Trigger: a version tag (v0.7.1, v0.8.0, …). Cut the tag AFTER the version bump
+# is on main and CHANGELOG is updated.
+#
+# Required repository secret:
+#   NPM_TOKEN — an npm automation token with publish rights to the three
+#               packages. Without it the job fails fast (it does not silently
+#               no-op), so a release can never appear to succeed while npm stays
+#               stale.
+#
+# Publish order matters: `slop-detect` (CLI) pins an exact `slop-detect-core`
+# version, so core must land first.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Preflight — NPM_TOKEN present
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "::error::NPM_TOKEN must be set as a repo secret to publish."
+            exit 1
+          fi
+
+      # Workspace deps only; the publishable packages never need wrangler/sharp
+      # or playwright, so skip lifecycle scripts (keeps the runner fast + green).
+      - run: npm ci --ignore-scripts
+
+      # Gate the release on the unit suite — never publish a red build.
+      - run: npm test
+
+      # Guard: a tag must match the versions it claims to publish. Stops a stale
+      # `v0.8.0` tag from re-publishing 0.7.0 (or failing midway, half-released).
+      - name: Verify tag matches package versions
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          for pkg in core cli mcp; do
+            PV="$(node -p "require('./packages/$pkg/package.json').version")"
+            if [ "$PV" != "$TAG" ]; then
+              echo "::error::tag $GITHUB_REF_NAME != packages/$pkg version $PV — bump versions before tagging."
+              exit 1
+            fi
+          done
+
+      - name: Publish slop-detect-core
+        run: npm publish -w slop-detect-core --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish slop-detect (CLI)
+        run: npm publish -w slop-detect --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish slop-detect-mcp
+        run: npm publish -w slop-detect-mcp --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,25 @@ Thanks for considering a contribution. The whole project is ~2,000 lines of Java
 ```bash
 git clone https://github.com/<you>/slop-detect.git
 cd slop-detect
-npm install              # installs all 3 workspaces
+npm install              # installs all 4 workspaces
 npm run demo             # smoke test: scans 3 known sites
 ```
 
+If `npm install` fails building `sharp` (a transitive native dep of
+`wrangler` → `miniflare`, pulled in only by the web workspace) on a very new
+Node, install with lifecycle scripts skipped:
+
+```bash
+npm install --ignore-scripts   # links workspaces; tests, lint, CLI all work
+```
+
+That's enough for everything except `npm run web:dev` (the local Cloudflare
+Pages server), which wants the full `wrangler` install on a Node LTS where
+sharp's prebuilt binary resolves.
+
 You need:
 
-- Node 20+
+- Node 20+ (Node LTS recommended for the web workspace)
 - A Cloudflare account if you want to run the web app locally with real scans (Browser Rendering requires Workers Paid; ~$5/mo)
 
 For pure pattern development you don't need Cloudflare — the CLI runs everything locally with Playwright.

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -35,10 +35,15 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
 - ✅ **Observability shim.** Structured logs + optional `ERROR_WEBHOOK`.
   - 🔧 Set `ERROR_WEBHOOK` (Slack/Discord/Sentry ingest) and turn on **Logpush**.
   - 🔧 Add an external **uptime check** (e.g. on `/api/patterns`).
-- ✅ **Deploy/release workflow** (`.github/workflows/deploy.yml`), test-gated.
-  - 🔧 Set `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` repo secrets.
-  - 🔧 Tag a release (`v0.6.0`) and publish the npm packages so `slop-detect` /
-    `-core` / `-mcp` resolve at 0.6.0; cut a matching Action tag for `@v0.6.0`.
+- ✅ **Deploy + publish workflows**, test-gated: `deploy.yml` (Cloudflare Pages)
+  and `publish.yml` (npm), both triggered on a `v*` tag.
+  - 🔧 Set `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` and `NPM_TOKEN` repo
+    secrets.
+  - 🔴 **npm is stale: repo is 0.7.0, but `slop-detect` / `-core` / `-mcp` are
+    published at 0.5.x.** No release was tagged after `v0.5.2`, so `npx
+    slop-detect` ships users a build WITHOUT the copy axis and DESIGN.md system
+    axis the README sells. Cut a `v0.7.x` tag (versions already bumped in the
+    workspaces) to fire `publish.yml`; cut a matching Action tag.
 - ✅ **Engine has real tests now** (scoring/grades/presets/combine + catalogue
   integrity, 92 total). ⏳ Still no DOM-level golden tests of the 27 design
   patterns — see below.
@@ -76,5 +81,6 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
 | Pages env | `SWEEP_MAX` | domains re-scanned per sweep (default 50) |
 | Pages env | `SESSION_SECRET` | HMAC secret for dashboard magic-link sessions |
 | Repo secret | `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` | deploy |
+| Repo secret | `NPM_TOKEN` | publish core/cli/mcp to npm (`publish.yml`) |
 | Repo secret | `CRON_SECRET` | the `monitor-sweep` workflow auth (matches Pages) |
 | Repo setting | branch protection → require `test` + `lint` | merge gate |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ slop-detect https://example.com --axes all       # same thing
 ```
   🟡 Mild  ·  B-  ·  unified 22/100  (2 axes)
 
-  🟢 design  Clean   A-   score   8/100   2/19 flagged
+  🟢 design  Clean   A-   score   8/100   2/27 flagged
   🟡 copy    Mild    B-   score  18/100   4/9 flagged
 
 Copy slop:
@@ -326,7 +326,7 @@ Plus cross-cutting guidance ("don't replace one slop pattern with another", "emp
 ```js
 import { PATTERNS, scorePatterns } from 'slop-detect-core';
 
-// PATTERNS is the array of 19 rule definitions.
+// PATTERNS is the array of 27 rule definitions.
 // Each has { id, label, weight, extract, detect } where:
 //   extract(ctx) runs in the page's DOM context and returns signals
 //   detect(signals) is a pure function deciding triggered: true/false

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ By April 2026, AI-generated landing pages had collapsed onto a measurable visual
 `slop-detect` reproduces Krebs's methodology, adds the signals Meng To identified in his [May 2026 Aura tutorial](https://x.com/MengTo/status/2058893181740359863), and packages it three ways:
 
 - 🟢 **`slop-detect`** — Playwright-based, run from your terminal or CI
-- 🟢 **`slop-detect.com`** — drop-in web UI, scan any URL in 8 seconds
+- 🟢 **`slop-detect.com`** — drop-in web UI, scan any URL in about 5 seconds
 - 🟢 **`slop-detect-core`** — pure detection engine, embed it in your own pipeline
 
 All three share the **same 27-rule scoring engine** so a Heavy from the CLI is a Heavy from the web is a Heavy from the API.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ when slop creeps above your threshold.
 `fail-under` accepts a number (fail if the slop score exceeds it) or a letter
 grade (fail if the grade is worse). Leave it empty for report-only mode.
 
-The repo also ships an [Agent Skill](skills/slop-detect/SKILL.md) following the [agentskills.io](https://agentskills.io) open spec, any compatible agent (Claude Code, Cursor, GitHub Copilot, Gemini CLI, Codex, Roo Code, Junie, and 20+ others) will autonomously invoke the scanner when you ask it to audit a landing page.
+The repo also ships an [Agent Skill](skills/slop-detect/SKILL.md) following the [agentskills.io](https://agentskills.io) open spec. Any compatible agent (Claude Code, Cursor, GitHub Copilot, Gemini CLI, Codex, Roo Code, Junie, and 20+ others) will autonomously invoke the scanner when you ask it to audit a landing page.
 
 ## Monitor a domain + the directory
 
@@ -149,7 +149,7 @@ owner-gated catalogue with a real backlink to each listed site. See also
 reproducible scan of well-known landing pages (how much of the web now reads as
 AI-generated, and who's still clean). We only store
 your email to send the alerts you asked for, only after you confirm, and never
-sell it, see the [privacy policy](https://slop-detect.com/privacy.md). Engine
+sell it. See the [privacy policy](https://slop-detect.com/privacy.md). Engine
 stays MIT and free forever; only continuity (history + alerts) is the paid layer.
 
 ## The 27 patterns
@@ -213,7 +213,7 @@ slop-detect https://example.com --preset minimal       # the 3 dead-giveaways
 | `minimal` | slop fonts + VibeCode purple + gradient text |
 
 The API accepts `{ "url": "...", "preset": "strict" }`. New patterns can be added
-declaratively, see [CONTRIBUTING.md](CONTRIBUTING.md#the-low-friction-path-declarative-rules).
+declaratively; see [CONTRIBUTING.md](CONTRIBUTING.md#the-low-friction-path-declarative-rules).
 
 ## The system axis: DESIGN.md compliance
 
@@ -223,7 +223,7 @@ system?"** Declare your tokens in a [DESIGN.md](https://github.com/google-labs-c
 (Google Labs' open spec, colors, typography, radii, components), and
 slop-detect reports **drift**: fonts in use that aren't declared, CTA/surface
 colors off the palette, radii off the scale. Relative, per-site, and immune to
-the false-positive trap, a bespoke site checked against its own system scores
+the false-positive trap: a bespoke site checked against its own system scores
 *Aligned*, never "slop."
 
 ```bash
@@ -285,7 +285,7 @@ slop-detect/
 │   └── action/                     ← GitHub Action wrapper (not published to npm)
 ```
 
-A monorepo with four npm workspaces (plus the Action). The `core` package is the single source of truth for the 27 rules, `cli`, `web`, and `mcp` are thin runtime adapters around it.
+A monorepo with four npm workspaces (plus the Action). The `core` package is the single source of truth for the 27 rules; `cli`, `web`, and `mcp` are thin runtime adapters around it.
 
 ## Quickstart: contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # slop-detect
 
-> **Score any landing page against the 27-rule AI-design-slop fingerprint — then keep it clean.**
+> **Score any landing page against the 27-rule AI-design-slop fingerprint, then keep it clean.**
 > Detect Cursor / v0 / Lovable / Bolt templates in the wild, check a page against its own `DESIGN.md`, and get a copy-pasteable fix prompt. Monitor a domain and get emailed when it drifts.
 
 <p>
@@ -42,30 +42,30 @@ By April 2026, AI-generated landing pages had collapsed onto a measurable visual
 
 `slop-detect` reproduces Krebs's methodology, adds the signals Meng To identified in his [May 2026 Aura tutorial](https://x.com/MengTo/status/2058893181740359863), and packages it three ways:
 
-- 🟢 **`slop-detect`** — Playwright-based, run from your terminal or CI
-- 🟢 **`slop-detect.com`** — drop-in web UI, scan any URL in about 5 seconds
-- 🟢 **`slop-detect-core`** — pure detection engine, embed it in your own pipeline
+- 🟢 **`slop-detect`**, Playwright-based, run from your terminal or CI
+- 🟢 **`slop-detect.com`**, drop-in web UI, scan any URL in about 5 seconds
+- 🟢 **`slop-detect-core`**, pure detection engine, embed it in your own pipeline
 
 All three share the **same 27-rule scoring engine** so a Heavy from the CLI is a Heavy from the web is a Heavy from the API.
 
 ## Try it now
 
 ```bash
-# Web UI — fastest
+# Web UI: fastest
 open https://slop-detect.com
 
-# API — one curl away
+# API: one curl away
 curl -s -X POST -H 'Content-Type: application/json' \
   https://slop-detect.com/api/scan \
   -d '{"url":"https://your-site.com"}' | jq
 
-# CLI — for CI, batch scans, or air-gapped work
+# CLI: for CI, batch scans, or air-gapped work
 npx slop-detect https://your-site.com
 
-# CLI without a local browser — scan via the API (zero Playwright install)
+# CLI without a local browser: scan via the API (zero Playwright install)
 npx slop-detect https://your-site.com --remote
 
-# Agent Skill — drop into Claude Code / Cursor / Copilot / Codex / Junie
+# Agent Skill: drop into Claude Code / Cursor / Copilot / Codex / Junie
 git clone --depth 1 https://github.com/ravidsrk/slop-detect /tmp/sd \
   && cp -r /tmp/sd/skills/slop-detect ~/.claude/skills/
 ```
@@ -92,7 +92,7 @@ plus an `id` and `resultUrl` for the shareable permalink.
 ## Use it in your agent (MCP)
 
 [`slop-detect-mcp`](packages/mcp) is a Model Context Protocol server that lets
-Cursor / Claude Code / Windsurf agents scan a page **before** they ship it — and
+Cursor / Claude Code / Windsurf agents scan a page **before** they ship it, and
 pull the fix prompt back into the editing loop. Four tools: `scan_page`,
 `check_aeo` (can AI engines read & cite the page?), `check_design_system`
 (does the page honor its own `DESIGN.md`?), and `fix_prompt`.
@@ -121,7 +121,7 @@ when slop creeps above your threshold.
 `fail-under` accepts a number (fail if the slop score exceeds it) or a letter
 grade (fail if the grade is worse). Leave it empty for report-only mode.
 
-The repo also ships an [Agent Skill](skills/slop-detect/SKILL.md) following the [agentskills.io](https://agentskills.io) open spec — any compatible agent (Claude Code, Cursor, GitHub Copilot, Gemini CLI, Codex, Roo Code, Junie, and 20+ others) will autonomously invoke the scanner when you ask it to audit a landing page.
+The repo also ships an [Agent Skill](skills/slop-detect/SKILL.md) following the [agentskills.io](https://agentskills.io) open spec, any compatible agent (Claude Code, Cursor, GitHub Copilot, Gemini CLI, Codex, Roo Code, Junie, and 20+ others) will autonomously invoke the scanner when you ask it to audit a landing page.
 
 ## Monitor a domain + the directory
 
@@ -137,24 +137,24 @@ curl -s -X POST -H 'Content-Type: application/json' \
 
 Add `"system": true` and the daily sweep also checks the domain against its own
 `DESIGN.md`, emailing you when the page **drifts off its declared design
-system** — the check that catches what an agent or a non-designer quietly broke.
+system**, the check that catches what an agent or a non-designer quietly broke.
 Every monitored domain gets a print-friendly client report at
 `slop-detect.com/report/<domain>`, and the [dashboard](https://slop-detect.com/dashboard)
 (magic-link sign-in, no password) shows every domain on your email in one view.
 
 `list: true` also opts the domain into the public, crawlable
-[**directory**](https://slop-detect.com/directory) of scored sites — an
+[**directory**](https://slop-detect.com/directory) of scored sites, an
 owner-gated catalogue with a real backlink to each listed site. See also
-[**The State of AI Design Slop**](https://slop-detect.com/leaderboard) — a
+[**The State of AI Design Slop**](https://slop-detect.com/leaderboard), a
 reproducible scan of well-known landing pages (how much of the web now reads as
 AI-generated, and who's still clean). We only store
 your email to send the alerts you asked for, only after you confirm, and never
-sell it — see the [privacy policy](https://slop-detect.com/privacy.md). Engine
+sell it, see the [privacy policy](https://slop-detect.com/privacy.md). Engine
 stays MIT and free forever; only continuity (history + alerts) is the paid layer.
 
 ## The 27 patterns
 
-`definitions@2026.09` — versioned ruleset. Scores from a given definition
+`definitions@2026.09`, versioned ruleset. Scores from a given definition
 version are comparable; the version ships in every result (`definitionsVersion`).
 
 | # | Pattern | Weight | What it detects |
@@ -208,22 +208,22 @@ slop-detect https://example.com --preset minimal       # the 3 dead-giveaways
 | Preset | Scores |
 |---|---|
 | `full` (default) | all 27 patterns |
-| `strict` | only weight ≥ 5 (fewest false positives — good CI gate) |
+| `strict` | only weight ≥ 5 (fewest false positives, good CI gate) |
 | `marketing` | fonts, colours, gradients, hero treatment |
 | `minimal` | slop fonts + VibeCode purple + gradient text |
 
 The API accepts `{ "url": "...", "preset": "strict" }`. New patterns can be added
-declaratively — see [CONTRIBUTING.md](CONTRIBUTING.md#the-low-friction-path-declarative-rules).
+declaratively, see [CONTRIBUTING.md](CONTRIBUTING.md#the-low-friction-path-declarative-rules).
 
-## The system axis — DESIGN.md compliance
+## The system axis: DESIGN.md compliance
 
 The absolute slop score asks "does this look AI-generated?" The **system axis**
 asks the durable question: **"does this page honor its own declared design
 system?"** Declare your tokens in a [DESIGN.md](https://github.com/google-labs-code/design.md)
-(Google Labs' open spec — colors, typography, radii, components), and
+(Google Labs' open spec, colors, typography, radii, components), and
 slop-detect reports **drift**: fonts in use that aren't declared, CTA/surface
 colors off the palette, radii off the scale. Relative, per-site, and immune to
-the false-positive trap — a bespoke site checked against its own system scores
+the false-positive trap, a bespoke site checked against its own system scores
 *Aligned*, never "slop."
 
 ```bash
@@ -236,9 +236,9 @@ curl -s -X POST -H 'Content-Type: application/json' \
 ```
 
 Higher is better: `Aligned` (≥80) · `Drifting` (≥50) · `Off-system` (<50).
-Every drift item is a named, contestable signal — never a verdict.
+Every drift item is a named, contestable signal, never a verdict.
 
-## Multi-axis slop — design + copy
+## Multi-axis slop: design + copy
 
 Slop isn't only visual. The same page that wears a v0 template usually has
 GPT-default *prose* too. slop-detect scores a second **copy axis** on the page's
@@ -285,9 +285,9 @@ slop-detect/
 │   └── action/                     ← GitHub Action wrapper (not published to npm)
 ```
 
-A monorepo with four npm workspaces (plus the Action). The `core` package is the single source of truth for the 27 rules — `cli`, `web`, and `mcp` are thin runtime adapters around it.
+A monorepo with four npm workspaces (plus the Action). The `core` package is the single source of truth for the 27 rules, `cli`, `web`, and `mcp` are thin runtime adapters around it.
 
-## Quickstart — contributing
+## Quickstart: contributing
 
 ```bash
 git clone https://github.com/ravidsrk/slop-detect.git
@@ -316,7 +316,7 @@ curl -s -X POST -H 'Content-Type: application/json' \
 
 Each triggered pattern comes back with:
 
-- **Why this reads as AI-slop** (the tell — `Tailwind indigo-600`, `background-clip: text`, etc.)
+- **Why this reads as AI-slop** (the tell, `Tailwind indigo-600`, `background-clip: text`, etc.)
 - **Fix recipe** (the senior designer's prescription)
 - **Better alternatives** (3–5 concrete directions with brand references)
 - **Hard rule** (a testable constraint the agent self-checks against)
@@ -341,24 +341,24 @@ const patternResults = PATTERNS.map(p => {
 const { score, tier, patternsFlagged } = scorePatterns(patternResults);
 ```
 
-The runner is yours — Playwright, Puppeteer, Cloudflare Browser Rendering, Browserless, whatever you have. The `core` package never touches a browser.
+The runner is yours, Playwright, Puppeteer, Cloudflare Browser Rendering, Browserless, whatever you have. The `core` package never touches a browser.
 
 ## Roadmap
 
 See [ROADMAP.md](ROADMAP.md) for the full strategic plan. Phase 1 (distribution
 primitives) shipped in v0.2.0:
 
-- [x] **Shareable result permalinks** — every scan gets `slop-detect.com/r/<id>`
-- [x] **OG share cards** — auto-generated 1200×630 image per result (`/og/<id>.png`)
-- [x] **Letter grades + verdict** — A+→F grade and a one-liner on every score
-- [x] **Embeddable SVG badge** — `slop-detect.com/badge/<domain>.svg` + copy-paste snippets
-- [x] **Versioned slop definitions** — scores tagged with `definitionsVersion`
-- [x] **GitHub Action** — sticky PR comment + pass/fail status check on preview URLs
+- [x] **Shareable result permalinks**: every scan gets `slop-detect.com/r/<id>`
+- [x] **OG share cards**: auto-generated 1200×630 image per result (`/og/<id>.png`)
+- [x] **Letter grades + verdict**: A+→F grade and a one-liner on every score
+- [x] **Embeddable SVG badge**: `slop-detect.com/badge/<domain>.svg` + copy-paste snippets
+- [x] **Versioned slop definitions**: scores tagged with `definitionsVersion`
+- [x] **GitHub Action**: sticky PR comment + pass/fail status check on preview URLs
 - [x] **MCP server** (`slop-detect-mcp`) so agents self-audit before shipping
 - [x] **Public REST API** with key-based rate-limit tiers ([API.md](packages/web/API.md))
 - [x] **Declarative rule format** + named presets (strict / marketing / minimal)
-- [x] **New 2026.07 patterns** — bento walls, aurora gradients, AI sparkles
-- [x] **Multi-axis slop score** — design + copy axes, unified score, both-axis fix prompts
+- [x] **New 2026.07 patterns**: bento walls, aurora gradients, AI sparkles
+- [x] **Multi-axis slop score**: design + copy axes, unified score, both-axis fix prompts
 - [ ] Community rule registry + web rule authoring UI
 - [ ] AI-builder provenance signal ("likely built with v0 / Lovable / Bolt")
 - [ ] Code-slop axis (repo / view-source hook)
@@ -366,9 +366,9 @@ primitives) shipped in v0.2.0:
 
 ## Acknowledgments
 
-- **[Adrian Krebs](https://www.adriankrebs.ch/blog/design-slop/)** — original AI-design-slop study and 12-pattern fingerprint
-- **[Meng To](https://x.com/MengTo)** — Aura tutorial that codified the gradient-letter avatar pattern
-- All the **AI tools we're detecting** — Cursor, v0, Lovable, Bolt — which generated the corpus that taught us what slop looks like
+- **[Adrian Krebs](https://www.adriankrebs.ch/blog/design-slop/)**: original AI-design-slop study and 12-pattern fingerprint
+- **[Meng To](https://x.com/MengTo)**: Aura tutorial that codified the gradient-letter avatar pattern
+- All the **AI tools we're detecting** (Cursor, v0, Lovable, Bolt), which generated the corpus that taught us what slop looks like
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -280,17 +280,19 @@ slop-detect/
 ├── packages/
 │   ├── core/    slop-detect-core   ← pure detection engine (Node, Workers, browser)
 │   ├── cli/     slop-detect    ← Playwright runner for terminal + CI
-│   └── web/     slop-detect-web    ← Cloudflare Pages app powering slop-detect.com
+│   ├── web/     slop-detect-web    ← Cloudflare Pages app powering slop-detect.com
+│   ├── mcp/     slop-detect-mcp    ← Model Context Protocol server for agents
+│   └── action/                     ← GitHub Action wrapper (not published to npm)
 ```
 
-A monorepo with npm workspaces. The `core` package is the single source of truth for the 27 rules — `cli` and `web` are thin runtime adapters around it.
+A monorepo with four npm workspaces (plus the Action). The `core` package is the single source of truth for the 27 rules — `cli`, `web`, and `mcp` are thin runtime adapters around it.
 
 ## Quickstart — contributing
 
 ```bash
 git clone https://github.com/ravidsrk/slop-detect.git
 cd slop-detect
-npm install                     # installs all 3 workspaces
+npm install                     # installs all 4 workspaces
 
 # Run the CLI locally
 npm run demo                    # scans 3 example sites

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Three research findings force the revision:
 2. **Absolute slop-grading is commoditized.** Impeccable (~34.7k★, free, OSS)
    owns the "most patterns" game; Sailop, aiwebsitedetector et al. fill the
    rest, all enumerating the same tells. A rule list is copyable in an
-   afternoon. Meanwhile "slop" the meme peaked (2025 Word of the Year), the
+   afternoon. Meanwhile "slop" the meme peaked (2025 Word of the Year). The
    attention is a **depreciating asset to harvest, not a moat to defend**.
 
 3. **Our own evidence shows the fatal failure mode.** The detector scores
@@ -112,7 +112,7 @@ DESIGN.md. Workflow lock-in is the only durable distribution.
   At most: an opt-in *pairwise* LLM critique layer; never the scoring authority.
 - **No head-on AEO/citation-tracking business.** The monetizable core is owned
   by funded startups (Profound ~$1B) and Semrush/Ahrefs; our crawlability/
-  llms.txt axis is the commoditized free slice, keep it as funnel only.
+  llms.txt axis is the commoditized free slice; keep it as funnel only.
 - **No "% AI" verdicts, ever.** Named rules, contestable signals, page-not-person.
 - **No one-time licenses.** (Tailwind UI's collapse is the cautionary tale.)
   Recurring only.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
-# slop-detect — Strategic Roadmap v2
+# slop-detect: Strategic Roadmap v2
 
 > Where this project goes next, and why.
 > Last updated: 2026-06-05 · Current version: v0.6.0
 > Supersedes the v1 roadmap (preserved in git history). Grounded in the
-> June 2026 deep-research pass — see "Research basis" at the bottom — and in
+> June 2026 deep-research pass, see "Research basis" at the bottom, and in
 > our own calibration evidence (`CALIBRATION.md`).
 
 ---
@@ -18,18 +18,18 @@ Three research findings force the revision:
    detectors reliably degrade (antivirus, AI-text detectors), and the
    generators are being actively engineered to suppress the default look:
    Google's **DESIGN.md** standard (Apache-2.0, ~15k★, ships `lint`/`export`
-   tooling) injects per-brand constraints into AI builders and agents — the
+   tooling) injects per-brand constraints into AI builders and agents, the
    design-world equivalent of malware polymorphism. The thing we detect is
    being standardized away.
 
 2. **Absolute slop-grading is commoditized.** Impeccable (~34.7k★, free, OSS)
    owns the "most patterns" game; Sailop, aiwebsitedetector et al. fill the
    rest, all enumerating the same tells. A rule list is copyable in an
-   afternoon. Meanwhile "slop" the meme peaked (2025 Word of the Year) — the
+   afternoon. Meanwhile "slop" the meme peaked (2025 Word of the Year), the
    attention is a **depreciating asset to harvest, not a moat to defend**.
 
 3. **Our own evidence shows the fatal failure mode.** The detector scores
-   Linear/Vercel as Heavy and Stripe as Mild — punishing a *style* as
+   Linear/Vercel as Heavy and Stripe as Mild, punishing a *style* as
    *provenance*, the exact false-positive trap that killed OpenAI's own AI-text
    classifier and discredited the text-detector industry (Stanford/Cell). An
    absolute "is this AI?" verdict cannot be made reliable; a **relative**
@@ -38,9 +38,9 @@ Three research findings force the revision:
 So the strategy inverts:
 
 > **Free, loud slop grader = acquisition channel (now, while attention peaks).**
-> **Paid product = continuous design-system / brand-drift monitoring —
+> **Paid product = continuous design-system / brand-drift monitoring:
 > "your non-designers and coding agents keep shipping to your site; we keep it
-> on-brand and on-system" — sold to agencies and teams as recurring continuity.**
+> on-brand and on-system", sold to agencies and teams as recurring continuity.**
 > **Technical posture: ride DESIGN.md, don't fight it.** Compliance with a
 > site's *own declared system* is a relative signal that cannot decay and
 > structurally cannot false-positive on great custom design.
@@ -61,23 +61,23 @@ acquire (free, peak-hype)          retain (paid, durable)
 ```
 
 The continuity layer (watch/alerts/directory) shipped in v0.6.0. The missing
-piece — and **the first deliverable of this roadmap** — is the relative axis
+piece, and **the first deliverable of this roadmap**, is the relative axis
 that makes monitoring worth paying for:
 
-### P1 — The `system` axis: DESIGN.md compliance (NOW)
+### P1: The `system` axis: DESIGN.md compliance (NOW)
 
 "Does this page honor its declared design system?" Parse a site's `DESIGN.md`
-(Google Labs spec: YAML front-matter tokens — colors, typography, rounded,
+(Google Labs spec: YAML front-matter tokens, colors, typography, rounded,
 spacing, components), compare against what the scanned page actually renders
 (fonts in use, CTA/surface colors, radii), and report **drift** as named,
 contestable signals. Ships in core (pure, zero-dep), CLI (`--design-md`), and
 the web API. This:
-- **fixes the Linear/Stripe false-positive class structurally** — a bespoke
+- **fixes the Linear/Stripe false-positive class structurally**: a bespoke
   site checked against its own tokens scores *aligned*, not "slop";
-- **cannot decay** — the reference point is per-customer, not a global fashion;
+- **cannot decay**: the reference point is per-customer, not a global fashion;
 - **aligns us with the standard that would otherwise obsolete us**.
 
-### P2 — Sell continuity to agencies (NEXT, 1–2 quarters)
+### P2: Sell continuity to agencies (NEXT, 1–2 quarters)
 
 The research is unambiguous about the indie buyer: **digital agencies** pay
 recurring for white-label reports, scheduled multi-site audits, and drift
@@ -88,7 +88,7 @@ pipeline shipped in v0.6), CI gate on `system` compliance. Open-core stays MIT
 Realistic target: **$1–10K MRR within 12–18 months**, plus $800–4K/mo
 well-structured GitHub Sponsors.
 
-### P3 — Versioned community ruleset ("slop definitions") (ONGOING)
+### P3: Versioned community ruleset ("slop definitions") (ONGOING)
 
 Keep the free fingerprint current on the **Semgrep registry model**:
 community-contributed, versioned, months-cadence refresh; favor structural
@@ -97,10 +97,10 @@ DESIGN.md/builder updates as the leading decay indicator. Calibration
 (`CALIBRATION.md`, labeled corpus, honest precision/recall) is **strategic**,
 not housekeeping: signals-not-verdicts is the credibility model.
 
-### P4 — Agent-loop depth (ONGOING)
+### P4: Agent-loop depth (ONGOING)
 
 The MCP server's job shifts from "scan after the fact" to "**the design-system
-check inside the coding-agent loop** before it ships" — consuming the repo's
+check inside the coding-agent loop** before it ships", consuming the repo's
 DESIGN.md. Workflow lock-in is the only durable distribution.
 
 ---
@@ -112,7 +112,7 @@ DESIGN.md. Workflow lock-in is the only durable distribution.
   At most: an opt-in *pairwise* LLM critique layer; never the scoring authority.
 - **No head-on AEO/citation-tracking business.** The monetizable core is owned
   by funded startups (Profound ~$1B) and Semrush/Ahrefs; our crawlability/
-  llms.txt axis is the commoditized free slice — keep it as funnel only.
+  llms.txt axis is the commoditized free slice, keep it as funnel only.
 - **No "% AI" verdicts, ever.** Named rules, contestable signals, page-not-person.
 - **No one-time licenses.** (Tailwind UI's collapse is the cautionary tale.)
   Recurring only.
@@ -142,7 +142,7 @@ DESIGN.md. Workflow lock-in is the only durable distribution.
 | P2a Drift alerts on `system` axis via existing sweep | ✅ Shipped (`watch { system:true }` → sweep checks DESIGN.md → drift email, once per event) |
 | P2b-lite Print-friendly client report (`/report/:domain`) | ✅ Shipped (the PDF-infra substitute) |
 | P2b Agency multi-site dashboard | ✅ Shipped (lite): magic-link sign-in → /dashboard, one view across every domain on an email. Team seats/roles later |
-| P2c Pricing live ($29–$149/mo) | With P2b (needs Stripe keys — operator task) |
+| P2c Pricing live ($29–$149/mo) | With P2b (needs Stripe keys, operator task) |
 | P3 Community ruleset + calibration corpus growth | Ongoing |
 | P4 MCP design-system mode (`check_design_system` tool) | ✅ Shipped |
 

--- a/packages/web/public/api/llms.txt
+++ b/packages/web/public/api/llms.txt
@@ -1,4 +1,4 @@
-# Slop Detector — API
+# Slop Detector: API
 
 > Scoped context for the Slop Detector HTTP API. Full manual: https://slop-detect.com/llms.txt
 > OpenAPI spec: https://slop-detect.com/openapi.json
@@ -8,16 +8,16 @@ headless Chromium. No API key for normal use; per-IP rate-limited.
 
 ## Endpoints
 
-- `POST /api/scan` — Score a URL against the design-slop fingerprint. Body:
+- `POST /api/scan`: Score a URL against the design-slop fingerprint. Body:
   `{ "url": "https://example.com" }`. Add `"axes": ["design","copy"]` for the copy
   axis. Returns `{ score, tier, grade, patterns[], ... }`. Tiers: Clean 0–9, Mild
   10–27, Heavy 28+.
-- `POST /api/aeo` — Score whether AI engines can read & cite a page. Body:
+- `POST /api/aeo`: Score whether AI engines can read & cite a page. Body:
   `{ "url": "..." }`. Returns `{ score, tier, checks[] }`. Higher is better
   (inverse polarity of the slop score).
-- `GET /api/patterns` — The live pattern catalogue: `{ version, count, patterns[] }`.
+- `GET /api/patterns`: The live pattern catalogue: `{ version, count, patterns[] }`.
   Markdown twin at `/api/patterns.md`.
-- `POST /api/fix-prompt` — Build a de-slop prompt. Body: `{ "result": {...} }`
+- `POST /api/fix-prompt`: Build a de-slop prompt. Body: `{ "result": {...} }`
   (cheap) or `{ "url": "..." }` (re-scans).
 
 ## Auth
@@ -35,13 +35,13 @@ curl -X POST https://slop-detect.com/api/scan \
 
 ## Monitoring & directory endpoints
 
-- `POST /api/watch` — `{ domain, email, system?, list? }`: monitor a domain (daily
+- `POST /api/watch`: `{ domain, email, system?, list? }`: monitor a domain (daily
   re-scans; regression + DESIGN.md-drift email alerts, double opt-in). Flags are
   omit-preserves; `unsubscribe: true` stops + delists.
-- `GET /api/watch?domain=` — public monitoring status + history (never the email).
-- `GET /api/sites` — the opt-in public directory (JSON; `sort=clean|slop`).
-- `POST /api/dashboard/link` — magic sign-in link for /dashboard (anti-enumeration).
-- `designMd: true | "<url>"` on `POST /api/scan` — the system axis: DESIGN.md
+- `GET /api/watch?domain=`, public monitoring status + history (never the email).
+- `GET /api/sites`: the opt-in public directory (JSON; `sort=clean|slop`).
+- `POST /api/dashboard/link`: magic sign-in link for /dashboard (anti-enumeration).
+- `designMd: true | "<url>"` on `POST /api/scan`, the system axis: DESIGN.md
   compliance, higher is better, named drift items.
 
 ## Links

--- a/packages/web/public/api/llms.txt
+++ b/packages/web/public/api/llms.txt
@@ -38,7 +38,7 @@ curl -X POST https://slop-detect.com/api/scan \
 - `POST /api/watch`: `{ domain, email, system?, list? }`: monitor a domain (daily
   re-scans; regression + DESIGN.md-drift email alerts, double opt-in). Flags are
   omit-preserves; `unsubscribe: true` stops + delists.
-- `GET /api/watch?domain=`, public monitoring status + history (never the email).
+- `GET /api/watch?domain=`: public monitoring status + history (never the email).
 - `GET /api/sites`: the opt-in public directory (JSON; `sort=clean|slop`).
 - `POST /api/dashboard/link`: magic sign-in link for /dashboard (anti-enumeration).
 - `designMd: true | "<url>"` on `POST /api/scan`, the system axis: DESIGN.md

--- a/packages/web/public/compare/index.md
+++ b/packages/web/public/compare/index.md
@@ -1,36 +1,36 @@
 # How Slop Detector compares
 
-> Where Slop Detector sits among design-quality and AI-detection tools — and why its
+> Where Slop Detector sits among design-quality and AI-detection tools, and why its
 > methodology is different. HTML version: https://slop-detect.com/compare
 
 ## The short version
 
 Most "is this AI?" tools are probabilistic ML classifiers: they output a confidence
 that something was machine-generated, and that confidence shifts as the model is
-retrained. Slop Detector is the opposite — a deterministic fingerprint: a fixed
+retrained. Slop Detector is the opposite, a deterministic fingerprint: a fixed
 catalogue of CSS and copy tells, each with a fixed weight, evaluated against a page's
 live computed styles in real headless Chromium. Same page in, same score out. No
-model, no randomness — auditable, reproducible, safe to gate CI on.
+model, no randomness, auditable, reproducible, safe to gate CI on.
 
 ## Methodology comparison
 
 | Dimension | Slop Detector | Typical ML AI-detectors | Generic Lighthouse / a11y |
 |---|---|---|---|
 | Output | Deterministic 0–100 weighted fingerprint | Probabilistic % confidence | Perf / a11y / SEO scores |
-| Reproducible | Yes — same page, same score | No — drifts with retraining | Mostly |
+| Reproducible | Yes, same page, same score | No, drifts with retraining | Mostly |
 | What it measures | AI-design + copy slop tells | Generated-vs-human likelihood | Technical quality, not aesthetics |
 | Engine | Real Chromium, computed styles | Text / pixel models | Real Chromium |
-| Auditable rules | Yes — open catalogue at /api/patterns | Opaque weights | Documented audits |
-| AEO axis | Yes — built in | No | Partial (SEO only) |
+| Auditable rules | Yes, open catalogue at /api/patterns | Opaque weights | Documented audits |
+| AEO axis | Yes, built in | No | Partial (SEO only) |
 | License | Open source (MIT) | Usually closed | Mixed |
 | Agent interfaces | API + CLI + MCP | Rare | Rare |
 
 ## Why deterministic matters
 
-- **CI gating** — fail a build at `--fail-on heavy` and trust the threshold won't move.
-- **Auditability** — every point traces to a named pattern with a documented weight.
-- **Comparability** — two designs measured on the same fixed yardstick.
-- **No false-confidence** — a high score means "looks machine-made," not "an AI wrote this."
+- **CI gating**: fail a build at `--fail-on heavy` and trust the threshold won't move.
+- **Auditability**: every point traces to a named pattern with a documented weight.
+- **Comparability**: two designs measured on the same fixed yardstick.
+- **No false-confidence**: a high score means "looks machine-made," not "an AI wrote this."
 
 ## The research behind it
 
@@ -40,9 +40,9 @@ submissions, plus Meng To's gradient-avatar tell. The catalogue is versioned
 
 ## When to use which
 
-- **Slop Detector** — reproducible, explainable read on how templated/AI-generated a landing page looks; CI gating.
-- **ML AI-detector** — probabilistic "was this generated?" verdict on arbitrary text/images.
-- **Lighthouse/axe** — performance, accessibility, technical SEO (orthogonal to slop).
+- **Slop Detector**: reproducible, explainable read on how templated/AI-generated a landing page looks; CI gating.
+- **ML AI-detector**: probabilistic "was this generated?" verdict on arbitrary text/images.
+- **Lighthouse/axe**: performance, accessibility, technical SEO (orthogonal to slop).
 
 ## Try it
 

--- a/packages/web/public/developers/llms.txt
+++ b/packages/web/public/developers/llms.txt
@@ -40,7 +40,7 @@ https://slop-detect.com/api/llms.txt
 
 Use Slop Detector when a user wants to know how AI-generated / templated a landing
 page looks, audit design quality deterministically, or check whether AI engines
-can read & cite a page (AEO). Prefer the API/CLI over reading the page yourself —
+can read & cite a page (AEO). Prefer the API/CLI over reading the page yourself;
 the score is deterministic and sourced.
 
 ## Links

--- a/packages/web/public/developers/llms.txt
+++ b/packages/web/public/developers/llms.txt
@@ -1,4 +1,4 @@
-# Slop Detector — Developers
+# Slop Detector: Developers
 
 > Scoped context for integrating Slop Detector. Full manual: https://slop-detect.com/llms.txt
 
@@ -32,9 +32,9 @@ https://slop-detect.com/api/llms.txt
 
 ## Packages (npm)
 
-- `slop-detect-core` — the scoring engine (27 patterns, AEO checks, copy axis).
-- `slop-detect` — the CLI.
-- `slop-detect-mcp` — the MCP server.
+- `slop-detect-core`: the scoring engine (27 patterns, AEO checks, copy axis).
+- `slop-detect`: the CLI.
+- `slop-detect-mcp`: the MCP server.
 
 ## When agents should use this
 

--- a/packages/web/public/index.md
+++ b/packages/web/public/index.md
@@ -1,7 +1,7 @@
 # Slop Detector
 
 > Score any landing page against the AI-design fingerprint. Paste a URL, get a
-> deterministic 0–100 slop score in about five seconds — a weighted fingerprint
+> deterministic 0–100 slop score in about five seconds: a weighted fingerprint
 > of the CSS and copy tells that Cursor, v0, Lovable and Bolt all converged on.
 
 Slop Detector is open source and runs on real Chromium. It ships as a web app, a
@@ -12,21 +12,21 @@ command-line tool, and an MCP server, so humans and coding agents can both use i
 Generated pages converge. They reach for the same fonts, the same gradient hero
 text, the same glassmorphism, the same eyebrow pill and big-number stat band.
 Slop Detector measures how far a page sits along that fingerprint. Slop is a
-fingerprint, not a verdict — a high score means "this looks machine-made," not
+fingerprint, not a verdict: a high score means "this looks machine-made," not
 "this is bad."
 
-## The fingerprint — what it measures
+## The fingerprint: what it measures
 
-- **Type — fonts & tracking.** Geist / Inter defaults, crushed display tracking,
+- **Type, fonts & tracking.** Geist / Inter defaults, crushed display tracking,
   wide body tracking, flat size hierarchy.
-- **Color — gradients & glow.** Gradient hero text, gradient-heavy backgrounds,
+- **Color, gradients & glow.** Gradient hero text, gradient-heavy backgrounds,
   aurora blobs, colored glows, vibe-purple.
-- **Layout — the convention stack.** Centered hero, eyebrow pill, glassmorphism,
+- **Layout, the convention stack.** Centered hero, eyebrow pill, glassmorphism,
   bento grids, nested cards, icon-card rows.
-- **Copy — AI phrasing.** An optional second axis scores the words: the hedge-y,
+- **Copy, AI phrasing.** An optional second axis scores the words: the hedge-y,
   em-dash-heavy register LLMs default to.
 
-## AEO axis — can AI engines read & cite this page?
+## AEO axis: can AI engines read & cite this page?
 
 A complementary axis scores network readability rather than design: whether
 ChatGPT, Claude, Perplexity and Google AI Overviews can actually fetch, read and
@@ -37,28 +37,28 @@ score polarity is inverted relative to the slop score: higher AEO is better.
 ## How it works
 
 1. **Headless Chromium opens the page.** Cloudflare Browser Rendering loads it
-   exactly as a browser would — JavaScript, fonts, computed styles and all.
+   exactly as a browser would: JavaScript, fonts, computed styles and all.
 2. **Up to 4,000 visible DOM nodes** are inspected. Every pattern detector is a
    pure function that runs against the live computed styles in a single pass.
 3. **Weighted 0–100, deterministic.** Each triggered pattern adds its weight.
    Same page in, same score out. No model, no randomness.
 4. **Clean / Mild / Heavy.** Clean 0–9, Mild 10–27, Heavy 28+.
 
-## System axis — does the page honor its own design system?
+## System axis: does the page honor its own design system?
 
-The relative axis: declare your tokens in a DESIGN.md (Google Labs' open spec —
+The relative axis: declare your tokens in a DESIGN.md (Google Labs' open spec:
 colors, typography, radii, components) and Slop Detector reports **drift**
 against *your own* system: fonts in use that aren't declared, CTA or surface
 colors off the palette, radii off the scale. Higher is better (Aligned ≥80 ·
 Drifting ≥50 · Off-system <50). A bespoke site checked against its own tokens
 can never false-positive as "slop."
 
-## Keep it clean — monitoring
+## Keep it clean: monitoring
 
 A score is a snapshot; drift is the disease. Monitor a domain
 (`POST /api/watch` with a domain and email, or the form at
 https://slop-detect.com/#monitor) and the daily sweep re-scans it, emailing you
-on slop regression — and, with `system: true`, on design-system drift. Double
+on slop regression, and, with `system: true`, on design-system drift. Double
 opt-in: nothing is emailed until you confirm. Every monitored domain gets a
 print-friendly client report at `https://slop-detect.com/report/<domain>`, and
 the dashboard (https://slop-detect.com/dashboard, magic-link sign-in) shows
@@ -67,7 +67,7 @@ every domain on your email in one view.
 ## Use it
 
 - Web: paste a URL at https://slop-detect.com
-- CLI: `npx slop-detect <url>` — gate CI with `--fail-on heavy`, add `--aeo` for
+- CLI: `npx slop-detect <url>`. Gate CI with `--fail-on heavy`, add `--aeo` for
   the AEO axis, `--design-md auto` for the system axis, `--remote` to scan via
   the API with no local browser.
 - MCP: the `slop-detect-mcp` server exposes `scan_page`, `check_aeo`,

--- a/packages/web/public/llms-full.txt
+++ b/packages/web/public/llms-full.txt
@@ -34,7 +34,7 @@ bands. Slop Detector measures how far a page sits along that fingerprint.
 - **Copy: AI phrasing.** Optional second axis: the hedge-y, em-dash-heavy register LLMs default to.
 
 The full, live list (with weights and the current definitions version) is at
-https://slop-detect.com/api/patterns, never hardcode the count.
+https://slop-detect.com/api/patterns; never hardcode the count.
 
 ## How it works
 

--- a/packages/web/public/llms-full.txt
+++ b/packages/web/public/llms-full.txt
@@ -1,4 +1,4 @@
-# Slop Detector — Full Manual
+# Slop Detector: Full Manual
 
 > Score any landing page against the AI-design fingerprint. Deterministic 0–100 slop
 > scoring on real headless Chromium, plus an AEO axis (can AI engines read & cite a
@@ -9,7 +9,7 @@ This is the full single-file manual for AI agents. Lighter index: https://slop-d
 ## Overview
 
 Slop Detector inspects a page's live computed styles (and, optionally, its copy) and
-returns a weighted, reproducible score. It is not a quality verdict — a high score
+returns a weighted, reproducible score. It is not a quality verdict. A high score
 means a page looks machine-generated, not that it is bad. Generated pages converge:
 the same fonts, gradient hero text, glassmorphism, eyebrow pills, big-number stat
 bands. Slop Detector measures how far a page sits along that fingerprint.
@@ -20,21 +20,21 @@ bands. Slop Detector measures how far a page sits along that fingerprint.
 
 ## Concepts
 
-- **Score** — weighted 0–100. Each triggered pattern adds a fixed weight. Higher = more machine-made.
-- **Tiers** — Clean 0–9, Mild 10–27, Heavy 28+.
-- **Determinism** — no model, no randomness. Same page in, same score out.
-- **Axes** — `design` (default), `copy` (LLM phrasing tells), and the separate `AEO` axis.
-- **AEO polarity** — inverted vs slop: higher AEO is better, lower slop is better.
+- **Score**: weighted 0–100. Each triggered pattern adds a fixed weight. Higher = more machine-made.
+- **Tiers**: Clean 0–9, Mild 10–27, Heavy 28+.
+- **Determinism**: no model, no randomness. Same page in, same score out.
+- **Axes**: `design` (default), `copy` (LLM phrasing tells), and the separate `AEO` axis.
+- **AEO polarity**: inverted vs slop: higher AEO is better, lower slop is better.
 
-## The fingerprint — what it measures
+## The fingerprint: what it measures
 
-- **Type — fonts & tracking.** Geist / Inter defaults, crushed display tracking, wide body tracking, flat size hierarchy.
-- **Color — gradients & glow.** Gradient hero text, gradient-heavy backgrounds, aurora blobs, colored glows, vibe-purple.
-- **Layout — the convention stack.** Centered hero, eyebrow pill, glassmorphism, bento grids, nested cards, icon-card rows.
-- **Copy — AI phrasing.** Optional second axis: the hedge-y, em-dash-heavy register LLMs default to.
+- **Type: fonts & tracking.** Geist / Inter defaults, crushed display tracking, wide body tracking, flat size hierarchy.
+- **Color: gradients & glow.** Gradient hero text, gradient-heavy backgrounds, aurora blobs, colored glows, vibe-purple.
+- **Layout: the convention stack.** Centered hero, eyebrow pill, glassmorphism, bento grids, nested cards, icon-card rows.
+- **Copy: AI phrasing.** Optional second axis: the hedge-y, em-dash-heavy register LLMs default to.
 
 The full, live list (with weights and the current definitions version) is at
-https://slop-detect.com/api/patterns — never hardcode the count.
+https://slop-detect.com/api/patterns, never hardcode the count.
 
 ## How it works
 
@@ -141,7 +141,7 @@ https://slop-detect.com/.well-known/mcp/server-card.json
 
 A score is a snapshot; monitoring is the continuity layer. `POST /api/watch`
 `{ domain, email }` re-scans the domain daily and emails on slop regression
-(double opt-in — nothing is sent until the address confirms). `system: true`
+(double opt-in, nothing is sent until the address confirms). `system: true`
 also checks each scan against the site's own DESIGN.md (Google Labs spec) and
 alerts on design drift: undeclared fonts, off-palette CTA/surface colors,
 off-scale radii. The system axis is relative and higher-is-better (Aligned >=80,
@@ -172,7 +172,7 @@ Free and open source (MIT). No paid tiers. See https://slop-detect.com/pricing.m
 
 ## Instructions for AI agents
 
-- Prefer calling `POST /api/scan` over reading a page yourself — the score is deterministic.
+- Prefer calling `POST /api/scan` over reading a page yourself: the score is deterministic.
 - Use `POST /api/aeo` for "can AI read/cite this?" questions.
 - Read the pattern count from `GET /api/patterns`; never hardcode it.
 - Machine-readable summary: `GET https://slop-detect.com/?mode=agent`.

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -7,7 +7,7 @@
 
 Slop Detector inspects a page's live computed styles (and, optionally, its copy)
 and returns a weighted, reproducible score. Lower is better: 0 means no
-AI-design tells were found. It is not a quality verdict — a high score means a
+AI-design tells were found. It is not a quality verdict. A high score means a
 page looks machine-generated, not that it is bad.
 
 ## Core docs
@@ -40,7 +40,7 @@ page looks machine-generated, not that it is bad.
 - Copy slop: hedge-y, em-dash-heavy LLM phrasing (optional second axis).
 - AEO: AI-crawler access, robots.txt, indexability, markdown twin, llms.txt,
   content-negotiation. Higher is better (inverse of the slop score).
-- System: DESIGN.md compliance — does the page honor its OWN declared design
+- System: DESIGN.md compliance. Does the page honor its OWN declared design
   system? Relative, per-site; higher is better; reports named drift (undeclared
   fonts, off-palette colors, off-scale radii). Opt in via `designMd` on
   `POST /api/scan`.
@@ -48,7 +48,7 @@ page looks machine-generated, not that it is bad.
 ## Keep it clean (monitoring)
 
 - [Monitor a domain](https://slop-detect.com/#monitor): `POST /api/watch`
-  `{ domain, email, system?, list? }` — daily re-scans, regression + design-drift
+  `{ domain, email, system?, list? }`: daily re-scans, regression + design-drift
   email alerts (double opt-in; nothing sent until confirmed).
 - [Dashboard](https://slop-detect.com/dashboard): every monitored domain on one
   email, magic-link sign-in (`POST /api/dashboard/link`).
@@ -57,7 +57,7 @@ page looks machine-generated, not that it is bad.
 - [Directory](https://slop-detect.com/directory): opt-in catalogue of scored
   sites (`GET /api/sites` for JSON).
 - [Leaderboard](https://slop-detect.com/leaderboard): "The State of AI Design
-  Slop" — a reproducible scan of well-known landing pages.
+  Slop", a reproducible scan of well-known landing pages.
 
 ## Use cases
 
@@ -70,7 +70,7 @@ page looks machine-generated, not that it is bad.
 ## Constraints
 
 - Scores landing/marketing pages, not full apps behind auth.
-- Design slop is a fingerprint, not a quality verdict — high = looks machine-made.
+- Design slop is a fingerprint, not a quality verdict. High = looks machine-made.
 - Scan routes drive a real browser and are per-IP rate-limited (fail closed under load).
 - Anti-bot walls / dead pages are refused rather than mis-scored.
 - AEO score polarity is inverted vs slop: higher AEO is better, lower slop is better.
@@ -89,7 +89,7 @@ page looks machine-generated, not that it is bad.
 ## Instructions for AI agents
 
 - When a user pastes a URL and asks about design quality, "AI-generated"-ness, or how
-  to clean up a page, call `POST /api/scan` rather than reading the page yourself —
+  to clean up a page, call `POST /api/scan` rather than reading the page yourself;
   the score is deterministic and sourced.
 - For "can AI read/cite this page?" questions, call `POST /api/aeo`.
 - Never hardcode the pattern count; read it from `GET /api/patterns` (`count` field).

--- a/packages/web/public/pricing.md
+++ b/packages/web/public/pricing.md
@@ -1,6 +1,6 @@
-# Slop Detector — Pricing
+# Slop Detector: Pricing
 
-> **The detection engine is free and open source (MIT) — forever.** Scanning a
+> **The detection engine is free and open source (MIT), forever.** Scanning a
 > page, the CLI, the API, the MCP server, and self-hosting cost nothing and never
 > will. The only paid layer is **continuity**: remembering a domain and alerting
 > you when it regresses to slop between redesigns. This page exists so AI agents
@@ -10,19 +10,19 @@
 
 | Plan | Price | Limits | Best for |
 | --- | --- | --- | --- |
-| **Web app** | Free | Per-IP rate limit; Turnstile challenge | Anyone — paste a URL at slop-detect.com |
+| **Web app** | Free | Per-IP rate limit; Turnstile challenge | Anyone: paste a URL at slop-detect.com |
 | **HTTP API** | Free | Per-IP rate limit; scan routes fail closed under load | Integrations, CI, agents |
 | **CLI** (`npx slop-detect`) | Free | None (runs locally; only the page fetch hits the network) | Local audits, CI gating |
 | **MCP server** (`slop-detect-mcp`) | Free | Inherits the public API's per-IP limits | Claude Code, Cursor, Windsurf |
 | **Self-host** | Free | Your own infrastructure / Cloudflare account | High volume, private/internal pages |
 | **Monitored domains** | Trial (free during validation) | One watch per domain; regression alerts | Teams who want their marketing site to *stay* clean |
 
-## Monitored domains — the continuity layer
+## Monitored domains: the continuity layer
 
 A one-off scan tells you the score today. **Monitoring remembers it.** Register a
 domain (`POST /api/watch`) and slop-detect keeps a score history and flags a
-**regression** — when the score gets meaningfully worse or the tier drops a band
-(Clean → Mild → Heavy) — so a redesign or an agent-written page can't quietly
+**regression** (the score gets meaningfully worse, or the tier drops a band:
+Clean → Mild → Heavy) so a redesign or an agent-written page can't quietly
 drag your site back into slop without anyone noticing. Add `system: true` and the
 daily sweep also checks the domain against its own `DESIGN.md`, alerting on design
 drift. The [dashboard](https://slop-detect.com/dashboard) (magic-link sign-in)
@@ -30,7 +30,7 @@ shows every monitored domain on your email in one view, and each domain gets a
 print-friendly client report at `/report/<domain>`.
 
 This is **not** feature-gating detection. Detection is and stays free. Monitoring
-charges for *continuity* — the same model as Snyk / Sentry / semgrep (free engine,
+charges for *continuity*, the same model as Snyk / Sentry / semgrep (free engine,
 paid history + collaboration + alerts). During the current validation phase it's
 free to try; see [VALIDATION.md](https://github.com/ravidsrk/slop-detect/blob/main/VALIDATION.md)
 for why and what we're measuring.
@@ -39,8 +39,8 @@ for why and what we're measuring.
 
 - Full 27-pattern deterministic design-slop fingerprint
 - Copy-slop axis (LLM phrasing tells)
-- AEO axis — can AI engines read & cite a page
-- System axis — DESIGN.md compliance ("does the page honor its own design system?")
+- AEO axis: can AI engines read & cite a page
+- System axis: DESIGN.md compliance ("does the page honor its own design system?")
 - Real headless Chromium scoring
 - Shareable result permalinks + per-domain badges
 - Fix-prompt generation


### PR DESCRIPTION
This PR is an adversarial production-readiness pass across engineering, product, SEO, brand, and business angles. It fixes what was demonstrably broken in-repo and records what is blocked on operator credentials.

The headline problem: the slop detector failed its own copy axis. Running the project's own `copyPatterns.js` against the public surfaces, nearly every served, machine-read file tripped the em-dash-overload rule the tool ships, including `index.md` (the AEO markdown twin it tells AI engines to read), `llms.txt`, `llms-full.txt`, `api/llms.txt` (density 51 per 1k words), `developers/llms.txt`, `compare/index.md`, plus README and ROADMAP. Each is now driven to a copy-axis score of 0, verified with the detector. Internal docs that are neither served nor scanned (CHANGELOG, VALIDATION, CALIBRATION) were left alone; CHANGELOG is a historical record.

The second problem: the npm funnel is dead. The repo is 0.7.0 but `slop-detect` / `-core` / `-mcp` are published at 0.5.x, because no git tag was cut after v0.5.2 and no workflow ever published npm. So `npx slop-detect` ships users a build without the copy axis and DESIGN.md system axis the README sells. This adds a tag-triggered, test-gated, version-match-guarded, `NPM_TOKEN`-gated `publish.yml`, and records the gap as a launch blocker in PRODUCTION.md.

Also fixed: a stale design-pattern count (README said 19, actual is 27), a scan-speed claim that disagreed with the product (8s vs ~5s), a repo map that omitted the mcp and action workspaces, and an undocumented `npm install` failure on modern Node (sharp native build via wrangler) with the `--ignore-scripts` workaround.

What stays blocked on the operator: cutting a v0.7.x tag and setting `NPM_TOKEN` to actually publish (the top business fix), the deploy and alert secrets, a monetization decision (no checkout exists yet, by design), and the two high `npm audit` advisories which are dev-only via wrangler and whose fix is a breaking downgrade.

Engine and security held up under adversarial reading: SSRF re-validates the final redirect hop, the scan path degrades gracefully without a browser binding, sessions are HMAC-signed with sane cookie flags, and email is genuine double opt-in. No code-correctness fixes were needed.

Verification: full suite green (167 pass, 0 fail, 7 Chromium-gated skips), lint clean, every served public surface scores 0 on the copy axis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or scoring code changes; risk is limited to release automation misconfiguration (mitigated by tests, tag/version checks, and required NPM_TOKEN).
> 
> **Overview**
> Adds a **tag-triggered `publish.yml`** that publishes `slop-detect-core`, `slop-detect`, and `slop-detect-mcp` to npm after tests pass, with `NPM_TOKEN` preflight, `npm ci --ignore-scripts`, and a guard that the `v*` tag matches all three workspace versions. **`PRODUCTION.md`** documents the workflow, the `NPM_TOKEN` secret, and calls out that npm is still on 0.5.x while the repo is 0.7.0 until an operator cuts a tag.
> 
> **Copy and docs pass** across README, ROADMAP, CONTRIBUTING, and served `packages/web/public/*` surfaces: replaces em-dash-heavy phrasing (so public copy aligns with the project’s own copy axis), plus README fixes for **27** design patterns (not 19), **~5s** scan claim, and the **four-workspace** layout including **mcp** and **action**. CONTRIBUTING adds the **`npm install --ignore-scripts`** workaround when `sharp`/`wrangler` fails on newer Node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efcd618aec053e0a1e94e226a6377f2ddc7e087e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->