### PR TITLE
Score hub PR3: homepage hub (live stats + score loop), retire light /landing

### DIFF
--- a/packages/web/functions/api/stats.js
+++ b/packages/web/functions/api/stats.js
@@ -1,0 +1,24 @@
+// GET /api/stats — live aggregate scan stats for the homepage hub.
+//
+// Reads the single global score histogram (stats:dist, bumped once per scan in
+// recordScan) and returns the headline numbers: how many scans are on record,
+// the average score, the share that carry slop, and the tier breakdown. One KV
+// read, no per-domain enumeration. Public, GET (not gated by the middleware).
+
+import { getStats } from '../_shared.js';
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=120, s-maxage=120'
+    }
+  });
+}
+
+export async function onRequestGet({ env }) {
+  if (!env.RESULTS) return json({ count: 0, avgScore: 0, slopShare: 0, clean: 0, mild: 0, heavy: 0 });
+  const stats = await getStats(env.RESULTS).catch(() => null);
+  return json(stats || { count: 0, avgScore: 0, slopShare: 0, clean: 0, mild: 0, heavy: 0 });
+}

--- a/packages/web/public/_redirects
+++ b/packages/web/public/_redirects
@@ -1,0 +1,3 @@
+# The homepage is the hub now (dark, scan + live stats + leaderboard). The old
+# light /landing/ page is retired; send it and its assets to the root.
+/landing/* / 301

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -1121,6 +1121,8 @@
             <button data-url="https://stripe.com">stripe.com</button>
             <button data-url="https://linear.app">linear.app</button>
           </div>
+
+          <div class="hubstats" id="hubStats" hidden style="margin-top:16px;font-family:var(--mono);font-size:12px;color:var(--dim);letter-spacing:-0.01em"></div>
         </div>
 
         <!-- Sample readout: shows the output shape before you scan. Static, decorative. -->
@@ -1362,6 +1364,24 @@
 const $ = (id) => document.getElementById(id);
 const form = $('form'), urlInput = $('url'), goBtn = $('go'),
       statusEl = $('status'), resultEl = $('result');
+
+// ── Live scan stats (homepage hub) ───────────────────────────────────────────
+// Show how many scans are on record, but only once there's enough data to read
+// as momentum rather than "0 scans". One cached GET, no per-domain enumeration.
+(async () => {
+  try {
+    const r = await fetch('/api/stats');
+    if (!r.ok) return;
+    const s = await r.json();
+    if (!s || (s.count || 0) < 50) return;
+    const el = $('hubStats');
+    if (!el) return;
+    const gradeFor = (n) => n<=2?'A+':n<=5?'A':n<=9?'A-':n<=14?'B+':n<=19?'B':n<=23?'B-':n<=27?'C':n<=33?'D+':n<=39?'D':'F';
+    el.textContent = s.count.toLocaleString('en-US') + ' scans scored · avg ' +
+      gradeFor(Math.round(s.avgScore)) + ' (' + s.avgScore + '/100) · ' + s.slopShare + '% carry slop';
+    el.hidden = false;
+  } catch (_) {}
+})();
 
 // ── Live rule catalogue ──────────────────────────────────────────────────────
 // Pull the pattern list + count from /api/patterns so the "N rules" labels and
@@ -1608,6 +1628,7 @@ function render(d, totalMs) {
       <div class="monitor-nudge">keep it clean &rarr;
         <a id="monitorNudgeLink">monitor ${escapeHtml(domainOf(d.finalUrl || d.url))}</a>
         &middot; daily re-scan, drift alerts</div>
+      ${d.resultUrl ? `<div class="monitor-nudge"><a href="/score/${escapeHtml(domainOf(d.finalUrl || d.url))}">${escapeHtml(domainOf(d.finalUrl || d.url))} score page</a> &middot; history, peer rank, live badge &rarr;</div>` : ''}
     </div>
     ${triggered.length ? `
       <div class="pat-section">

--- a/packages/web/public/sitemap.xml
+++ b/packages/web/public/sitemap.xml
@@ -6,11 +6,6 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://slop-detect.com/landing/</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://slop-detect.com/index.md</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/packages/web/test/api-stats.test.js
+++ b/packages/web/test/api-stats.test.js
@@ -1,0 +1,36 @@
+// GET /api/stats — homepage hub aggregate stats. Wraps getStats; verify the
+// handler shape + the no-storage fallback.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequestGet } from '../functions/api/stats.js';
+import { recordScan } from '../functions/_shared.js';
+
+function makeKv() {
+  const s = new Map();
+  return {
+    async get(k) { return s.has(k) ? s.get(k) : null; },
+    async put(k, v) { s.set(k, v); },
+    async delete(k) { s.delete(k); }
+  };
+}
+
+test('GET /api/stats returns aggregate counts from the distribution', async () => {
+  const kv = makeKv();
+  await recordScan(kv, { id: 'a', domain: 'a.com', score: 4, tier: 'Clean' });
+  await recordScan(kv, { id: 'b', domain: 'b.com', score: 30, tier: 'Heavy' });
+  const res = await onRequestGet({ env: { RESULTS: kv } });
+  assert.equal(res.status, 200);
+  const j = await res.json();
+  assert.equal(j.count, 2);
+  assert.equal(j.clean, 1);
+  assert.equal(j.heavy, 1);
+  assert.equal(j.slopShare, 50);
+});
+
+test('GET /api/stats is safe with no storage configured', async () => {
+  const res = await onRequestGet({ env: {} });
+  assert.equal(res.status, 200);
+  const j = await res.json();
+  assert.equal(j.count, 0);
+});


### PR DESCRIPTION
This PR turns the homepage into the hub and unifies the app on one design system. The root page is already dark, so this enhances it in place (keeping the working scan/monitor JS) rather than rewriting it.

- `/api/stats`: live aggregate from the global score histogram added in PR1 (count, average score, slop share, tier counts). One cached KV read, no per-domain enumeration.
- Homepage: a live stats strip under the hero ('N scans scored, avg C, X% carry slop'), shown only once at least 50 scans are on record so a fresh deploy never reads '0'. After a scan, the result now links to `/score/<domain>` to close the loop into the per-domain hub.
- Retire the light `/landing/` page: we unified on the dark app system that /score, /directory, /leaderboard, /report, and /dashboard already share, so `/landing/*` 301-redirects to `/` and is dropped from the sitemap.

Verification: `/api/stats` handler tests (with and without storage); the homepage still scores 0 on the copy axis; the inline scripts parse; full suite 186 pass / 0 fail; lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only public stats and homepage/SEO routing changes; no auth or scan pipeline modifications.
> 
> **Overview**
> Turns the root homepage into the product hub by surfacing **live aggregate scan momentum** and tightening the path from a scan into per-domain score pages, while retiring the separate light **/landing** experience.
> 
> Adds a public **`GET /api/stats`** handler that reads the existing global score histogram via `getStats` (one KV read, 2-minute cache) and returns count, average score, slop share, and tier breakdown, with safe zeroed fallbacks when storage is missing.
> 
> On **`index.html`**, a hidden **`#hubStats`** strip under the hero fetches `/api/stats` and only appears once **`count >= 50`**, showing formatted scan totals and average grade. Post-scan results gain a nudge link to **`/score/<domain>`** when `resultUrl` is present.
> 
> **`/landing/*`** now **301-redirects to `/`** via `_redirects`, and **`/landing/`** is removed from **`sitemap.xml`**. Tests cover the stats handler with KV and without `RESULTS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc334de526eae4820e07354c0a7bf4bc43db1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->