### PR TITLE
Score hub PR5: scaffold /blog with markdown twins

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "web:deploy": "npm run --workspace slop-detect-web deploy",
     "calibrate": "node packages/cli/calibration/run.mjs",
     "test": "node --test packages/core/test/*.test.js packages/web/test/*.test.js packages/cli/test/*.test.js packages/mcp/test/*.test.js",
-    "lint": "node --check packages/core/src/*.js packages/cli/src/*.js packages/cli/bin/*.js packages/mcp/src/*.js packages/mcp/bin/*.js packages/web/functions/api/*.js packages/web/functions/api/cron/*.js packages/web/functions/api/watch/*.js packages/web/functions/api/dashboard/*.js packages/web/functions/*.js packages/web/functions/score/*.js packages/web/functions/r/*.js packages/web/functions/report/*.js packages/web/functions/og/*.js packages/web/functions/badge/*.js"
+    "lint": "node --check packages/core/src/*.js packages/cli/src/*.js packages/cli/bin/*.js packages/mcp/src/*.js packages/mcp/bin/*.js packages/web/functions/api/*.js packages/web/functions/api/cron/*.js packages/web/functions/api/watch/*.js packages/web/functions/api/dashboard/*.js packages/web/functions/*.js packages/web/functions/score/*.js packages/web/functions/r/*.js packages/web/functions/report/*.js packages/web/functions/og/*.js packages/web/functions/badge/*.js packages/web/functions/blog/*.js"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/web/functions/_posts.js
+++ b/packages/web/functions/_posts.js
@@ -1,0 +1,117 @@
+// Seed content for /blog. Posts are authored once here as markdown (single
+// source of truth); the dynamic route renders them to HTML and also serves the
+// raw markdown twin at /blog/<slug>.md, the AEO convention the tool preaches.
+//
+// Bodies are deliberately written clean (commas/colons, no buzzwords) so the
+// blog passes the copy axis it represents.
+
+import { escapeHtml } from './_shared.js';
+
+export const POSTS = [
+  {
+    slug: 'how-the-slop-score-works',
+    title: 'How the slop score works',
+    date: '2026-06-13',
+    summary: 'A weighted, deterministic fingerprint: same page in, same score out. No model, no randomness.',
+    body: `Every scan runs the same set of named checks against a page's live
+computed styles, adds up the weight of the ones that fire, and returns a number
+from 0 to 100. Lower is cleaner.
+
+## Deterministic by design
+
+There is no model and no randomness. The score is a pure function of the page:
+scan the same URL twice and you get the same number. That is the point. A
+probabilistic "is this AI?" verdict cannot be audited or trusted at a threshold.
+A fixed, named fingerprint can.
+
+## Weights and tiers
+
+Each pattern carries a fixed weight, heavier for the strongest tells (the
+AI-default font stack, vibe purple) and lighter for the softer ones. The total
+maps to three tiers:
+
+- Clean, 0 to 9
+- Mild, 10 to 27
+- Heavy, 28 and up
+
+## A fingerprint, not a verdict
+
+A high score means the page reads as machine-generated, not that it is bad and
+not that an AI wrote it. Everyone uses AI now. The score measures how generic the
+result reads, nothing about the team behind it. Reproduce any score yourself with
+\`npx slop-detect <url>\`.`
+  },
+  {
+    slug: 'why-detectors-decay',
+    title: 'Why slop detectors decay, and what we do about it',
+    date: '2026-06-13',
+    summary: 'A fixed visual fingerprint degrades as generators suppress the default look. The durable signal is per-site, not global.',
+    body: `A signature-style detector that enumerates today's visual tells
+degrades over time. The generators that produce the slop are actively engineered
+to suppress the default look, and design standards push per-brand constraints
+into them. The exact fonts and gradients we flag today will not be the tells a
+year from now.
+
+## The absolute score is the hook, not the moat
+
+A loud, free "how AI-generated does this look?" grader gets attention while the
+meme is hot. But the rule list is copyable in an afternoon, and the fashion it
+tracks will move. So the absolute score is acquisition, not a durable product.
+
+## The durable signal is per-site
+
+The question that does not decay is relative: does this page honor its own
+declared design system? Point a scan at a site's DESIGN.md, the open token spec
+for colors, typography, radii, and components, and the scan reports drift: fonts
+in use that were never declared, CTA colors off the palette, radii off the scale.
+A bespoke site checked against its own tokens can never false-positive as slop,
+and the reference point is the customer's own system, not a global fashion that
+ages.
+
+## What this means for you
+
+Use the free slop score to catch the obvious generated look. Use the system axis
+to keep a real design system honest as non-designers and coding agents keep
+shipping to it. One is the hook, the other is the thing worth monitoring.`
+  }
+];
+
+export function getPost(slug) {
+  return POSTS.find((p) => p.slug === slug) || null;
+}
+
+// Minimal, safe markdown to HTML for the seed posts. Escapes first, then applies
+// a small set of block + inline rules (headings, unordered lists, fenced code,
+// paragraphs, links, bold, inline code). Not a full CommonMark parser by design.
+export function mdToHtml(md) {
+  const lines = String(md).replace(/\r\n/g, '\n').split('\n');
+  const inline = (s) => escapeHtml(s)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2">$1</a>');
+  const out = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (/^```/.test(line)) {
+      const buf = []; i++;
+      while (i < lines.length && !/^```/.test(lines[i])) buf.push(lines[i++]);
+      i++;
+      out.push(`<pre><code>${escapeHtml(buf.join('\n'))}</code></pre>`);
+      continue;
+    }
+    const h = line.match(/^(#{2,4})\s+(.*)$/);
+    if (h) { const lvl = h[1].length; out.push(`<h${lvl}>${inline(h[2])}</h${lvl}>`); i++; continue; }
+    if (/^-\s+/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^-\s+/.test(lines[i])) items.push(`<li>${inline(lines[i++].replace(/^-\s+/, ''))}</li>`);
+      out.push(`<ul>${items.join('')}</ul>`);
+      continue;
+    }
+    if (!line.trim()) { i++; continue; }
+    const buf = [];
+    while (i < lines.length && lines[i].trim() && !/^(#{2,4}\s|-\s|```)/.test(lines[i])) buf.push(lines[i++]);
+    out.push(`<p>${inline(buf.join(' '))}</p>`);
+  }
+  return out.join('\n');
+}

--- a/packages/web/functions/blog.js
+++ b/packages/web/functions/blog.js
@@ -1,0 +1,77 @@
+// GET /blog — the index of posts. Crawlable, server-rendered on the shared brand
+// system (anti-slop), with a Blog JSON-LD for AEO. Content lives in _posts.js.
+
+import { escapeHtml } from './_shared.js';
+import { POSTS } from './_posts.js';
+import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
+
+const ORIGIN = 'https://slop-detect.com';
+
+export async function onRequestGet({ request }) {
+  const origin = new URL(request.url).origin;
+  const posts = POSTS.slice().sort((a, b) => (a.date < b.date ? 1 : -1));
+
+  const items = posts.map((p) => `
+    <li class="post">
+      <a class="post-title" href="${origin}/blog/${escapeHtml(p.slug)}">${escapeHtml(p.title)}</a>
+      <div class="post-meta">${escapeHtml(p.date)}</div>
+      <p class="post-sum">${escapeHtml(p.summary)}</p>
+    </li>`).join('');
+
+  const jsonLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    '@id': `${ORIGIN}/blog`,
+    name: 'Slop Detector blog',
+    url: `${ORIGIN}/blog`,
+    blogPost: posts.map((p) => ({
+      '@type': 'BlogPosting',
+      headline: p.title,
+      datePublished: p.date,
+      url: `${ORIGIN}/blog/${p.slug}`
+    }))
+  });
+
+  const html = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Blog · slop-detect</title>
+<meta name="description" content="Notes on the AI-design-slop fingerprint: how the score works, why detectors decay, and the durable per-site signal.">
+<link rel="canonical" href="${ORIGIN}/blog">
+<meta property="og:title" content="Slop Detector blog">
+<meta property="og:description" content="How the slop score works, and why the durable signal is per-site.">
+<meta property="og:url" content="${ORIGIN}/blog">
+<meta property="og:image" content="${ORIGIN}/og.png">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<script type="application/ld+json">${jsonLd}</script>
+${BRAND_FONTS_HEAD}
+<style>${BRAND_CSS}
+  body{padding:48px 20px 80px}
+  .wrap{max-width:680px;margin:0 auto}
+  .brand{font-size:14px;font-weight:600;margin-bottom:22px}
+  .brand .slash{color:var(--dim);font-weight:400}
+  h1{font-size:30px;font-weight:700;letter-spacing:-0.02em;margin:6px 0 6px}
+  .lead{color:var(--muted);margin-bottom:26px;max-width:60ch}
+  .posts{list-style:none}
+  .post{padding:20px 0;border-bottom:1px solid var(--bg-2)}
+  .post-title{font-size:19px;font-weight:700;letter-spacing:-0.01em;text-decoration:none}
+  .post-title:hover{text-decoration:underline}
+  .post-meta{font-family:var(--mono);font-size:11.5px;color:var(--dim);margin-top:4px}
+  .post-sum{color:var(--text-2);font-size:14.5px;margin-top:8px;max-width:62ch}
+  footer{margin-top:36px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  footer a{color:var(--muted)}
+</style></head><body><div class="wrap">
+  <div class="brand"><a href="/" style="color:inherit">slop&#8209;detect</a> <span class="slash">/ blog</span></div>
+  <div class="eyebrow"><span class="reg">&sect;log</span><span class="reg-label">notes</span></div>
+  <h1>Blog</h1>
+  <p class="lead">Notes on the AI-design-slop fingerprint: how the score works, why
+    detectors decay, and the durable per-site signal.</p>
+  <ul class="posts">${items}</ul>
+  <footer><a href="${origin}/">slop-detect.com</a> &middot;
+    <a href="${origin}/leaderboard">the report</a> &middot;
+    <a href="https://github.com/ravidsrk/slop-detect">source</a></footer>
+</div></body></html>`;
+
+  return new Response(html, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=600' }
+  });
+}

--- a/packages/web/functions/blog/[slug].js
+++ b/packages/web/functions/blog/[slug].js
@@ -1,0 +1,94 @@
+// GET /blog/<slug>      → the post, server-rendered (anti-slop, BlogPosting JSON-LD).
+// GET /blog/<slug>.md    → the raw markdown twin, the AEO convention we preach.
+//
+// Single source: both come from _posts.js, so the HTML and the twin never drift.
+
+import { escapeHtml } from '../_shared.js';
+import { getPost, mdToHtml } from '../_posts.js';
+import { BRAND_FONTS_HEAD, BRAND_CSS } from '../_brand.js';
+
+const ORIGIN = 'https://slop-detect.com';
+
+export async function onRequestGet({ params, request }) {
+  const origin = new URL(request.url).origin;
+  const raw = String(params.slug || '');
+  const wantsMd = raw.endsWith('.md');
+  const slug = wantsMd ? raw.slice(0, -3) : raw;
+  const post = getPost(slug);
+
+  if (!post) {
+    return new Response('Post not found', { status: 404, headers: { 'Content-Type': 'text/plain; charset=utf-8' } });
+  }
+
+  // Markdown twin: the post body, with a leading H1 + summary, served raw.
+  if (wantsMd) {
+    const md = `# ${post.title}\n\n> ${post.summary}\n\n${post.body}\n`;
+    return new Response(md, {
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8', 'Cache-Control': 'public, max-age=600' }
+    });
+  }
+
+  const url = `${ORIGIN}/blog/${post.slug}`;
+  const jsonLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    '@id': url,
+    headline: post.title,
+    description: post.summary,
+    datePublished: post.date,
+    dateModified: post.date,
+    url,
+    isPartOf: { '@type': 'Blog', name: 'Slop Detector blog', url: `${ORIGIN}/blog` },
+    author: { '@type': 'Person', name: 'Ravindra Kumar' }
+  });
+
+  const html = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(post.title)} · slop-detect</title>
+<meta name="description" content="${escapeHtml(post.summary)}">
+<link rel="canonical" href="${url}">
+<link rel="alternate" type="text/markdown" href="${url}.md">
+<meta property="og:type" content="article">
+<meta property="og:title" content="${escapeHtml(post.title)}">
+<meta property="og:description" content="${escapeHtml(post.summary)}">
+<meta property="og:url" content="${url}">
+<meta property="og:image" content="${ORIGIN}/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<script type="application/ld+json">${jsonLd}</script>
+${BRAND_FONTS_HEAD}
+<style>${BRAND_CSS}
+  body{padding:48px 20px 90px}
+  .wrap{max-width:660px;margin:0 auto}
+  .brand{font-size:14px;font-weight:600;margin-bottom:22px}
+  .brand .slash{color:var(--dim);font-weight:400}
+  h1{font-size:30px;font-weight:700;letter-spacing:-0.02em;line-height:1.15;margin:6px 0 6px}
+  .meta{font-family:var(--mono);font-size:12px;color:var(--dim);margin-bottom:26px}
+  .body{font-size:16px;color:var(--text-2);line-height:1.7}
+  .body h2{font-size:20px;font-weight:700;color:var(--text);letter-spacing:-0.01em;margin:30px 0 8px}
+  .body h3{font-size:16px;font-weight:700;color:var(--text);margin:22px 0 6px}
+  .body p{margin:0 0 16px}
+  .body ul{margin:0 0 16px;padding-left:20px}
+  .body li{margin:4px 0}
+  .body a{color:var(--accent)}
+  .body code{font-family:var(--mono);font-size:13.5px;color:var(--text);background:var(--bg-2);border:1px solid var(--border);border-radius:5px;padding:1px 5px}
+  .body pre{background:var(--bg-2);border:1px solid var(--border);border-radius:8px;padding:14px;overflow:auto;margin:0 0 16px}
+  .body pre code{border:0;padding:0;background:none}
+  .twin{margin-top:30px;font-family:var(--mono);font-size:12px;color:var(--dim)}
+  .twin a{color:var(--muted)}
+  footer{margin-top:36px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  footer a{color:var(--muted)}
+</style></head><body><div class="wrap">
+  <div class="brand"><a href="/" style="color:inherit">slop&#8209;detect</a> <span class="slash">/ <a href="${origin}/blog" style="color:inherit">blog</a></span></div>
+  <h1>${escapeHtml(post.title)}</h1>
+  <div class="meta">${escapeHtml(post.date)}</div>
+  <div class="body">${mdToHtml(post.body)}</div>
+  <div class="twin">Machine-readable twin: <a href="${url}.md">${escapeHtml(post.slug)}.md</a></div>
+  <footer><a href="${origin}/blog">&larr; all posts</a> &middot;
+    <a href="${origin}/">scan a page</a></footer>
+</div></body></html>`;
+
+  return new Response(html, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=600' }
+  });
+}

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -1316,6 +1316,7 @@
           <a href="/dashboard">Dashboard</a>
           <a href="/leaderboard">Leaderboard</a>
           <a href="/directory">Directory</a>
+          <a href="/blog">Blog</a>
         </div>
         <div class="footer-col">
           <h5>install</h5>

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -16,6 +16,8 @@ page looks machine-generated, not that it is bad.
   Detector measures and how the scan works.
 - [Pattern catalogue (JSON)](https://slop-detect.com/api/patterns): Every design
   and copy pattern, with weights and the current definitions version.
+- [Blog](https://slop-detect.com/blog): how the score works and why a fixed
+  detector decays. Each post has a markdown twin at `/blog/<slug>.md`.
 
 ## How it works
 

--- a/packages/web/public/sitemap.xml
+++ b/packages/web/public/sitemap.xml
@@ -16,6 +16,21 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://slop-detect.com/blog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/blog/how-the-slop-score-works</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/blog/why-detectors-decay</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://slop-detect.com/directory</loc>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>

--- a/packages/web/test/blog.test.js
+++ b/packages/web/test/blog.test.js
@@ -1,0 +1,54 @@
+// /blog index + /blog/<slug> (HTML and the .md twin) render from _posts.js.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequestGet as indexGet } from '../functions/blog.js';
+import { onRequestGet as postGet } from '../functions/blog/[slug].js';
+import { POSTS, mdToHtml } from '../functions/_posts.js';
+
+const req = (path) => ({ url: `https://slop-detect.com${path}` });
+
+test('/blog lists every post with a link', async () => {
+  const res = await indexGet({ request: req('/blog') });
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  for (const p of POSTS) {
+    assert.match(html, new RegExp(p.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.match(html, new RegExp(`/blog/${p.slug}`));
+  }
+  assert.match(html, /application\/ld\+json/);
+});
+
+test('/blog/<slug> renders the post HTML with structured data + a twin link', async () => {
+  const slug = 'how-the-slop-score-works';
+  const res = await postGet({ params: { slug }, request: req(`/blog/${slug}`) });
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.match(html, /How the slop score works/);
+  assert.match(html, /<h2>Deterministic by design<\/h2>/);
+  assert.match(html, /BlogPosting/);
+  assert.match(html, new RegExp(`rel="canonical" href="https://slop-detect.com/blog/${slug}"`));
+  assert.match(html, new RegExp(`rel="alternate" type="text/markdown" href="https://slop-detect.com/blog/${slug}.md"`));
+});
+
+test('/blog/<slug>.md serves the raw markdown twin', async () => {
+  const res = await postGet({ params: { slug: 'how-the-slop-score-works.md' }, request: req('/blog/how-the-slop-score-works.md') });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('Content-Type'), /text\/markdown/);
+  const md = await res.text();
+  assert.match(md, /^# How the slop score works/);
+});
+
+test('unknown slug returns 404', async () => {
+  const res = await postGet({ params: { slug: 'nope' }, request: req('/blog/nope') });
+  assert.equal(res.status, 404);
+});
+
+test('mdToHtml renders blocks and escapes HTML in inline code', () => {
+  const html = mdToHtml('## Head\n\n- one\n- two\n\nUse `npx slop-detect <url>` and **bold** text and a [link](https://x.com).');
+  assert.match(html, /<h2>Head<\/h2>/);
+  assert.match(html, /<ul><li>one<\/li><li>two<\/li><\/ul>/);
+  assert.match(html, /<code>npx slop-detect &lt;url&gt;<\/code>/); // angle brackets escaped
+  assert.match(html, /<strong>bold<\/strong>/);
+  assert.match(html, /<a href="https:\/\/x\.com">link<\/a>/);
+});


### PR DESCRIPTION
This PR scaffolds /blog, the AEO dogfood. We sell the answer-engine-optimization axis (can AI engines read and cite a page), so the blog should itself be the worked example, with a markdown twin per post.

Posts are authored once as markdown in functions/_posts.js (single source of truth). The route renders them to HTML and also serves the raw markdown twin at /blog/<slug>.md, advertised via <link rel=alternate type=text/markdown>, so the HTML and the twin can never drift.

- functions/blog.js (index) and functions/blog/[slug].js (post HTML plus the .md twin), both on the shared dark brand system with Blog and BlogPosting JSON-LD.
- Two seed posts (how the score works; why a fixed detector decays) written clean so the blog passes the copy axis it represents (verified 0).
- Discovery: /blog and the posts are in sitemap.xml, referenced in llms.txt, and linked from the homepage footer; the blog directory is added to the lint glob.

Verification: 5 tests (index, post HTML and structured data, the .md twin, 404, and the markdown renderer's HTML escaping); rendered and screenshotted a post; copy axis 0; full suite 191 pass / 0 fail; lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only content routes and static discovery links; no auth, payments, or scan pipeline changes.
> 
> **Overview**
> Adds a **server-rendered `/blog`** on the shared brand stack, with posts defined once in `_posts.js` and exposed as HTML plus **markdown twins** at `/blog/<slug>.md` (via `rel="alternate" type="text/markdown"`).
> 
> **Routes:** `functions/blog.js` (index with Blog JSON-LD) and `functions/blog/[slug].js` (post HTML with BlogPosting JSON-LD, or raw `.md` when the slug ends in `.md`). A small **`mdToHtml`** helper escapes HTML then renders headings, lists, code fences, and inline markup.
> 
> **Content:** Two seed posts (how the score works; why detectors decay).
> 
> **Discovery:** Blog linked in the homepage footer; **`sitemap.xml`** and **`llms.txt`** updated; root **`lint`** script includes `packages/web/functions/blog/*.js`.
> 
> **Tests:** `blog.test.js` covers index, post HTML/structured data, `.md` twin, 404, and `mdToHtml` escaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e14f81e63fa288fca5c7bb8e76d45fda6a684b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->