### PR TITLE
Score hub PR4: category-grouped leaderboard + live scan counter

### DIFF
--- a/packages/web/functions/leaderboard.js
+++ b/packages/web/functions/leaderboard.js
@@ -10,10 +10,19 @@
 // Anti-slop by construction: no Inter/Geist, no gradient text, no VibeCode
 // purple — this page should itself score Clean.
 
-import { tierColors, escapeHtml } from './_shared.js';
+import { tierColors, escapeHtml, getStats } from './_shared.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
 
 const ORIGIN = 'https://slop-detect.com';
+
+// Display names + order for the corpus categories (see leaderboard/corpus.json).
+const CATEGORY_NAMES = {
+  'ai-builder': 'AI builders',
+  'saas': 'SaaS & dev tools',
+  'bigtech': 'Big tech',
+  'classic': 'Classic, deliberately plain'
+};
+const CATEGORY_ORDER = ['ai-builder', 'saas', 'bigtech', 'classic'];
 
 async function loadData(request) {
   try {
@@ -23,21 +32,31 @@ async function loadData(request) {
   } catch (_) { return null; }
 }
 
-function chip(tier, label) {
-  const c = tierColors(tier);
-  return `<span class="chip" style="color:${c.fg};border-color:${c.fg}">${escapeHtml(label)}</span>`;
-}
-
-function cleanRow(s, origin) {
+// One ranked row. The domain links into its score hub (history, re-scan, claim),
+// closing the loop instead of dead-ending on the external site.
+function rankRow(s, rank, origin) {
   const c = tierColors(s.tier);
-  const link = s.resultUrl ? `${origin}/r/${escapeHtml(String(s.resultUrl).split('/r/')[1] || '')}` : null;
-  const dom = `<a class="dom" href="https://${escapeHtml(s.domain)}">${escapeHtml(s.domain)}</a>`;
   return `<li class="r">
+    <span class="rank">${rank}</span>
     <span class="g" style="color:${c.fg};border-color:${c.fg}">${escapeHtml(s.grade)}</span>
     <span class="sc">${s.score}<small>/100</small></span>
-    <span class="d">${dom}</span>
-    ${link ? `<a class="scan" href="${link}">scan&nbsp;&rarr;</a>` : ''}
+    <span class="d"><a class="dom" href="${origin}/score/${escapeHtml(s.domain)}">${escapeHtml(s.domain)}</a></span>
   </li>`;
+}
+
+// Group scored sites by category and render each as a cleanest-first ranking.
+function categorySections(sites, origin) {
+  const groups = {};
+  for (const s of sites) (groups[s.category || 'other'] = groups[s.category || 'other'] || []).push(s);
+  const keys = [
+    ...CATEGORY_ORDER.filter((k) => groups[k]),
+    ...Object.keys(groups).filter((k) => !CATEGORY_ORDER.includes(k))
+  ];
+  return keys.map((k) => {
+    const rows = groups[k].slice().sort((a, b) => a.score - b.score)
+      .map((s, i) => rankRow(s, i + 1, origin)).join('');
+    return `<h2>${escapeHtml(CATEGORY_NAMES[k] || k)}</h2><ol class="rows">${rows}</ol>`;
+  }).join('');
 }
 
 function builderRows(byBuilder) {
@@ -52,14 +71,14 @@ function builderRows(byBuilder) {
   }).join('');
 }
 
-export async function onRequestGet({ request }) {
+export async function onRequestGet({ request, env }) {
   const origin = new URL(request.url).origin;
   const data = await loadData(request);
+  const live = env?.RESULTS ? await getStats(env.RESULTS).catch(() => null) : null;
 
   const generating = !data || !data.scored;
   const stats = data?.stats || {};
   const sites = (data?.sites || []).filter((s) => s.scored);
-  const hallOfClean = sites.filter((s) => s.tier === 'Clean').slice(0, 10);
   const when = data?.generatedAt ? new Date(data.generatedAt).toISOString().slice(0, 10) : '—';
 
   const headline = generating
@@ -69,10 +88,17 @@ export async function onRequestGet({ request }) {
         detectable AI-design-slop tells (score &ge; 10). Average score <strong>${stats.avgScore}</strong>/100.
         ${stats.cleanCount} Clean &middot; ${stats.mildCount} Mild &middot; ${stats.heavyCount} Heavy.</p>`;
 
-  const hall = hallOfClean.length
-    ? `<h2>Hall of Clean</h2>
-       <p class="note">The lowest scores in the set &mdash; pages that read as deliberate, not generated.</p>
-       <ol class="rows">${hallOfClean.map((s) => cleanRow(s, origin)).join('')}</ol>`
+  // Live counter across every scan slop-detect has run (not just the corpus),
+  // shown only once it reads as momentum rather than "0".
+  const liveLine = (live && live.count >= 50)
+    ? `<p class="livestat">Across every page slop-detect has scored:
+        <strong>${live.count.toLocaleString('en-US')}</strong> scans,
+        average <strong>${live.avgScore}</strong>/100, ${live.slopShare}% carry slop.</p>`
+    : '';
+
+  const ranked = (!generating && sites.length)
+    ? `<p class="note">Cleanest first within each category. Every name links to its score hub.</p>
+       ${categorySections(sites, origin)}`
     : '';
 
   const byBuilder = !generating && builderRows(data.byBuilder)
@@ -100,8 +126,11 @@ ${BRAND_FONTS_HEAD}
   .lead{font-size:19px;color:var(--text-2);max-width:62ch}
   .lead strong{color:var(--text)}
   .note{color:var(--muted);font-size:14px;margin-bottom:12px;max-width:62ch}
+  .livestat{font-family:var(--mono);font-size:13px;color:var(--muted);margin:14px 0 4px}
+  .livestat strong{color:var(--text)}
   .rows{list-style:none;margin-top:8px}
-  .r{display:grid;grid-template-columns:34px 78px 1fr auto;gap:12px;align-items:baseline;padding:11px 2px;border-bottom:1px solid var(--bg-2)}
+  .r{display:grid;grid-template-columns:24px 34px 78px 1fr;gap:12px;align-items:baseline;padding:11px 2px;border-bottom:1px solid var(--bg-2)}
+  .rank{font-family:var(--mono);font-size:12px;color:var(--dim);text-align:right}
   .g{font-family:var(--mono);font-weight:700;font-size:14px;border:1px solid;border-radius:5px;text-align:center;padding:1px 0}
   .sc{font-family:var(--mono);color:var(--text-2);font-size:13px}
   .sc small{color:var(--dim);font-size:11px}
@@ -119,18 +148,19 @@ ${BRAND_FONTS_HEAD}
   .meth code{font-family:var(--mono);color:var(--muted)}
   footer{margin-top:32px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
   footer a{color:var(--muted)}
-  @media(max-width:560px){.r{grid-template-columns:30px 64px 1fr}.scan{display:none}}
+  @media(max-width:560px){.r{grid-template-columns:34px 64px 1fr}.rank{display:none}}
 </style></head><body><div class="wrap">
   <div class="eyebrow"><span class="reg">&sect;rpt</span><span class="reg-label">the report</span></div>
   <h1>The State of AI Design Slop</h1>
   ${headline}
+  ${liveLine}
 
   <div class="cta">
     Wondering about your own site? <a href="${origin}/">Scan it free</a> &middot;
     keep it clean over time with <a href="${origin}/#monitor">monitoring</a>.
   </div>
 
-  ${hall}
+  ${ranked}
   ${byBuilder}
 
   <p class="meth">Methodology: each URL scanned once in a headless browser against the

--- a/packages/web/test/leaderboard.test.js
+++ b/packages/web/test/leaderboard.test.js
@@ -1,5 +1,6 @@
 // /leaderboard renders the generated dataset (fetched at request time) into a
-// research-framed page: aggregate stat + Hall of Clean + by-builder, anti-slop.
+// research-framed page: corpus headline + a live counter + category rankings +
+// by-builder, anti-slop. Each name links into its /score hub.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -13,7 +14,7 @@ const SAMPLE = {
   byBuilder: { v0: { count: 1, avgScore: 30 }, custom: { count: 2, avgScore: 7 } },
   byCategory: {},
   sites: [
-    { domain: 'stripe.com', url: 'https://stripe.com', builtWith: 'custom', category: 'saas', scored: true, score: 4, grade: 'A', tier: 'Clean', resultUrl: 'https://slop-detect.com/r/aaa' },
+    { domain: 'stripe.com', url: 'https://stripe.com', builtWith: 'custom', category: 'saas', scored: true, score: 4, grade: 'A', tier: 'Clean' },
     { domain: 'news.ycombinator.com', url: 'https://news.ycombinator.com', builtWith: 'custom', category: 'classic', scored: true, score: 6, grade: 'A-', tier: 'Clean' },
     { domain: 'demo.v0', url: 'https://demo.v0', builtWith: 'v0', category: 'ai-builder', scored: true, score: 30, grade: 'C', tier: 'Heavy' }
   ]
@@ -26,31 +27,38 @@ function withFetch(impl, fn) {
   return Promise.resolve(fn()).finally(() => { globalThis.fetch = orig; });
 }
 
+// KV mock whose stats:dist seeds getStats with `n` scans (all at one bucket).
+function kvWithScans(n) {
+  const dist = new Array(101).fill(0); dist[12] = n;
+  const store = new Map([['stats:dist', JSON.stringify(dist)]]);
+  return { async get(k) { return store.has(k) ? store.get(k) : null; }, async put(k, v) { store.set(k, v); }, async delete(k) { store.delete(k); } };
+}
+
 const req = { url: 'https://slop-detect.com/leaderboard' };
 
-test('/leaderboard renders the headline stat, Hall of Clean, and by-builder', async () => {
+test('/leaderboard renders the headline, category rankings, and by-builder', async () => {
   await withFetch(async () => new Response(JSON.stringify(SAMPLE), { status: 200 }), async () => {
-    const res = await onRequestGet({ request: req });
+    const res = await onRequestGet({ request: req, env: {} });
     assert.equal(res.status, 200);
     const html = await res.text();
-    assert.match(html, /33%/, 'shows slop share');
-    assert.match(html, /Hall of Clean/);
-    assert.match(html, /stripe\.com/, 'names a clean site (praise is fine)');
+    assert.match(html, /33%/, 'shows corpus slop share');
+    assert.match(html, /AI builders/);
+    assert.match(html, /SaaS &amp; dev tools|SaaS & dev tools/);
+    assert.match(html, /Classic/);
     assert.match(html, /By builder/);
     assert.match(html, /v0/, 'builder breakdown present');
-    // Anti-slop self-check.
+    // Names link into the score hub (closing the loop), not dead-ending elsewhere.
+    assert.match(html, /href="https:\/\/slop-detect\.com\/score\/stripe\.com"/);
+    // Anti-slop self-check + framing caveat.
     assert.doesNotMatch(html, /Inter|Geist|Space Grotesk/i);
     assert.doesNotMatch(html, /background-clip:\s*text/i);
-    // Framing caveat must be present (not a verdict on a company).
     assert.match(html, /fingerprint, not a verdict/i);
-    // Hall of Clean links out to the clean site (a backlink / praise).
-    assert.match(html, /href="https:\/\/stripe\.com"/);
   });
 });
 
 test('/leaderboard shows a graceful "generating" state when data is missing', async () => {
   await withFetch(async () => new Response('not found', { status: 404 }), async () => {
-    const res = await onRequestGet({ request: req });
+    const res = await onRequestGet({ request: req, env: {} });
     assert.equal(res.status, 200);
     const html = await res.text();
     assert.match(html, /being generated/i);
@@ -58,11 +66,11 @@ test('/leaderboard shows a graceful "generating" state when data is missing', as
   });
 });
 
-test('/leaderboard never lists a Heavy site in the Hall of Clean', async () => {
+test('/leaderboard shows the live scan counter once enough scans exist', async () => {
   await withFetch(async () => new Response(JSON.stringify(SAMPLE), { status: 200 }), async () => {
-    const res = await onRequestGet({ request: req });
-    const html = await res.text();
-    const hall = html.slice(html.indexOf('Hall of Clean'), html.indexOf('By builder'));
-    assert.ok(!hall.includes('demo.v0'), 'the Heavy site must not appear in Hall of Clean');
+    const withData = await (await onRequestGet({ request: req, env: { RESULTS: kvWithScans(120) } })).text();
+    assert.match(withData, /120<\/strong>\s*scans|>120<\/strong>/);
+    const tooFew = await (await onRequestGet({ request: req, env: { RESULTS: kvWithScans(10) } })).text();
+    assert.doesNotMatch(tooFew, /scans,\s*\n?\s*average/);
   });
 });


### PR DESCRIPTION
This PR restructures /leaderboard into category rankings and wires it into the score-hub loop.

Today the page is a flat 'Hall of Clean' plus a by-builder table. This groups the corpus into category sections (AI builders, SaaS & dev tools, Big tech, Classic), ranked cleanest-first within each, the layout the reference uses. Every name now links into its /score/<domain> hub, so the leaderboard drives engagement into the per-domain pages instead of dead-ending on the external site.

It also adds a live counter across every scan slop-detect has run (from getStats over the PR1 histogram), shown only once at least 50 scans exist so a fresh deploy never reads '0'. The curated corpus stays the editorial source; the by-builder breakdown and the 'fingerprint, not a verdict' framing are kept.

Verification: tests updated for the new structure (category headings, /score links, live-counter threshold, generating fallback); rendered and screenshotted with sample data; copy axis 0, no design tells; full suite 186 pass / 0 fail; lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Leaderboard HTML and an optional KV stats read with `.catch(() => null)`; no auth or scoring logic changes.
> 
> **Overview**
> **`/leaderboard`** no longer shows a flat **Hall of Clean** list. Corpus sites are grouped into category sections (AI builders, SaaS & dev tools, Big tech, Classic), each ranked **cleanest-first**, with rank numbers on each row.
> 
> Domain links now point to **`/score/<domain>`** on the same origin instead of the external site or per-scan **`/r/...`** links, so the report feeds the score-hub flow.
> 
> When **`env.RESULTS`** is available, the handler pulls **`getStats`** and may show a **live** line (total scans, average score, slop share) only if **`count >= 50`**, so new deploys avoid a “0 scans” message. The curated corpus headline, by-builder table, and methodology copy are unchanged.
> 
> Tests were updated for category headings, score-hub URLs, the live-counter threshold, and the missing-data fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f660d080f740ec6a1d6f46c2df36630664a95c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->