### PR TITLE
docs: move Dualmark AEO attribution from inline comments to NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,5 +23,16 @@ The WCAG contrast/luminance helpers in packages/core/src/color.js
 (relativeLuminance, contrastRatio) were likewise adapted from Impeccable's
 shared/color.mjs.
 
+This product also includes AEO (Answer-Engine-Optimization) logic adapted
+from Dualmark (https://github.com/dodopayments/dualmark), Copyright (c) Dodo
+Payments, licensed under the Apache License, Version 2.0.
+
+Specifically, the AI-agent registry and the weighted AEO conformance model
+in packages/core/src/aeo.ts (AI_BOTS, the AEO check ladder, and the markdown-
+twin / llms.txt RECOMMENDED conventions) were adapted from Dualmark's
+@dualmark/core (bots.ts) and re-graded so a plain marketing site can reach
+the top tier without adopting any specific framework. The HTTP probing and
+SSRF-safe fetch boundary are slop-detect's own.
+
 A copy of the Apache License, Version 2.0 is available at:
 https://www.apache.org/licenses/LICENSE-2.0

--- a/packages/core/src/aeo.ts
+++ b/packages/core/src/aeo.ts
@@ -4,23 +4,22 @@
 // ChatGPT/Claude/Perplexity because it blocks their crawlers, serves JS soup, or
 // publishes no machine-readable twin.
 //
-// Adopted from the Dualmark AEO spec (https://github.com/dodopayments/dualmark,
-// Apache-2.0) — specifically its AI-bot registry and weighted conformance model
-// — and reframed for an AI-SEO audience. Unlike Dualmark's `verify` (which
-// assumes you already run their framework and have markdown twins), these checks
-// are graded so that a plain, well-behaved marketing site can still reach the
-// top tier without adopting any specific tool: the markdown-twin / llms.txt
-// checks are RECOMMENDED bonuses, while "AI crawlers aren't blocked" and "the
-// page is indexable" are the REQUIRED fundamentals.
+// The axis is graded so a plain, well-behaved marketing site can reach the top
+// tier without adopting any specific tool: the markdown-twin / llms.txt checks
+// are RECOMMENDED bonuses, while "AI crawlers aren't blocked" and "the page is
+// indexable" are the REQUIRED fundamentals. The AI-bot registry and weighted
+// conformance model are adapted from upstream open-source AEO work — see NOTICE
+// for full attribution.
 //
 // Pure JS, zero deps. `fetch` is injectable so this runs identically in Node
 // (CLI), a Cloudflare Worker (web), or a test. The CALLER is responsible for
 // SSRF validation before passing a URL in (web uses validateScanUrl()).
 
 // ── AI Agent Registry ────────────────────────────────────────────────────────
-// Ported from @dualmark/core bots.ts and refreshed. `purpose` distinguishes
-// training crawlers from on-demand search/answer fetchers — the latter are the
-// ones that decide whether your page gets *cited* in an AI answer.
+// `purpose` distinguishes training crawlers from on-demand search/answer
+// fetchers — the latter are the ones that decide whether your page gets *cited*
+// in an AI answer. Registry derived from upstream open-source AEO work
+// (see NOTICE).
 export const AI_BOTS = [
   {
     name: 'GPTBot',
@@ -500,7 +499,7 @@ export async function runAeoChecks(
     checks.push(result(pickCheck('html.indexable'), false, 'HTML not reachable — cannot verify'));
   }
 
-  // 5. Markdown twin at <url>.md (RECOMMENDED — the Dualmark convention).
+  // 5. Markdown twin at <url>.md (RECOMMENDED — content-negotiation convention).
   const mdUrl = toMarkdownUrl(url.toString());
   let md = null;
   try {


### PR DESCRIPTION
## Summary

`packages/core/src/aeo.ts` had three inline comments attributing the AI-bot registry and weighted AEO conformance model to Dualmark (Apache-2.0). Apache-2.0 §4 requires preserving that attribution in derivatives — but the NOTICE file (where Impeccable's attribution already lives) didn't have a Dualmark block, leaving the inline comments as the sole legal carrier.

This PR consolidates: NOTICE gets a Dualmark block matching the Impeccable one, and the inline comments are rewritten to describe the AEO axis on its own terms with a pointer back to NOTICE.

## Changes

- `NOTICE`: add Dualmark / Apache-2.0 attribution block (alongside the existing Impeccable block).
- `packages/core/src/aeo.ts`: rewrite three comment passages — the file header, the AI Agent Registry header, and the markdown-twin check note — to remove inline upstream references. Comments now describe slop-detect's own behavior and point readers to NOTICE for upstream attribution.

## Why

- Centralizes upstream license attribution in the canonical location (NOTICE).
- Source comments stay focused on what the code does, not where it came from.
- No legal change — Apache-2.0 attribution is preserved in NOTICE.

## Test plan

- [ ] `grep -ri 'dualmark\|dodopayments' packages/` returns no results
- [ ] `NOTICE` is included in the published tarball (it already is)
- [ ] `bun run typecheck -w slop-detect-core` still passes (comments-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and NOTICE-only change; license attribution is preserved with no functional impact.
> 
> **Overview**
> **Apache-2.0 attribution** for the AEO logic (AI-bot registry, weighted checks, markdown-twin / `llms.txt` conventions) moves from inline comments in `packages/core/src/aeo.ts` into **`NOTICE`**, alongside the existing Impeccable block. The NOTICE text spells out what was adapted from Dualmark’s `@dualmark/core` and notes that HTTP probing and the SSRF-safe fetch boundary remain slop-detect’s own.
> 
> In **`aeo.ts`**, three comment-only passages are rewritten: the file header, the AI Agent Registry header, and the markdown-twin check note. They now describe slop-detect’s grading model in neutral terms and defer upstream credit to **NOTICE**, so `packages/` no longer mentions Dualmark by name. **No runtime or API behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c9fa318647eadec3c639dbf8b1d4d3f712a895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->