### PR TITLE
Score hub PR1: record every scan into per-domain history + global stats

### DIFF
--- a/packages/web/functions/_shared.js
+++ b/packages/web/functions/_shared.js
@@ -339,6 +339,99 @@ async function appendHistory(kv, domain, point) {
   return capped;
 }
 
+// Build the compact timeline point a scan contributes. Shared by the always-on
+// recorder and the watch-specific one so the two can never diverge.
+function historyPoint(slim) {
+  const p = {
+    id: slim.id,
+    score: slim.score,
+    grade: slim.grade,
+    tier: slim.tier,
+    createdAt: slim.createdAt || new Date().toISOString()
+  };
+  if (slim.system) p.sys = { score: slim.system.score, tier: slim.system.tier };
+  return p;
+}
+
+// ── Global score distribution (peer percentile without KV enumeration) ────────
+// One 101-bucket histogram (index = slop score 0..100, value = count), bumped
+// once per persisted scan. Lets the score page answer "cleaner than X% of N
+// scanned sites" and the homepage show live aggregate stats, without ever
+// enumerating per-domain keys. Read-modify-write is not atomic in KV, so counts
+// are approximate under heavy concurrency, which is fine for a percentile.
+const STATS_DIST_KEY = 'stats:dist';
+
+export async function getScoreDistribution(kv) {
+  const empty = () => new Array(101).fill(0);
+  if (!kv) return empty();
+  const raw = await kv.get(STATS_DIST_KEY);
+  if (!raw) return empty();
+  try {
+    const a = JSON.parse(raw);
+    return Array.isArray(a) && a.length === 101 ? a.map(n => Number(n) || 0) : empty();
+  } catch { return empty(); }
+}
+
+async function bumpScoreStats(kv, score) {
+  if (!kv || typeof score !== 'number' || !Number.isFinite(score)) return;
+  const dist = await getScoreDistribution(kv);
+  const i = Math.max(0, Math.min(100, Math.round(score)));
+  dist[i] = (dist[i] || 0) + 1;
+  await kv.put(STATS_DIST_KEY, JSON.stringify(dist)); // durable: no TTL
+}
+
+// Aggregate a distribution into the headline stats the UI shows. Tier bands
+// match the engine: Clean 0..9, Mild 10..27, Heavy 28+.
+export function summarizeStats(dist) {
+  let count = 0, sum = 0, clean = 0, mild = 0, heavy = 0;
+  for (let i = 0; i <= 100; i++) {
+    const n = (dist && dist[i]) || 0;
+    count += n; sum += i * n;
+    if (i <= 9) clean += n; else if (i <= 27) mild += n; else heavy += n;
+  }
+  return {
+    count,
+    avgScore: count ? Math.round((sum / count) * 10) / 10 : 0,
+    slopShare: count ? Math.round(((mild + heavy) / count) * 100) : 0,
+    clean, mild, heavy
+  };
+}
+
+export async function getStats(kv) {
+  return summarizeStats(await getScoreDistribution(kv));
+}
+
+// "Cleaner than X% of N sites": the share of scans scoring strictly WORSE
+// (higher) than `score`. Lower slop score is cleaner, so a higher percentile is
+// better. Returns { count, cleanerThanPct } (pct is null when there's no data).
+export function percentileFromDistribution(dist, score) {
+  let count = 0, worse = 0;
+  const s = Math.max(0, Math.min(100, Math.round(Number(score) || 0)));
+  for (let i = 0; i <= 100; i++) {
+    const n = (dist && dist[i]) || 0;
+    count += n;
+    if (i > s) worse += n;
+  }
+  return { count, cleanerThanPct: count ? Math.round((worse / count) * 100) : null };
+}
+
+export async function percentileForScore(kv, score) {
+  return percentileFromDistribution(await getScoreDistribution(kv), score);
+}
+
+// Record EVERY persisted scan into the per-domain timeline + the global stats,
+// regardless of whether the domain is monitored. This is what lets a public
+// /score/<domain> page chart history and rank against peers. Watch
+// baseline/regression stays in recordScanForWatch, layered on top; its own
+// appendHistory call de-dupes against this one by scan id.
+export async function recordScan(kv, slim) {
+  if (!kv || !slim || !slim.domain) return;
+  await Promise.all([
+    appendHistory(kv, slim.domain, historyPoint(slim)),
+    bumpScoreStats(kv, slim.score)
+  ]);
+}
+
 // Decide whether `current` is a regression from `baseline`. Pure — unit-tested.
 export function isRegression(baseline, current) {
   if (!baseline || !current) return false;
@@ -373,16 +466,9 @@ export async function recordScanForWatch(kv, slim) {
   const watch = await getWatch(kv, slim.domain);
   if (!watch) return null;
 
-  const point = {
-    id: slim.id,
-    score: slim.score,
-    grade: slim.grade,
-    tier: slim.tier,
-    createdAt: slim.createdAt || new Date().toISOString()
-  };
   // History points carry a compact system reading when the axis ran, so the
   // report page can chart compliance over time alongside the slop score.
-  if (slim.system) point.sys = { score: slim.system.score, tier: slim.system.tier };
+  const point = historyPoint(slim);
   await appendHistory(kv, slim.domain, point);
 
   // Establish the baseline on the first observed scan if registration happened

--- a/packages/web/functions/api/scan.js
+++ b/packages/web/functions/api/scan.js
@@ -23,7 +23,7 @@ import {
   scoreCopy,
   combineAxes
 } from 'slop-detect-core';
-import { newId, slimResult, saveResult, validateScanUrl, isAllowedUrl, recordScanForWatch } from '../_shared.js';
+import { newId, slimResult, saveResult, recordScan, validateScanUrl, isAllowedUrl, recordScanForWatch } from '../_shared.js';
 import { report } from '../_report.js';
 
 // Normalize requested axes. Default: design only (backward-compatible).
@@ -216,8 +216,11 @@ export async function onRequestPost({ request, env }) {
         await saveResult(env.RESULTS, slim);
         result.id = id;
         result.resultUrl = `${new URL(request.url).origin}/r/${id}`;
-        // If this domain is being monitored, append the point to its history and
-        // recompute regression. Best-effort: monitoring must never break a scan.
+        // Record every scan into the per-domain timeline + global score stats
+        // (not just monitored domains) so /score/<domain> can chart history and
+        // rank against peers. Best-effort: persistence must never break a scan.
+        await recordScan(env.RESULTS, slim);
+        // If this domain is being monitored, refresh baseline/regression on top.
         const monitoring = await recordScanForWatch(env.RESULTS, slim);
         if (monitoring) result.monitoring = monitoring;
       } catch (e) {

--- a/packages/web/test/stats.test.js
+++ b/packages/web/test/stats.test.js
@@ -1,0 +1,131 @@
+// Tests for the always-on scan recorder + the global score distribution that
+// power the per-domain /score page (history for ALL domains, peer percentile).
+// Driven against the same in-memory KV mock the watch tests use.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  recordScan,
+  recordScanForWatch,
+  getHistory,
+  getStats,
+  getScoreDistribution,
+  summarizeStats,
+  percentileFromDistribution,
+  percentileForScore
+} from '../functions/_shared.js';
+
+function makeKv(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    async get(k) { return store.has(k) ? store.get(k) : null; },
+    async put(k, v) { store.set(k, v); },
+    async delete(k) { store.delete(k); }
+  };
+}
+
+function slim(over = {}) {
+  return {
+    id: 'aaaa1111',
+    domain: 'example.com',
+    score: 8,
+    grade: 'A-',
+    tier: 'Clean',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    ...over
+  };
+}
+
+// ── history for ALL domains (the core PR1 behavior) ──────────────────────────
+test('recordScan appends a history point for an UNWATCHED domain', async () => {
+  const kv = makeKv();
+  await recordScan(kv, slim({ id: 'p1', score: 8, tier: 'Clean' }));
+  const hist = await getHistory(kv, 'example.com');
+  assert.equal(hist.length, 1);
+  assert.equal(hist[0].id, 'p1');
+  assert.equal(hist[0].score, 8);
+  assert.equal(hist[0].tier, 'Clean');
+});
+
+test('recordScan grows the timeline across re-scans and de-dupes by id', async () => {
+  const kv = makeKv();
+  await recordScan(kv, slim({ id: 'p1', score: 8 }));
+  await recordScan(kv, slim({ id: 'p1', score: 8 }));   // same scan id, no-op
+  await recordScan(kv, slim({ id: 'p2', score: 30, tier: 'Heavy', grade: 'D' }));
+  const hist = await getHistory(kv, 'example.com');
+  assert.deepEqual(hist.map(h => h.id), ['p1', 'p2']);
+});
+
+test('recordScan then recordScanForWatch does not double-append (production path)', async () => {
+  // A watched domain: scan.js calls recordScan (all-domains) then
+  // recordScanForWatch (watch baseline). The second append must de-dupe.
+  const kv = makeKv({
+    'w:example.com': JSON.stringify({ domain: 'example.com', email: 'a@b.com' })
+  });
+  const s = slim({ id: 'p1', score: 8 });
+  await recordScan(kv, s);
+  await recordScanForWatch(kv, s);
+  const hist = await getHistory(kv, 'example.com');
+  assert.equal(hist.length, 1, 'same scan id appended once across both recorders');
+});
+
+test('recordScan carries the system reading when the axis ran', async () => {
+  const kv = makeKv();
+  await recordScan(kv, slim({ id: 'p1', system: { score: 72, tier: 'Aligned' } }));
+  const hist = await getHistory(kv, 'example.com');
+  assert.deepEqual(hist[0].sys, { score: 72, tier: 'Aligned' });
+});
+
+// ── global score distribution + stats ────────────────────────────────────────
+test('recordScan bumps the score distribution; getStats aggregates it', async () => {
+  const kv = makeKv();
+  await recordScan(kv, slim({ id: 'a', domain: 'a.com', score: 4, tier: 'Clean' }));   // Clean
+  await recordScan(kv, slim({ id: 'b', domain: 'b.com', score: 20, tier: 'Mild' }));   // Mild
+  await recordScan(kv, slim({ id: 'c', domain: 'c.com', score: 40, tier: 'Heavy' }));  // Heavy
+  const stats = await getStats(kv);
+  assert.equal(stats.count, 3);
+  assert.equal(stats.clean, 1);
+  assert.equal(stats.mild, 1);
+  assert.equal(stats.heavy, 1);
+  assert.equal(stats.avgScore, Math.round(((4 + 20 + 40) / 3) * 10) / 10);
+  assert.equal(stats.slopShare, 67); // 2 of 3 score >= 10
+});
+
+test('getScoreDistribution returns a 101-bucket array, empty when unseeded', async () => {
+  const kv = makeKv();
+  const dist = await getScoreDistribution(kv);
+  assert.equal(dist.length, 101);
+  assert.ok(dist.every(n => n === 0));
+});
+
+test('summarizeStats handles an empty distribution without NaN', () => {
+  const s = summarizeStats(new Array(101).fill(0));
+  assert.deepEqual(s, { count: 0, avgScore: 0, slopShare: 0, clean: 0, mild: 0, heavy: 0 });
+});
+
+// ── peer percentile ("cleaner than X% of N sites") ───────────────────────────
+test('percentileFromDistribution counts sites scoring strictly worse', () => {
+  const dist = new Array(101).fill(0);
+  dist[5] = 1; dist[10] = 1; dist[20] = 1; dist[50] = 1; // 4 sites
+  // score 10 -> sites scoring > 10 are {20,50} = 2 of 4 = 50% cleaner-than
+  assert.deepEqual(percentileFromDistribution(dist, 10), { count: 4, cleanerThanPct: 50 });
+  // a 5 (cleanest) is cleaner than the other 3 of 4 = 75%
+  assert.equal(percentileFromDistribution(dist, 5).cleanerThanPct, 75);
+  // the worst (50) is cleaner than 0%
+  assert.equal(percentileFromDistribution(dist, 50).cleanerThanPct, 0);
+});
+
+test('percentile is null with no data, and clamps out-of-range scores', () => {
+  assert.deepEqual(percentileFromDistribution(new Array(101).fill(0), 8), { count: 0, cleanerThanPct: null });
+  const dist = new Array(101).fill(0); dist[100] = 1;
+  assert.equal(percentileFromDistribution(dist, 999).cleanerThanPct, 0); // clamps to 100
+});
+
+test('percentileForScore reads the live distribution from KV', async () => {
+  const kv = makeKv();
+  await recordScan(kv, slim({ id: 'a', domain: 'a.com', score: 30 }));
+  await recordScan(kv, slim({ id: 'b', domain: 'b.com', score: 5 }));
+  // scoring 5: one site (30) is worse -> cleaner than 50% of 2
+  assert.deepEqual(await percentileForScore(kv, 5), { count: 2, cleanerThanPct: 50 });
+});


### PR DESCRIPTION
This PR is the data-model groundwork for the per-domain score hub (the scan to score to re-scan to backlink loop). It changes no UI.

Today the per-domain timeline (`h:<domain>`) is written only for monitored domains, so an unmonitored scan has no history and there is no cheap way to rank a domain against peers. This adds an always-on recorder so every scan contributes a timeline point and a single global score histogram.

What changes, all backward-compatible, in `packages/web/functions/_shared.js`:
- `recordScan()` appends a `historyPoint` for every persisted scan (de-duped by scan id) and bumps a 101-bucket score distribution (`stats:dist`). `recordScanForWatch` keeps owning watch baseline and regression; its own append de-dupes against `recordScan`.
- `getStats`/`summarizeStats` (count, avg, slop share, tier counts) and `percentileForScore` ('cleaner than X% of N sites') compute from the histogram with no per-domain KV enumeration.
- `api/scan.js` calls `recordScan` in the persistence block (best-effort, never breaks a scan).

Verification: 10 new unit tests cover history for unwatched domains, de-dupe across both recorders, distribution aggregation, and percentile math. Full suite 177 pass / 0 fail, lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds KV writes on every shared scan and a durable global histogram with non-atomic read-modify-write (approximate counts under concurrency); watch behavior stays layered on top with id de-dupe.
> 
> **Overview**
> Adds **always-on scan recording** so every persisted scan (not only monitored domains) writes a per-domain timeline point and updates a single global 101-bucket score histogram in KV (`stats:dist`).
> 
> Introduces **`recordScan`** plus helpers for aggregate stats (`getStats` / `summarizeStats`) and peer ranking (`percentileForScore` — “cleaner than X% of N sites”). Timeline shape is centralized in shared **`historyPoint`**; **`recordScanForWatch`** still handles baseline/regression and reuses that helper, with **`appendHistory`** de-duping by scan id when both run.
> 
> **`api/scan.js`** calls **`recordScan`** in the existing best-effort persistence block before **`recordScanForWatch`**. New unit tests in **`stats.test.js`** cover unwatched history, de-dupe across both recorders, distribution aggregation, and percentile math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9423ac97679637fde84c8445fa7602285dcdd70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->