### PR TITLE
security: fix SSRF IPv6 bypass + harden inline-script XSS (adversarial review fixes)

### DIFF
--- a/packages/cli/bin/slop.ts
+++ b/packages/cli/bin/slop.ts
@@ -57,6 +57,10 @@ for (let i = 0; i < args.length; i++) {
   else if (a === '--remote') flags.remote = true;
   else if (a === '--api' || a.startsWith('--api=')) {
     flags.api = a.startsWith('--api=') ? a.slice('--api='.length) : args[++i];
+    if (!flags.api || flags.api.startsWith('--')) {
+      console.error('--api needs a base URL value (e.g. --api https://slop-detect.com).');
+      process.exit(2);
+    }
     flags.remote = true; // a custom API endpoint implies remote scanning
   } else if (a === '--design-md' || a.startsWith('--design-md=')) {
     const val = a.startsWith('--design-md=') ? a.slice('--design-md='.length) : args[++i];
@@ -74,7 +78,7 @@ for (let i = 0; i < args.length; i++) {
       console.error(
         `Invalid --axes value: ${val}. Options: ${VALID_AXES.join(', ')} (comma-separated) or "all".`
       );
-      process.exit(1);
+      process.exit(2);
     }
     flags.axes = parsed;
   } else if (a === '--fail-on' || a.startsWith('--fail-on=')) {
@@ -95,25 +99,25 @@ for (let i = 0; i < args.length; i++) {
     const val = args[++i];
     if (!val || !isPreset(val)) {
       console.error(`Unknown preset: ${val}. Options: ${Object.keys(PRESETS).join(', ')}`);
-      process.exit(1);
+      process.exit(2);
     }
     flags.preset = val;
   } else if (a.startsWith('--preset=')) {
     const val = a.slice('--preset='.length);
     if (!isPreset(val)) {
       console.error(`Unknown preset: ${val}. Options: ${Object.keys(PRESETS).join(', ')}`);
-      process.exit(1);
+      process.exit(2);
     }
     flags.preset = val;
   } else if (a.startsWith('--')) {
     console.error(`Unknown flag: ${a}`);
-    process.exit(1);
+    process.exit(2);
   } else urls.push(a);
 }
 
 if (urls.length === 0) {
   help();
-  process.exit(1);
+  process.exit(2);
 }
 
 // Normalize bare hostnames the way the web UI does: `slop-detect example.com`

--- a/packages/cli/src/detector.ts
+++ b/packages/cli/src/detector.ts
@@ -307,11 +307,16 @@ export async function aeoRemote(url, opts: ScanOptions = {}) {
   const headers = { 'content-type': 'application/json' };
   const key = opts.apiKey || process.env.SLOP_API_KEY;
   if (key) headers['x-api-key'] = key;
-  const res = await fetch(new URL('/api/aeo', base), {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ url }),
-  });
+  let res;
+  try {
+    res = await fetch(new URL('/api/aeo', base), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ url }),
+    });
+  } catch (e) {
+    throw new Error(`Could not reach ${base} (${e.message}). Drop --remote to scan locally.`);
+  }
   const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
   if (!res.ok) throw new Error(data.error || `AEO check failed (HTTP ${res.status})`);
   return data;

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -40,14 +40,16 @@ test('non-http(s) scheme is rejected before any scan (exit 2)', () => {
   }
 });
 
-test('no args prints help and exits 1', () => {
+// Exit-code contract: 0 = ok, 1 = scan ran but failed the --fail-on gate (the CI
+// signal), 2 = usage/argument error. Usage errors must NOT collide with the gate.
+test('no args prints help and exits 2 (usage error)', () => {
   const r = run([]);
-  assert.equal(r.status, 1);
+  assert.equal(r.status, 2);
   assert.match(r.stdout, /Usage:/);
 });
 
-test('unknown flag exits 1', () => {
+test('unknown flag exits 2 (usage error)', () => {
   const r = run(['https://example.com', '--nope']);
-  assert.equal(r.status, 1);
+  assert.equal(r.status, 2);
   assert.match(r.stderr, /Unknown flag/);
 });

--- a/packages/core/src/aeo.ts
+++ b/packages/core/src/aeo.ts
@@ -206,6 +206,41 @@ function pickCheck(id) {
   return AEO_CHECKS.find((c) => c.id === id);
 }
 
+// Read a response body with a hard byte cap so a hostile/huge target page can't
+// exhaust memory (AEO only inspects <head>/meta/robots-ish prefixes). Streams and
+// stops at the cap rather than buffering the whole body via res.text().
+const MAX_HTML_BYTES = 2 * 1024 * 1024; // 2 MB
+async function readCapped(res, maxBytes = MAX_HTML_BYTES) {
+  if (!res.body || typeof res.body.getReader !== 'function') {
+    const t = await res.text();
+    return t.length > maxBytes ? t.slice(0, maxBytes) : t;
+  }
+  const reader = res.body.getReader();
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.byteLength;
+    if (total >= maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        /* ignore */
+      }
+      break;
+    }
+  }
+  const merged = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    merged.set(c, off);
+    off += c.byteLength;
+  }
+  return new TextDecoder('utf-8', { fatal: false }).decode(merged.subarray(0, maxBytes));
+}
+
 async function fetchWithTimeout(url, init, timeoutMs, fetchImpl, isUrlAllowed) {
   const controller = new AbortController();
   const t = setTimeout(() => controller.abort(), timeoutMs);
@@ -376,7 +411,7 @@ export async function runAeoChecks(
       fetchImpl,
       isUrlAllowed
     );
-    htmlBody = await html.text();
+    htmlBody = await readCapped(html);
   } catch (e) {
     htmlErr = e instanceof Error ? e.message : String(e);
   }

--- a/packages/web/functions/_data.ts
+++ b/packages/web/functions/_data.ts
@@ -138,6 +138,13 @@ export async function issueWatchToken(kv, domain) {
 }
 
 // Resolve + burn a token. Returns the domain it confirmed, or null if unknown/expired.
+//
+// NOTE: get-then-delete is not atomic, and Workers KV has no compare-and-delete
+// primitive, so two requests racing the SAME token within the (eventually
+// consistent) window can both succeed. We accept this — the blast radius is
+// benign: re-confirming a watch just re-sets verified:true (idempotent), and a
+// raced dashboard token only mints a second session for the SAME owner email.
+// True hard single-use would require a Durable Object; not worth it for this.
 export async function consumeWatchToken(kv, token) {
   if (!kv || !token) return null;
   const domain = await kv.get(`wv:${token}`);
@@ -159,6 +166,9 @@ export async function issueDashboardToken(kv, email) {
   return token;
 }
 
+// Single-use, with the same benign get-then-delete race caveat documented on
+// consumeWatchToken (KV has no atomic CAS; a raced token re-mints only the same
+// owner's session).
 export async function consumeDashboardToken(kv, token) {
   if (!kv || !token) return null;
   const email = await kv.get(`dt:${token}`);

--- a/packages/web/functions/_render.tsx
+++ b/packages/web/functions/_render.tsx
@@ -37,6 +37,20 @@ export function escapeXml(s) {
   );
 }
 
+// Serialize a value as JSON that is safe to embed inside an HTML <script> — both
+// inline JS (`const x = ${jsonForScript(v)}`) and JSON-LD blocks. JSON.stringify
+// does NOT escape `<`, so a value containing `</script>` (or `<!--`) would break
+// out of the element and become live markup. Escaping `<`/`>`/`&` to their \u
+// forms (still valid JSON and JS) closes that, plus the JS line separators.
+export function jsonForScript(value) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
 // ── Tier → color ──────────────────────────────────────────────────────────────
 export function tierColors(tier) {
   switch (tier) {

--- a/packages/web/functions/_ssrf.ts
+++ b/packages/web/functions/_ssrf.ts
@@ -37,10 +37,29 @@ function isPrivateIPv6(host) {
   if (h.startsWith('fc') || h.startsWith('fd')) return true; // fc00::/7 unique-local
   if (h.startsWith('fe8') || h.startsWith('fe9') || h.startsWith('fea') || h.startsWith('feb'))
     return true; // fe80::/10 link-local
-  // IPv4-mapped (::ffff:a.b.c.d) — re-check the embedded v4.
-  const mapped = h.match(/::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (mapped) return isPrivateIPv4(mapped[1]);
+  // IPv4-mapped (::ffff:a.b.c.d) and the deprecated IPv4-compatible (::a.b.c.d,
+  // ::/96) forms — re-check the embedded v4 against the IPv4 rules. CRITICAL:
+  // `new URL()` HEX-normalizes the embedded address (`[::ffff:169.254.169.254]`
+  // → `[::ffff:a9fe:a9fe]`), so a dotted-decimal-only check is bypassed. Decode
+  // the trailing 32 bits from hex words too.
+  const v4 = embeddedIPv4(h);
+  if (v4) return isPrivateIPv4(v4);
   return false;
+}
+
+// Decode the IPv4 embedded in an IPv4-mapped/compatible IPv6 address, handling
+// both the dotted form (`::ffff:1.2.3.4`) and the hex form WHATWG `new URL()`
+// produces (`::ffff:0102:0304`). Returns "a.b.c.d" or null.
+function embeddedIPv4(h) {
+  let m = h.match(/^::(?:ffff:)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (m) return m[1];
+  m = h.match(/^::(?:ffff:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (m) {
+    const hi = parseInt(m[1], 16);
+    const lo = parseInt(m[2], 16);
+    return `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
+  }
+  return null;
 }
 
 export function validateScanUrl(raw) {

--- a/packages/web/functions/api/_middleware.ts
+++ b/packages/web/functions/api/_middleware.ts
@@ -244,11 +244,10 @@ export async function onRequest(context) {
   const trusted = ALLOWED_ORIGINS.has(origin);
   const foreignOrigin = origin !== '' && !trusted;
 
-  // Client IP — Cloudflare always sets this on the request object.
-  const ip =
-    request.headers.get('CF-Connecting-IP') ||
-    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  // Client IP — Cloudflare always sets CF-Connecting-IP on the request object.
+  // Do NOT fall back to the client-supplied X-Forwarded-For: it's spoofable, so a
+  // caller could forge a fresh IP per request to evade the per-IP rate-limit.
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
 
   const route = url.pathname.replace(/^\/api\//, '');
 
@@ -382,6 +381,29 @@ export async function onRequest(context) {
     }
   }
 
+  // ── Turnstile ───────────────────────────────────────────────────────────────
+  // Required for /api/scan from browser origins WITHOUT a valid key. A valid key
+  // is proof-of-human enough, so any keyed caller (browser or CLI) skips it.
+  // Verified BEFORE the cost guard below: a failed/absent captcha must not burn
+  // the global daily-scan budget (else a spoofed trusted Origin could inflate the
+  // cap and 503 real users without ever running a scan).
+  const skipTurnstile = keyTier && keyTier.turnstile === false;
+  if (effectiveRoute === 'scan' && trusted && env.TURNSTILE_SECRET && !skipTurnstile) {
+    const token = request.headers.get('X-Turnstile-Token');
+    const verdict = await verifyTurnstile(token, env.TURNSTILE_SECRET, ip);
+    if (!verdict.ok) {
+      return jsonResponse(
+        {
+          error: 'turnstile_required',
+          message: 'Captcha verification failed. Reload the page and try again.',
+          reason: verdict.reason,
+        },
+        403,
+        origin
+      );
+    }
+  }
+
   // ── Global cost guard (browser path only) ───────────────────────────────────
   // Per-IP/per-key limits don't stop a distributed flood from running up the
   // Cloudflare Browser Rendering bill. Enforce an ACCOUNT-LEVEL daily ceiling and
@@ -427,26 +449,6 @@ export async function onRequest(context) {
       } catch (_) {
         /* best-effort */
       }
-    }
-  }
-
-  // ── Turnstile ───────────────────────────────────────────────────────────────
-  // Required for /api/scan from browser origins WITHOUT a valid key. A valid key
-  // is proof-of-human enough, so any keyed caller (browser or CLI) skips it.
-  const skipTurnstile = keyTier && keyTier.turnstile === false;
-  if (effectiveRoute === 'scan' && trusted && env.TURNSTILE_SECRET && !skipTurnstile) {
-    const token = request.headers.get('X-Turnstile-Token');
-    const verdict = await verifyTurnstile(token, env.TURNSTILE_SECRET, ip);
-    if (!verdict.ok) {
-      return jsonResponse(
-        {
-          error: 'turnstile_required',
-          message: 'Captcha verification failed. Reload the page and try again.',
-          reason: verdict.reason,
-        },
-        403,
-        origin
-      );
     }
   }
 

--- a/packages/web/functions/api/dashboard/link.ts
+++ b/packages/web/functions/api/dashboard/link.ts
@@ -17,7 +17,7 @@ function json(data, status = 200) {
   });
 }
 
-export async function onRequestPost({ request, env }) {
+export async function onRequestPost({ request, env, waitUntil }) {
   if (!env.RESULTS)
     return json({ error: 'dashboard_unavailable', message: 'Storage is offline.' }, 503);
   if (!emailConfigured(env) || !env.SESSION_SECRET) {
@@ -51,10 +51,19 @@ export async function onRequestPost({ request, env }) {
   try {
     const watches = await listWatchesByEmail(env.RESULTS, email);
     if (watches.length) {
-      const token = await issueDashboardToken(env.RESULTS, email);
-      const loginUrl = `${new URL(request.url).origin}/dashboard?token=${token}`;
-      const msg = buildDashboardLinkEmail(loginUrl, watches.length);
-      await sendEmail(env, { to: email, subject: msg.subject, text: msg.text });
+      // Issue + send out-of-band so the response latency is IDENTICAL whether or
+      // not the address owns watches. Doing the KV write + email round-trip inline
+      // would make existence measurable (a timing oracle) despite the generic
+      // body. `waitUntil` runs it after the response is sent; we fall back to an
+      // inline await only when it's unavailable (e.g. unit tests).
+      const send = (async () => {
+        const token = await issueDashboardToken(env.RESULTS, email);
+        const loginUrl = `${new URL(request.url).origin}/dashboard?token=${token}`;
+        const msg = buildDashboardLinkEmail(loginUrl, watches.length);
+        await sendEmail(env, { to: email, subject: msg.subject, text: msg.text });
+      })().catch(() => {});
+      if (typeof waitUntil === 'function') waitUntil(send);
+      else await send;
     }
   } catch (_) {
     /* best-effort: still return the generic response */

--- a/packages/web/functions/api/scan.ts
+++ b/packages/web/functions/api/scan.ts
@@ -100,10 +100,13 @@ export async function onRequestPost({ request, env }) {
 
     const data = await page.evaluate(pageScript);
 
-    // SSRF: the navigation may have followed redirects to a different host. The
-    // pre-flight guard only saw the originally-requested URL — so re-validate the
-    // FINAL url before we hand back its title/h1/text/screenshot. Refuse to
-    // return content scraped from a private/internal host reached via redirect.
+    // SSRF (defense-in-depth): the navigation may have followed redirects to a
+    // different host, so re-validate the final url before handing back its
+    // title/h1/text/screenshot. CAVEAT: data.url is the page-reported
+    // location.href, which a hostile page can spoof via history.pushState — this
+    // is NOT a hard boundary. The real guards are the pre-flight validateScanUrl
+    // on the requested host and Cloudflare Browser Rendering's own egress; a
+    // resolve-and-pin check would be needed to fully close DNS-rebinding/spoofing.
     if (data.url && !isAllowedUrl(data.url)) {
       return json(
         {

--- a/packages/web/functions/blog.tsx
+++ b/packages/web/functions/blog.tsx
@@ -3,6 +3,7 @@
 // system (anti-slop), with a Blog JSON-LD for AEO. Content lives in _posts.js.
 
 import { raw } from 'hono/html';
+import { jsonForScript } from './_render.js';
 import { POSTS } from './_posts.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
 
@@ -29,7 +30,7 @@ export async function onRequestGet({ request }) {
   const origin = new URL(request.url).origin;
   const posts = POSTS.slice().sort((a, b) => (a.date < b.date ? 1 : -1));
 
-  const jsonLd = JSON.stringify({
+  const jsonLd = jsonForScript({
     '@context': 'https://schema.org',
     '@type': 'Blog',
     '@id': `${ORIGIN}/blog`,

--- a/packages/web/functions/blog/[slug].tsx
+++ b/packages/web/functions/blog/[slug].tsx
@@ -5,6 +5,7 @@
 // Single source: both come from _posts.js, so the HTML and the twin never drift.
 
 import { raw as rawHtml } from 'hono/html';
+import { jsonForScript } from '../_render.js';
 import { getPost, mdToHtml } from '../_posts.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from '../_brand.js';
 
@@ -59,7 +60,7 @@ export async function onRequestGet({ params, request }) {
   }
 
   const url = `${ORIGIN}/blog/${post.slug}`;
-  const jsonLd = JSON.stringify({
+  const jsonLd = jsonForScript({
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     '@id': url,

--- a/packages/web/functions/directory.tsx
+++ b/packages/web/functions/directory.tsx
@@ -12,7 +12,7 @@
 // purple, no glows — this page should itself score Clean on slop-detect.
 
 import { raw } from 'hono/html';
-import { listAllSites, tierColors } from './_shared.js';
+import { listAllSites, tierColors, jsonForScript } from './_shared.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
 
 const ORIGIN = 'https://slop-detect.com';
@@ -90,7 +90,7 @@ function Row({ site, origin }) {
 }
 
 function jsonLd(sites) {
-  return JSON.stringify({
+  return jsonForScript({
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'slop-detect — directory of scanned sites',

--- a/packages/web/functions/r/[id].tsx
+++ b/packages/web/functions/r/[id].tsx
@@ -7,7 +7,7 @@
 // the viral loop (see UX.md, Flow D).
 
 import { raw } from 'hono/html';
-import { getResult, tierColors } from '../_shared.js';
+import { getResult, tierColors, jsonForScript } from '../_shared.js';
 
 export async function onRequestGet({ params, env, request }) {
   const id = String(params.id || '')
@@ -94,8 +94,8 @@ function resultDoc(s, origin) {
   document.getElementById('badgeMd').addEventListener('click',()=>copy(badgeText,'Badge copied'));
   document.getElementById('copyBadge').addEventListener('click',()=>copy(badgeText,'Badge copied'));
   document.getElementById('shareX').addEventListener('click',()=>{
-    const text=${JSON.stringify(shareText)};
-    const u='https://twitter.com/intent/tweet?text='+encodeURIComponent(text)+'&url='+encodeURIComponent(${JSON.stringify(pageUrl)});
+    const text=${jsonForScript(shareText)};
+    const u='https://twitter.com/intent/tweet?text='+encodeURIComponent(text)+'&url='+encodeURIComponent(${jsonForScript(pageUrl)});
     window.open(u,'_blank','noopener');
   });
 `;

--- a/packages/web/functions/score/[domain].tsx
+++ b/packages/web/functions/score/[domain].tsx
@@ -26,6 +26,7 @@ import {
   publicWatch,
   percentileForScore,
   tierColors,
+  jsonForScript,
 } from '../_shared.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from '../_brand.js';
 
@@ -215,7 +216,7 @@ export async function onRequestGet({ params, request, env }) {
   const pts = chartPoints(history);
   const tells = (latest.triggered || []).slice(0, 10);
 
-  const jsonLd = JSON.stringify({
+  const jsonLd = jsonForScript({
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     '@id': pageUrl,
@@ -235,8 +236,8 @@ export async function onRequestGet({ params, request, env }) {
   if(bm)bm.addEventListener('click',()=>copy(bm.textContent,'Badge copied'));
   const sx=document.getElementById('shareX');
   if(sx)sx.addEventListener('click',()=>{
-    const text=${JSON.stringify(shareText)};
-    window.open('https://twitter.com/intent/tweet?text='+encodeURIComponent(text)+'&url='+encodeURIComponent(${JSON.stringify(pageUrl)}),'_blank','noopener');
+    const text=${jsonForScript(shareText)};
+    window.open('https://twitter.com/intent/tweet?text='+encodeURIComponent(text)+'&url='+encodeURIComponent(${jsonForScript(pageUrl)}),'_blank','noopener');
   });
   const cf=document.getElementById('claimForm');
   if(cf)cf.addEventListener('submit',async(e)=>{
@@ -246,7 +247,7 @@ export async function onRequestGet({ params, request, env }) {
     msg.textContent='Submitting…';
     try{
       const r=await fetch('/api/watch',{method:'POST',headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({domain:${JSON.stringify(domain)},email,list:true})});
+        body:JSON.stringify({domain:${jsonForScript(domain)},email,list:true})});
       const j=await r.json().catch(()=>({}));
       msg.textContent=r.ok?(j.note||'Check your email to confirm and switch on alerts.'):(j.error||'Could not submit. Try again.');
     }catch(_){msg.textContent='Network error. Try again.';}

--- a/packages/web/test/inline-scripts.test.js
+++ b/packages/web/test/inline-scripts.test.js
@@ -104,3 +104,44 @@ test('shared result (/r/:id) inline script is syntactically valid', async () => 
   });
   assertScriptsParse(await res.text(), 'r/:id');
 });
+
+// Regression: values embedded in inline scripts (and JSON-LD) via jsonForScript
+// must not be able to break out of the <script> element. Even though verdict is a
+// fixed pool and domain is hostname-shaped today, a hostile value containing
+// </script> must come out <-escaped, leaving the script tags balanced.
+test('hostile field values cannot break out of inline scripts', async () => {
+  const evil = '</script><img src=x onerror=alert(1)>';
+  const kv = makeKv();
+  const s = {
+    id: 'evil0001',
+    url: 'https://ex.com/' + evil,
+    finalUrl: 'https://ex.com/' + evil,
+    domain: 'ex.com',
+    title: evil,
+    score: 30,
+    tier: 'Heavy',
+    grade: 'D',
+    verdict: 'pwn ' + evil,
+    patternsFlagged: 7,
+    patternsTotal: 27,
+    definitionsVersion: '2026.09',
+    triggered: [{ label: evil, weight: 8 }],
+    createdAt: '2026-06-10T12:00:00.000Z',
+  };
+  await saveResult(kv, s);
+  await recordScan(kv, s);
+
+  for (const [name, fn, params] of [
+    ['r/:id', rGet, { id: 'evil0001' }],
+    ['score', scoreGet, { domain: 'ex.com' }],
+  ]) {
+    const html = await (
+      await fn({ params, request: { url: 'https://slop-detect.com/x' }, env: { RESULTS: kv } })
+    ).text();
+    const opens = (html.match(/<script\b/gi) || []).length;
+    const closes = (html.match(/<\/script>/gi) || []).length;
+    assert.equal(opens, closes, `${name}: unbalanced <script> tags → breakout`);
+    assert.ok(!html.includes('</script><img'), `${name}: raw </script> breakout present`);
+    assert.ok(html.includes('\\u003c'), `${name}: payload should be \\u003c-escaped`);
+  }
+});

--- a/packages/web/test/middleware.test.js
+++ b/packages/web/test/middleware.test.js
@@ -151,6 +151,31 @@ test('SCAN_DISABLED kill switch returns 503 scanning_paused', async () => {
   assert.equal((await res.json()).error, 'scanning_paused');
 });
 
+test('a failed Turnstile 403s WITHOUT incrementing the global daily cap', async () => {
+  // Regression: Turnstile is verified BEFORE the cost guard, so a captcha-less
+  // (or spoofed-Origin) request can't burn the global daily-scan budget and 503
+  // real users. A trusted origin with no X-Turnstile-Token must 403 and leave the
+  // rl:global:scan:<day> counter untouched.
+  const puts = [];
+  const kv = {
+    get: async () => '0',
+    put: async (k) => {
+      puts.push(k);
+    },
+  };
+  const req = makeRequest({
+    headers: { Origin: ALLOWED, 'CF-Connecting-IP': '203.0.113.7' },
+    body: { url: 'https://x.com' },
+  });
+  const res = await onRequest(makeContext(req, { RATE_LIMIT: kv, TURNSTILE_SECRET: 'secret' }));
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'turnstile_required');
+  assert.ok(
+    !puts.some((k) => k.startsWith('rl:global:scan:')),
+    'global daily cap must NOT be incremented when Turnstile fails'
+  );
+});
+
 test('OPTIONS preflight returns 204 regardless of origin', async () => {
   const req = makeRequest({ method: 'OPTIONS', headers: { Origin: 'https://evil.example.com' } });
   const res = await onRequest(makeContext(req));

--- a/packages/web/test/ssrf.test.js
+++ b/packages/web/test/ssrf.test.js
@@ -26,6 +26,15 @@ const BLOCKED = [
   'http://[fc00::1]', // unique-local
   'http://[fe80::1]', // link-local
   'http://::ffff:127.0.0.1', // IPv4-mapped loopback
+  // Regression: new URL() HEX-normalizes the embedded v4 ([::ffff:169.254.169.254]
+  // → [::ffff:a9fe:a9fe]), which the old dotted-decimal-only check let through —
+  // a read-SSRF to cloud metadata. These bracketed mapped/compatible forms must
+  // all be blocked now.
+  'http://[::ffff:169.254.169.254]/latest/meta-data/', // IPv4-mapped metadata
+  'http://[::ffff:127.0.0.1]/', // IPv4-mapped loopback (bracketed)
+  'http://[::169.254.169.254]/', // IPv4-compatible metadata (::/96)
+  'http://[::ffff:10.0.0.5]/', // IPv4-mapped RFC-1918
+  'http://[::ffff:192.168.1.1]/', // IPv4-mapped RFC-1918
   'file:///etc/passwd',
   'data:text/html,<script>',
   'ftp://example.com',
@@ -39,6 +48,9 @@ const ALLOWED = [
   ['http://172.32.0.1', 'http://172.32.0.1'], // just outside 172.16/12
   ['http://11.0.0.1', 'http://11.0.0.1'], // public, adjacent to 10/8
   ['http://8.8.8.8', 'http://8.8.8.8'],
+  // A PUBLIC IPv4-mapped address must still be allowed (we decode + apply the v4
+  // rule, not block the whole form) — guards against over-blocking the fix.
+  ['http://[::ffff:8.8.8.8]/', 'http://[::ffff:8.8.8.8]/'],
 ];
 
 test('SSRF guard blocks private/loopback/metadata/non-http hosts', () => {


### PR DESCRIPTION
Fixes from the end-to-end adversarial review. Each is verified, with regression tests. Base is `main` (the migration stack landed).

## 🔴 Critical
**SSRF bypass via IPv6-embedded IPv4** (`_ssrf.ts`) — `new URL()` hex-normalizes the IPv4 inside an IPv6 literal (`[::ffff:169.254.169.254]` → `[::ffff:a9fe:a9fe]`), which the dotted-decimal-only check let through. Unauthenticated **read-SSRF to cloud metadata / loopback / RFC-1918** via `POST /api/scan` and `/api/aeo`. Fix decodes the embedded v4 from **both dotted and hex** forms (mapped `::ffff:/96` + compatible `::/96`) and re-applies the IPv4 rules; public mapped addresses (`::ffff:8.8.8.8`) stay allowed.

## 🟠 Medium
- **Inline-script / JSON-LD XSS hardening** (`_render.tsx` + 5 views) — new `jsonForScript()` `\u`-escapes `<`/`>`/`&`/line-separators; every JSON embedded in a `<script>` (share/claim scripts, all JSON-LD) now routes through it. Not exploitable today (verdict is fixed-pool, domain is hostname-shaped) but had **zero** defense-in-depth — a hostile `verdict` provably broke out in testing; now closed.
- **Cost-cap before captcha** (`_middleware.ts`) — verify Turnstile **before** incrementing the global daily-scan cap, so a captcha-less / spoofed-`Origin` request can't exhaust the budget and 503 real users.
- **Dashboard-link timing oracle** (`link.ts`) — issue token + send email via `waitUntil` so response latency is identical whether or not the address owns watches.
- **CLI exit codes** (`slop.ts`) — usage errors now exit **2**; exit **1** is reserved for the `--fail-on` gate failure (the CI signal). Tests updated.
- **Token single-use race** (`_data.ts`) — **documented, not code-fixed**: KV has no atomic compare-and-delete, and the blast radius is benign (idempotent re-confirm / same-owner session). Hard single-use needs a Durable Object.

## 🟡 Low / hardening
Drop spoofable `X-Forwarded-For` for rate-limit bucketing · cap AEO response body at 2 MB (streaming) · `--api` requires a value (no flag-swallow) · `aeoRemote` gets the friendly fetch error · honest comment on the post-redirect `location.href` guard (spoofable, not a hard boundary).

## Tests (regression)
- SSRF: bracketed mapped/compatible vectors blocked + public mapped allowed
- XSS: hostile field values → balanced `<script>` tags, no breakout, payload `<`-escaped
- Turnstile: a failed captcha 403s **and** leaves the daily cap counter untouched

**Verified:** typecheck (4 pkgs) · **204 tests / 0 fail** · lint 0 errors · `wrangler pages functions build` compiles.

> Note: the deeper residuals — **DNS-rebinding** SSRF and the page-spoofable `location.href` re-check — are inherent to the Workers runtime (can't resolve-and-pin) and are now documented in-code rather than papered over.

https://claude.ai/code/session_01PAB3RBA5T9P8ahDfUaPVEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAB3RBA5T9P8ahDfUaPVEJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch authentication-adjacent flows (Turnstile, dashboard links, rate limits) and critical SSRF/XSS defenses on user-supplied URLs; regressions could block legitimate scans or re-open internal fetch paths.
> 
> **Overview**
> This PR closes gaps from an adversarial security review across the web API, SSRF guard, rendered pages, and CLI.
> 
> **Critical SSRF fix:** `validateScanUrl` now decodes IPv4 embedded in IPv6-mapped and IPv4-compatible literals in both dotted and hex forms (after `new URL()` normalization), blocking metadata/loopback/RFC-1918 URLs that previously slipped through on `/api/scan` and `/api/aeo`.
> 
> **Medium hardening:** New `jsonForScript()` `\u`-escapes values embedded in inline scripts and JSON-LD across share/claim pages and blog/directory views. API middleware verifies **Turnstile before** incrementing the global daily scan cap, rate-limits using **CF-Connecting-IP only** (no spoofable `X-Forwarded-For`), and dashboard magic-link email is sent via **`waitUntil`** to reduce timing oracles. CLI usage errors exit **2** so exit **1** stays reserved for `--fail-on` CI gates; `--api` must include a value.
> 
> **Low / docs:** AEO HTML bodies are capped at 2 MB via streaming `readCapped`; KV token single-use races are documented; post-redirect `location.href` checks are called out as spoofable, not a hard boundary. Regression tests cover SSRF vectors, script breakout, and Turnstile vs daily cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89405ca0277eb8d254be913bf02ae607b6dd82ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->