### PR TITLE
test(web): migrate apps/web from node:test to vitest (14 files, 127 tests)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "dev": "wrangler pages dev public",
-    "deploy": "wrangler pages deploy public --project-name=slop-detector --commit-dirty=true"
+    "deploy": "wrangler pages deploy public --project-name=slop-detector --commit-dirty=true",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@cloudflare/puppeteer": "^1.1.0",

--- a/apps/web/test/alerts.test.js
+++ b/apps/web/test/alerts.test.js
@@ -1,12 +1,11 @@
 // Email sender + alert-copy builders + monitoring sweep + confirm flow.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { sendEmail, emailConfigured } from '../functions/_email.js';
-import { buildVerificationEmail, buildRegressionAlert } from '../functions/_alerts.js';
-import { monitorSweep } from '../functions/_sweep.js';
-import { issueWatchToken, consumeWatchToken, getWatch } from '../functions/_shared.js';
-import { onRequestGet as confirmGet } from '../functions/api/watch/confirm.js';
+import { test, expect } from 'vitest';
+import { sendEmail, emailConfigured } from '../functions/_email.ts';
+import { buildVerificationEmail, buildRegressionAlert } from '../functions/_alerts.ts';
+import { monitorSweep } from '../functions/_sweep.ts';
+import { issueWatchToken, consumeWatchToken, getWatch } from '../functions/_shared.ts';
+import { onRequestGet as confirmGet } from '../functions/api/watch/confirm.tsx';
 
 function makeKv(seed = {}) {
   const store = new Map(
@@ -35,9 +34,9 @@ function makeKv(seed = {}) {
 
 // ── email sender ─────────────────────────────────────────────────────────────
 test('emailConfigured reflects RESEND_API_KEY + ALERT_FROM', () => {
-  assert.equal(emailConfigured({}), false);
-  assert.equal(emailConfigured({ RESEND_API_KEY: 'x' }), false);
-  assert.equal(emailConfigured({ RESEND_API_KEY: 'x', ALERT_FROM: 'a@b.com' }), true);
+  expect(emailConfigured({})).toBe(false);
+  expect(emailConfigured({ RESEND_API_KEY: 'x' })).toBe(false);
+  expect(emailConfigured({ RESEND_API_KEY: 'x', ALERT_FROM: 'a@b.com' })).toBe(true);
 });
 
 test('sendEmail no-ops (does not throw) when no provider is configured', async () => {
@@ -46,9 +45,9 @@ test('sendEmail no-ops (does not throw) when no provider is configured', async (
     called = true;
     return new Response('', { status: 200 });
   });
-  assert.equal(r.sent, false);
-  assert.equal(r.reason, 'no_provider');
-  assert.equal(called, false, 'must not hit the network without a provider');
+  expect(r.sent).toBe(false);
+  expect(r.reason).toBe('no_provider');
+  expect(called, 'must not hit the network without a provider').toBe(false);
 });
 
 test('sendEmail posts to Resend when configured', async () => {
@@ -59,11 +58,11 @@ test('sendEmail posts to Resend when configured', async () => {
     return new Response(JSON.stringify({ id: 'em_1' }), { status: 200 });
   };
   const r = await sendEmail(env, { to: 'dev@x.io', subject: 'Hi', text: 'Body' }, fetchImpl);
-  assert.equal(r.sent, true);
-  assert.equal(r.id, 'em_1');
-  assert.match(seen.url, /api\.resend\.com/);
-  assert.equal(seen.body.to[0], 'dev@x.io');
-  assert.equal(seen.auth, 'Bearer k');
+  expect(r.sent).toBe(true);
+  expect(r.id).toBe('em_1');
+  expect(seen.url).toMatch(/api\.resend\.com/);
+  expect(seen.body.to[0]).toBe('dev@x.io');
+  expect(seen.auth).toBe('Bearer k');
 });
 
 test('sendEmail reports failure but does not throw on a non-2xx', async () => {
@@ -73,8 +72,8 @@ test('sendEmail reports failure but does not throw on a non-2xx', async () => {
     { to: 'd@x.io', subject: 's', text: 't' },
     async () => new Response('nope', { status: 422 })
   );
-  assert.equal(r.sent, false);
-  assert.equal(r.reason, 'http_422');
+  expect(r.sent).toBe(false);
+  expect(r.reason).toBe('http_422');
 });
 
 // ── copy builders ────────────────────────────────────────────────────────────
@@ -83,9 +82,9 @@ test('verification email carries the confirm link and a privacy line', () => {
     'example.com',
     'https://slop-detect.com/api/watch/confirm?token=abc'
   );
-  assert.match(m.subject, /example\.com/);
-  assert.match(m.text, /confirm\?token=abc/);
-  assert.match(m.text, /privacy/i);
+  expect(m.subject).toMatch(/example\.com/);
+  expect(m.text).toMatch(/confirm\?token=abc/);
+  expect(m.text).toMatch(/privacy/i);
 });
 
 test('regression alert shows baseline vs now, tier drop, and unsubscribe', () => {
@@ -95,12 +94,12 @@ test('regression alert shows baseline vs now, tier drop, and unsubscribe', () =>
     { score: 30, grade: 'C', tier: 'Heavy' },
     { resultUrl: 'https://slop-detect.com/r/abc' }
   );
-  assert.match(m.subject, /example\.com/);
-  assert.match(m.text, /A-/);
-  assert.match(m.text, /Heavy/);
-  assert.match(m.text, /Clean → Heavy/);
-  assert.match(m.text, /\/r\/abc/);
-  assert.match(m.text, /unsubscribe/i);
+  expect(m.subject).toMatch(/example\.com/);
+  expect(m.text).toMatch(/A-/);
+  expect(m.text).toMatch(/Heavy/);
+  expect(m.text).toMatch(/Clean → Heavy/);
+  expect(m.text).toMatch(/\/r\/abc/);
+  expect(m.text).toMatch(/unsubscribe/i);
 });
 
 // ── sweep logic ──────────────────────────────────────────────────────────────
@@ -128,27 +127,27 @@ function sweepHarness(watches) {
 test('sweep alerts a verified, regressed, not-yet-notified domain exactly once', async () => {
   const h = sweepHarness([{ domain: 'a.com', verified: true, regressed: true, notified: false }]);
   const s1 = await h.run();
-  assert.equal(s1.alerted, 1);
-  assert.deepEqual(h.sent, ['a.com']);
-  assert.equal(h.store.get('a.com').notified, true);
+  expect(s1.alerted).toBe(1);
+  expect(h.sent).toEqual(['a.com']);
+  expect(h.store.get('a.com').notified).toBe(true);
   // Second sweep: already notified → no duplicate alert.
   const s2 = await h.run();
-  assert.equal(s2.alerted, 0);
-  assert.deepEqual(h.sent, ['a.com']);
+  expect(s2.alerted).toBe(0);
+  expect(h.sent).toEqual(['a.com']);
 });
 
 test('sweep skips unverified domains (consent gate)', async () => {
   const h = sweepHarness([{ domain: 'a.com', verified: false, regressed: true, notified: false }]);
   const s = await h.run();
-  assert.equal(s.skippedUnverified, 1);
-  assert.equal(s.alerted, 0);
-  assert.deepEqual(h.sent, []);
+  expect(s.skippedUnverified).toBe(1);
+  expect(s.alerted).toBe(0);
+  expect(h.sent).toEqual([]);
 });
 
 test('sweep does not alert a verified domain that is not regressed', async () => {
   const h = sweepHarness([{ domain: 'a.com', verified: true, regressed: false, notified: false }]);
   const s = await h.run();
-  assert.equal(s.alerted, 0);
+  expect(s.alerted).toBe(0);
 });
 
 test('sweep respects max and records errors without aborting', async () => {
@@ -167,17 +166,17 @@ test('sweep respects max and records errors without aborting', async () => {
     sendAlert: async () => ({ sent: true }),
     max: 5,
   });
-  assert.equal(s.errors, 1); // a.com threw
-  assert.equal(s.alerted, 1); // b.com still alerted
+  expect(s.errors).toBe(1); // a.com threw
+  expect(s.alerted).toBe(1); // b.com still alerted
 });
 
 // ── token + confirm flow ─────────────────────────────────────────────────────
 test('issue/consume token is single-use', async () => {
   const kv = makeKv();
   const token = await issueWatchToken(kv, 'example.com');
-  assert.ok(token && token.length >= 16);
-  assert.equal(await consumeWatchToken(kv, token), 'example.com');
-  assert.equal(await consumeWatchToken(kv, token), null, 'second use is rejected');
+  expect(token && token.length >= 16).toBeTruthy();
+  expect(await consumeWatchToken(kv, token)).toBe('example.com');
+  expect(await consumeWatchToken(kv, token), 'second use is rejected').toBe(null);
 });
 
 test('GET /api/watch/confirm flips the watch to verified', async () => {
@@ -189,9 +188,9 @@ test('GET /api/watch/confirm flips the watch to verified', async () => {
     request: { url: `https://slop-detect.com/api/watch/confirm?token=${token}` },
     env: { RESULTS: kv },
   });
-  assert.equal(res.status, 200);
-  assert.match(await res.text(), /all set/i);
-  assert.equal((await getWatch(kv, 'example.com')).verified, true);
+  expect(res.status).toBe(200);
+  expect(await res.text()).toMatch(/all set/i);
+  expect((await getWatch(kv, 'example.com')).verified).toBe(true);
 });
 
 test('GET /api/watch/confirm rejects a bad/expired token with 410', async () => {
@@ -200,5 +199,5 @@ test('GET /api/watch/confirm rejects a bad/expired token with 410', async () => 
     request: { url: 'https://slop-detect.com/api/watch/confirm?token=nope' },
     env: { RESULTS: kv },
   });
-  assert.equal(res.status, 410);
+  expect(res.status).toBe(410);
 });

--- a/apps/web/test/api-stats.test.js
+++ b/apps/web/test/api-stats.test.js
@@ -1,10 +1,9 @@
 // GET /api/stats — homepage hub aggregate stats. Wraps getStats; verify the
 // handler shape + the no-storage fallback.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { onRequestGet } from '../functions/api/stats.js';
-import { recordScan } from '../functions/_shared.js';
+import { test, expect } from 'vitest';
+import { onRequestGet } from '../functions/api/stats.ts';
+import { recordScan } from '../functions/_shared.ts';
 
 function makeKv() {
   const s = new Map();
@@ -26,17 +25,17 @@ test('GET /api/stats returns aggregate counts from the distribution', async () =
   await recordScan(kv, { id: 'a', domain: 'a.com', score: 4, tier: 'Clean' });
   await recordScan(kv, { id: 'b', domain: 'b.com', score: 30, tier: 'Heavy' });
   const res = await onRequestGet({ env: { RESULTS: kv } });
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
   const j = await res.json();
-  assert.equal(j.count, 2);
-  assert.equal(j.clean, 1);
-  assert.equal(j.heavy, 1);
-  assert.equal(j.slopShare, 50);
+  expect(j.count).toBe(2);
+  expect(j.clean).toBe(1);
+  expect(j.heavy).toBe(1);
+  expect(j.slopShare).toBe(50);
 });
 
 test('GET /api/stats is safe with no storage configured', async () => {
   const res = await onRequestGet({ env: {} });
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
   const j = await res.json();
-  assert.equal(j.count, 0);
+  expect(j.count).toBe(0);
 });

--- a/apps/web/test/blog.test.js
+++ b/apps/web/test/blog.test.js
@@ -1,35 +1,33 @@
 // /blog index + /blog/<slug> (HTML and the .md twin) render from _posts.js.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { onRequestGet as indexGet } from '../functions/blog.js';
-import { onRequestGet as postGet } from '../functions/blog/[slug].js';
-import { POSTS, mdToHtml } from '../functions/_posts.js';
+import { test, expect } from 'vitest';
+import { onRequestGet as indexGet } from '../functions/blog.tsx';
+import { onRequestGet as postGet } from '../functions/blog/[slug].tsx';
+import { POSTS, mdToHtml } from '../functions/_posts.ts';
 
 const req = (path) => ({ url: `https://slop-detect.com${path}` });
 
 test('/blog lists every post with a link', async () => {
   const res = await indexGet({ request: req('/blog') });
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
   const html = await res.text();
   for (const p of POSTS) {
-    assert.match(html, new RegExp(p.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    assert.match(html, new RegExp(`/blog/${p.slug}`));
+    expect(html).toMatch(new RegExp(p.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    expect(html).toMatch(new RegExp(`/blog/${p.slug}`));
   }
-  assert.match(html, /application\/ld\+json/);
+  expect(html).toMatch(/application\/ld\+json/);
 });
 
 test('/blog/<slug> renders the post HTML with structured data + a twin link', async () => {
   const slug = 'how-the-slop-score-works';
   const res = await postGet({ params: { slug }, request: req(`/blog/${slug}`) });
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
   const html = await res.text();
-  assert.match(html, /How the slop score works/);
-  assert.match(html, /<h2>Deterministic by design<\/h2>/);
-  assert.match(html, /BlogPosting/);
-  assert.match(html, new RegExp(`rel="canonical" href="https://slop-detect.com/blog/${slug}"`));
-  assert.match(
-    html,
+  expect(html).toMatch(/How the slop score works/);
+  expect(html).toMatch(/<h2>Deterministic by design<\/h2>/);
+  expect(html).toMatch(/BlogPosting/);
+  expect(html).toMatch(new RegExp(`rel="canonical" href="https://slop-detect.com/blog/${slug}"`));
+  expect(html).toMatch(
     new RegExp(
       `rel="alternate" type="text/markdown" href="https://slop-detect.com/blog/${slug}.md"`
     )
@@ -41,24 +39,24 @@ test('/blog/<slug>.md serves the raw markdown twin', async () => {
     params: { slug: 'how-the-slop-score-works.md' },
     request: req('/blog/how-the-slop-score-works.md'),
   });
-  assert.equal(res.status, 200);
-  assert.match(res.headers.get('Content-Type'), /text\/markdown/);
+  expect(res.status).toBe(200);
+  expect(res.headers.get('Content-Type')).toMatch(/text\/markdown/);
   const md = await res.text();
-  assert.match(md, /^# How the slop score works/);
+  expect(md).toMatch(/^# How the slop score works/);
 });
 
 test('unknown slug returns 404', async () => {
   const res = await postGet({ params: { slug: 'nope' }, request: req('/blog/nope') });
-  assert.equal(res.status, 404);
+  expect(res.status).toBe(404);
 });
 
 test('mdToHtml renders blocks and escapes HTML in inline code', () => {
   const html = mdToHtml(
     '## Head\n\n- one\n- two\n\nUse `npx slop-detect <url>` and **bold** text and a [link](https://x.com).'
   );
-  assert.match(html, /<h2>Head<\/h2>/);
-  assert.match(html, /<ul><li>one<\/li><li>two<\/li><\/ul>/);
-  assert.match(html, /<code>npx slop-detect &lt;url&gt;<\/code>/); // angle brackets escaped
-  assert.match(html, /<strong>bold<\/strong>/);
-  assert.match(html, /<a href="https:\/\/x\.com">link<\/a>/);
+  expect(html).toMatch(/<h2>Head<\/h2>/);
+  expect(html).toMatch(/<ul><li>one<\/li><li>two<\/li><\/ul>/);
+  expect(html).toMatch(/<code>npx slop-detect &lt;url&gt;<\/code>/); // angle brackets escaped
+  expect(html).toMatch(/<strong>bold<\/strong>/);
+  expect(html).toMatch(/<a href="https:\/\/x\.com">link<\/a>/);
 });

--- a/apps/web/test/dashboard.test.js
+++ b/apps/web/test/dashboard.test.js
@@ -1,23 +1,22 @@
 // Agency dashboard (P2b): HMAC sessions, magic-link tokens, the link endpoint's
 // anti-enumeration guarantee, and the /dashboard page's auth + isolation.
 
-import { test, afterEach } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect, afterEach } from 'vitest';
 import {
   signSession,
   verifySession,
   sessionCookie,
   clearSessionCookie,
   readSessionToken,
-} from '../functions/_session.js';
+} from '../functions/_session.ts';
 import {
   issueDashboardToken,
   consumeDashboardToken,
   listWatchesByEmail,
-} from '../functions/_shared.js';
-import { buildDashboardLinkEmail } from '../functions/_alerts.js';
-import { onRequestPost as linkPost } from '../functions/api/dashboard/link.js';
-import { onRequestGet as dashGet } from '../functions/dashboard.js';
+} from '../functions/_shared.ts';
+import { buildDashboardLinkEmail } from '../functions/_alerts.ts';
+import { onRequestPost as linkPost } from '../functions/api/dashboard/link.ts';
+import { onRequestGet as dashGet } from '../functions/dashboard.tsx';
 
 const SECRET = 'test-secret-0123456789';
 
@@ -72,38 +71,38 @@ afterEach(() => {
 // ── sessions ─────────────────────────────────────────────────────────────────
 test('session round-trips; tampering, expiry, and wrong secret all reject', async () => {
   const tok = await signSession('a@x.io', SECRET);
-  assert.equal(await verifySession(tok, SECRET), 'a@x.io');
+  expect(await verifySession(tok, SECRET)).toBe('a@x.io');
 
   // Tampered signature.
-  assert.equal(await verifySession(tok.slice(0, -2) + 'ff', SECRET), null);
+  expect(await verifySession(tok.slice(0, -2) + 'ff', SECRET)).toBe(null);
   // Tampered payload (forge a different email, keep the old signature).
   const [, sig] = [tok.slice(0, tok.lastIndexOf('.')), tok.slice(tok.lastIndexOf('.') + 1)];
   const forged =
     btoa(JSON.stringify({ e: 'evil@x.io', x: Date.now() + 9e9 })).replace(/=+$/, '') + '.' + sig;
-  assert.equal(await verifySession(forged, SECRET), null);
+  expect(await verifySession(forged, SECRET)).toBe(null);
   // Expired.
   const old = await signSession('a@x.io', SECRET, { ttlMs: 1000, now: Date.now() - 5000 });
-  assert.equal(await verifySession(old, SECRET), null);
+  expect(await verifySession(old, SECRET)).toBe(null);
   // Wrong secret.
-  assert.equal(await verifySession(tok, 'other-secret'), null);
+  expect(await verifySession(tok, 'other-secret')).toBe(null);
 });
 
 test('session cookie is HttpOnly+Secure and readable back off the request', async () => {
   const tok = await signSession('a@x.io', SECRET);
   const cookie = sessionCookie(tok);
-  assert.match(cookie, /HttpOnly/);
-  assert.match(cookie, /Secure/);
-  assert.match(cookie, /SameSite=Lax/);
-  assert.equal(readSessionToken(getReq('https://x/', cookie.split(';')[0])), tok);
-  assert.match(clearSessionCookie(), /Max-Age=0/);
+  expect(cookie).toMatch(/HttpOnly/);
+  expect(cookie).toMatch(/Secure/);
+  expect(cookie).toMatch(/SameSite=Lax/);
+  expect(readSessionToken(getReq('https://x/', cookie.split(';')[0]))).toBe(tok);
+  expect(clearSessionCookie()).toMatch(/Max-Age=0/);
 });
 
 // ── tokens + per-email listing ───────────────────────────────────────────────
 test('dashboard tokens are single-use', async () => {
   const kv = makeKv();
   const t = await issueDashboardToken(kv, 'a@x.io');
-  assert.equal(await consumeDashboardToken(kv, t), 'a@x.io');
-  assert.equal(await consumeDashboardToken(kv, t), null);
+  expect(await consumeDashboardToken(kv, t)).toBe('a@x.io');
+  expect(await consumeDashboardToken(kv, t)).toBe(null);
 });
 
 test('listWatchesByEmail returns only that owner, case-normalized', async () => {
@@ -113,7 +112,7 @@ test('listWatchesByEmail returns only that owner, case-normalized', async () => 
     'w:c.com': watch('c.com', 'other@y.io'),
   });
   const mine = await listWatchesByEmail(kv, '  Agency@X.io ');
-  assert.deepEqual(mine.map((w) => w.domain).sort(), ['a.com', 'b.com']);
+  expect(mine.map((w) => w.domain).sort()).toEqual(['a.com', 'b.com']);
 });
 
 // ── /api/dashboard/link ──────────────────────────────────────────────────────
@@ -121,7 +120,7 @@ const LIVE_ENV = { RESEND_API_KEY: 'k', ALERT_FROM: 'a@slop-detect.com', SESSION
 
 test('link endpoint is configured-off without provider/secret', async () => {
   const res = await linkPost({ request: postReq({ email: 'a@x.io' }), env: { RESULTS: makeKv() } });
-  assert.equal(res.status, 503);
+  expect(res.status).toBe(503);
 });
 
 test('link endpoint never reveals whether an email has watches (anti-enumeration)', async () => {
@@ -136,21 +135,21 @@ test('link endpoint never reveals whether an email has watches (anti-enumeration
   const r1 = await linkPost({ request: postReq({ email: 'known@x.io' }), env });
   const r2 = await linkPost({ request: postReq({ email: 'unknown@x.io' }), env });
   const [b1, b2] = [await r1.json(), await r2.json()];
-  assert.equal(r1.status, r2.status);
-  assert.deepEqual(b1, b2, 'identical bodies for known and unknown emails');
+  expect(r1.status).toBe(r2.status);
+  expect(b1, 'identical bodies for known and unknown emails').toEqual(b2);
 
   // …but only the known email actually got a message, with a token link in it.
-  assert.equal(sent.length, 1);
-  assert.equal(sent[0].to[0], 'known@x.io');
-  assert.match(sent[0].text, /\/dashboard\?token=/);
+  expect(sent.length).toBe(1);
+  expect(sent[0].to[0]).toBe('known@x.io');
+  expect(sent[0].text).toMatch(/\/dashboard\?token=/);
 });
 
 test('dashboard link email copy: single-use, 15 minutes, privacy', () => {
   const m = buildDashboardLinkEmail('https://slop-detect.com/dashboard?token=abc', 3);
-  assert.match(m.text, /token=abc/);
-  assert.match(m.text, /single-use/);
-  assert.match(m.text, /15 minutes/);
-  assert.match(m.text, /privacy/i);
+  expect(m.text).toMatch(/token=abc/);
+  expect(m.text).toMatch(/single-use/);
+  expect(m.text).toMatch(/15 minutes/);
+  expect(m.text).toMatch(/privacy/i);
 });
 
 // ── /dashboard page ──────────────────────────────────────────────────────────
@@ -159,7 +158,7 @@ test('/dashboard is configured-off without SESSION_SECRET', async () => {
     request: getReq('https://slop-detect.com/dashboard'),
     env: { RESULTS: makeKv() },
   });
-  assert.match(await res.text(), /not configured/i);
+  expect(await res.text()).toMatch(/not configured/i);
 });
 
 test('/dashboard without a cookie shows the login form, no domains', async () => {
@@ -169,8 +168,8 @@ test('/dashboard without a cookie shows the login form, no domains', async () =>
     env: { RESULTS: kv, SESSION_SECRET: SECRET },
   });
   const html = await res.text();
-  assert.match(html, /Sign in to your dashboard/);
-  assert.ok(!html.includes('a.com'), 'no domains before auth');
+  expect(html).toMatch(/Sign in to your dashboard/);
+  expect(html.includes('a.com'), 'no domains before auth').toBeFalsy();
 });
 
 test('a valid magic-link token mints a session cookie and redirects clean', async () => {
@@ -180,15 +179,15 @@ test('a valid magic-link token mints a session cookie and redirects clean', asyn
     request: getReq(`https://slop-detect.com/dashboard?token=${t}`),
     env: { RESULTS: kv, SESSION_SECRET: SECRET },
   });
-  assert.equal(res.status, 302);
-  assert.equal(res.headers.get('Location'), 'https://slop-detect.com/dashboard');
+  expect(res.status).toBe(302);
+  expect(res.headers.get('Location')).toBe('https://slop-detect.com/dashboard');
   const setCookie = res.headers.get('Set-Cookie');
-  assert.match(setCookie, /sd_session=/);
+  expect(setCookie).toMatch(/sd_session=/);
   // The minted cookie verifies back to the email.
   const minted = setCookie.match(/sd_session=([^;]+)/)[1];
-  assert.equal(await verifySession(minted, SECRET), 'agency@x.io');
+  expect(await verifySession(minted, SECRET)).toBe('agency@x.io');
   // And the token burned.
-  assert.equal(await consumeDashboardToken(kv, t), null);
+  expect(await consumeDashboardToken(kv, t)).toBe(null);
 });
 
 test('a bad/expired token falls back to login with an expiry note', async () => {
@@ -196,7 +195,7 @@ test('a bad/expired token falls back to login with an expiry note', async () => 
     request: getReq('https://slop-detect.com/dashboard?token=nope'),
     env: { RESULTS: makeKv(), SESSION_SECRET: SECRET },
   });
-  assert.match(await res.text(), /expired or was already used/i);
+  expect(await res.text()).toMatch(/expired or was already used/i);
 });
 
 test('a signed-in agency sees ONLY its own domains — never another owner’s', async () => {
@@ -211,12 +210,12 @@ test('a signed-in agency sees ONLY its own domains — never another owner’s',
     env: { RESULTS: kv, SESSION_SECRET: SECRET },
   });
   const html = await res.text();
-  assert.match(html, /a\.com/);
-  assert.match(html, /b\.com/);
-  assert.match(html, /drifted/, 'drift flag surfaced');
-  assert.match(html, /\/report\/a\.com/, 'per-domain report linked');
-  assert.ok(!html.includes('secret.com'), 'another owner’s domain must never render');
-  assert.ok(!html.includes('other@y.io'), 'another owner’s email must never render');
+  expect(html).toMatch(/a\.com/);
+  expect(html).toMatch(/b\.com/);
+  expect(html, 'drift flag surfaced').toMatch(/drifted/);
+  expect(html, 'per-domain report linked').toMatch(/\/report\/a\.com/);
+  expect(html.includes('secret.com'), 'another owner’s domain must never render').toBeFalsy();
+  expect(html.includes('other@y.io'), 'another owner’s email must never render').toBeFalsy();
 });
 
 test('?logout=1 clears the cookie and returns to login', async () => {
@@ -224,6 +223,6 @@ test('?logout=1 clears the cookie and returns to login', async () => {
     request: getReq('https://slop-detect.com/dashboard?logout=1'),
     env: { RESULTS: makeKv(), SESSION_SECRET: SECRET },
   });
-  assert.match(res.headers.get('Set-Cookie'), /Max-Age=0/);
-  assert.match(await res.text(), /Sign in to your dashboard/);
+  expect(res.headers.get('Set-Cookie')).toMatch(/Max-Age=0/);
+  expect(await res.text()).toMatch(/Sign in to your dashboard/);
 });

--- a/apps/web/test/drift.test.js
+++ b/apps/web/test/drift.test.js
@@ -2,8 +2,7 @@
 // Pure predicate, watch tracking, sweep alerting, email copy, the /api/watch
 // opt-in flag, and /report/:domain rendering — all against in-memory mocks.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
 import {
   isSystemDrift,
   recordScanForWatch,
@@ -11,11 +10,11 @@ import {
   slimResult,
   publicWatch,
   getHistory,
-} from '../functions/_shared.js';
-import { monitorSweep } from '../functions/_sweep.js';
-import { buildDriftAlert } from '../functions/_alerts.js';
-import { onRequestPost as watchPost } from '../functions/api/watch.js';
-import { onRequestGet as reportGet } from '../functions/report/[domain].js';
+} from '../functions/_shared.ts';
+import { monitorSweep } from '../functions/_sweep.ts';
+import { buildDriftAlert } from '../functions/_alerts.ts';
+import { onRequestPost as watchPost } from '../functions/api/watch.ts';
+import { onRequestGet as reportGet } from '../functions/report/[domain].tsx';
 
 function makeKv(seed = {}) {
   const store = new Map(
@@ -59,40 +58,30 @@ const sysSlim = (sysOver = {}, over = {}) =>
 
 // ── isSystemDrift (pure) ─────────────────────────────────────────────────────
 test('isSystemDrift: falling from an Aligned baseline is drift', () => {
-  assert.equal(
-    isSystemDrift({ score: 90, tier: 'Aligned' }, { score: 60, tier: 'Drifting' }),
-    true
-  );
-  assert.equal(
-    isSystemDrift({ score: 90, tier: 'Aligned' }, { score: 30, tier: 'Off-system' }),
+  expect(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: 60, tier: 'Drifting' })).toBe(true);
+  expect(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: 30, tier: 'Off-system' })).toBe(
     true
   );
 });
 
 test('isSystemDrift: staying Aligned, or improving, is never drift', () => {
-  assert.equal(
-    isSystemDrift({ score: 85, tier: 'Aligned' }, { score: 82, tier: 'Aligned' }),
-    false
-  );
-  assert.equal(
-    isSystemDrift({ score: 40, tier: 'Off-system' }, { score: 70, tier: 'Drifting' }),
+  expect(isSystemDrift({ score: 85, tier: 'Aligned' }, { score: 82, tier: 'Aligned' })).toBe(false);
+  expect(isSystemDrift({ score: 40, tier: 'Off-system' }, { score: 70, tier: 'Drifting' })).toBe(
     false
   );
 });
 
 test('isSystemDrift: a never-Aligned site only drifts on a meaningful worsening (≥15)', () => {
   const base = { score: 60, tier: 'Drifting' };
-  assert.equal(isSystemDrift(base, { score: 55, tier: 'Drifting' }), false, '-5 is noise');
-  assert.equal(isSystemDrift(base, { score: 45, tier: 'Drifting' }), true, '-15 is drift');
+  expect(isSystemDrift(base, { score: 55, tier: 'Drifting' }), '-5 is noise').toBe(false);
+  expect(isSystemDrift(base, { score: 45, tier: 'Drifting' }), '-15 is drift').toBe(true);
 });
 
 test('isSystemDrift: No system / No data tiers never drift', () => {
-  assert.equal(
-    isSystemDrift({ score: 90, tier: 'Aligned' }, { score: null, tier: 'No system' }),
+  expect(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: null, tier: 'No system' })).toBe(
     false
   );
-  assert.equal(
-    isSystemDrift({ score: 90, tier: 'Aligned' }, { score: null, tier: 'No data' }),
+  expect(isSystemDrift({ score: 90, tier: 'Aligned' }, { score: null, tier: 'No data' })).toBe(
     false
   );
 });
@@ -116,15 +105,15 @@ test('slimResult persists a compact system block only when the axis ran', () => 
     },
     'id1'
   );
-  assert.equal(withSys.system.score, 70);
-  assert.equal(withSys.system.drift[0].id, 'fonts.declared');
-  assert.equal(withSys.system.drift[0].evidence, undefined, 'evidence blobs are not persisted');
+  expect(withSys.system.score).toBe(70);
+  expect(withSys.system.drift[0].id).toBe('fonts.declared');
+  expect(withSys.system.drift[0].evidence, 'evidence blobs are not persisted').toBe(undefined);
 
   const noSys = slimResult(
     { url: 'https://x.com', score: 8, tier: 'Clean', grade: 'A-', patterns: [] },
     'id2'
   );
-  assert.equal(noSys.system, undefined);
+  expect(noSys.system).toBe(undefined);
 
   const undeclared = slimResult(
     {
@@ -137,10 +126,8 @@ test('slimResult persists a compact system block only when the axis ran', () => 
     },
     'id3'
   );
-  assert.equal(
-    undeclared.system,
-    undefined,
-    'No-system results are not persisted as compliance data'
+  expect(undeclared.system, 'No-system results are not persisted as compliance data').toBe(
+    undefined
   );
 });
 
@@ -157,10 +144,10 @@ test('recordScanForWatch sets a system baseline, then flags drift and resets on 
 
   // First system reading establishes the baseline (Aligned 95) — no drift.
   let out = await recordScanForWatch(kv, sysSlim({}, { id: 's1' }));
-  assert.equal(out.system.drifted, false);
+  expect(out.system.drifted).toBe(false);
   let w = await getWatch(kv, 'example.com');
-  assert.equal(w.baselineSystemScore, 95);
-  assert.equal(w.baselineSystemTier, 'Aligned');
+  expect(w.baselineSystemScore).toBe(95);
+  expect(w.baselineSystemTier).toBe('Aligned');
 
   // Agent pushes off-system change → drift flagged, drift items stored.
   out = await recordScanForWatch(
@@ -174,24 +161,24 @@ test('recordScanForWatch sets a system baseline, then flags drift and resets on 
       { id: 's2' }
     )
   );
-  assert.equal(out.system.drifted, true);
+  expect(out.system.drifted).toBe(true);
   w = await getWatch(kv, 'example.com');
-  assert.equal(w.systemRegressed, true);
-  assert.equal(w.lastSystemDrift[0].id, 'colors.cta');
-  assert.equal(w.baselineSystemScore, 95, 'baseline must not move');
+  expect(w.systemRegressed).toBe(true);
+  expect(w.lastSystemDrift[0].id).toBe('colors.cta');
+  expect(w.baselineSystemScore, 'baseline must not move').toBe(95);
 
   // Recovery → flag clears and systemNotified re-arms.
   w.systemNotified = true;
   await kv.put('w:example.com', JSON.stringify(w));
   out = await recordScanForWatch(kv, sysSlim({}, { id: 's3' }));
   w = await getWatch(kv, 'example.com');
-  assert.equal(w.systemRegressed, false);
-  assert.equal(w.systemNotified, false, 'recovery re-arms the alert');
+  expect(w.systemRegressed).toBe(false);
+  expect(w.systemNotified, 'recovery re-arms the alert').toBe(false);
 
   // History points carry the system reading.
   const hist = await getHistory(kv, 'example.com');
-  assert.equal(hist.length, 3);
-  assert.equal(hist[1].sys.tier, 'Drifting');
+  expect(hist.length).toBe(3);
+  expect(hist[1].sys.tier).toBe('Drifting');
 });
 
 test('a designMd-less scan does not erase system state', async () => {
@@ -208,8 +195,8 @@ test('a designMd-less scan does not erase system state', async () => {
   });
   await recordScanForWatch(kv, slim({ id: 'plain' })); // no .system
   const w = await getWatch(kv, 'example.com');
-  assert.equal(w.lastSystemScore, 55, 'system reading untouched');
-  assert.equal(w.systemRegressed, true, 'drift flag untouched');
+  expect(w.lastSystemScore, 'system reading untouched').toBe(55);
+  expect(w.systemRegressed, 'drift flag untouched').toBe(true);
 });
 
 // ── sweep: drift alert once, recovery re-arms; scanDomain gets the watch ─────
@@ -256,13 +243,13 @@ test('sweep fires the drift alert exactly once per drift event', async () => {
     },
   ]);
   const s1 = await h.run();
-  assert.equal(s1.driftAlerted, 1);
-  assert.equal(s1.alerted, 0, 'slop alert independent of drift alert');
-  assert.deepEqual(h.drifted, ['a.com']);
-  assert.equal(h.store.get('a.com').systemNotified, true);
+  expect(s1.driftAlerted).toBe(1);
+  expect(s1.alerted, 'slop alert independent of drift alert').toBe(0);
+  expect(h.drifted).toEqual(['a.com']);
+  expect(h.store.get('a.com').systemNotified).toBe(true);
 
   const s2 = await h.run();
-  assert.equal(s2.driftAlerted, 0, 'no duplicate drift alert');
+  expect(s2.driftAlerted, 'no duplicate drift alert').toBe(0);
 });
 
 test('sweep can fire BOTH alerts in one pass and passes the watch to scanDomain', async () => {
@@ -278,9 +265,9 @@ test('sweep can fire BOTH alerts in one pass and passes the watch to scanDomain'
     },
   ]);
   const s = await h.run();
-  assert.equal(s.alerted, 1);
-  assert.equal(s.driftAlerted, 1);
-  assert.deepEqual(h.scanned, [{ domain: 'b.com', system: true }], 'scanDomain sees watch.system');
+  expect(s.alerted).toBe(1);
+  expect(s.driftAlerted).toBe(1);
+  expect(h.scanned, 'scanDomain sees watch.system').toEqual([{ domain: 'b.com', system: true }]);
 });
 
 test('sweep without a sendDriftAlert callback skips drift silently (backward compatible)', async () => {
@@ -294,7 +281,7 @@ test('sweep without a sendDriftAlert callback skips drift silently (backward com
     putWatch: async (w) => store.set(w.domain, w),
     sendAlert: async () => ({ sent: true }),
   });
-  assert.equal(s.driftAlerted, 0);
+  expect(s.driftAlerted).toBe(0);
 });
 
 // ── drift email copy ─────────────────────────────────────────────────────────
@@ -306,12 +293,12 @@ test('buildDriftAlert names the drift, frames signals-not-verdicts, offers unsub
     [{ id: 'fonts.declared', message: 'font(s) in use but not in the system: inter' }],
     { resultUrl: 'https://slop-detect.com/r/abc' }
   );
-  assert.match(m.subject, /example\.com/);
-  assert.match(m.subject, /Aligned → Drifting/);
-  assert.match(m.text, /inter/);
-  assert.match(m.text, /not a verdict/i);
-  assert.match(m.text, /unsubscribe/i);
-  assert.match(m.text, /\/r\/abc/);
+  expect(m.subject).toMatch(/example\.com/);
+  expect(m.subject).toMatch(/Aligned → Drifting/);
+  expect(m.text).toMatch(/inter/);
+  expect(m.text).toMatch(/not a verdict/i);
+  expect(m.text).toMatch(/unsubscribe/i);
+  expect(m.text).toMatch(/\/r\/abc/);
 });
 
 // ── /api/watch { system: true } opt-in ──────────────────────────────────────
@@ -325,12 +312,12 @@ test('POST /api/watch { system:true } enables compliance monitoring; omit preser
     env,
   });
   let j = await res.json();
-  assert.equal(j.systemMonitoring, true);
+  expect(j.systemMonitoring).toBe(true);
 
   // Re-subscribe without the flag — preserved.
   res = await watchPost({ request: req({ domain: 'example.com', email: 'o@x.io' }), env });
   j = await res.json();
-  assert.equal(j.systemMonitoring, true);
+  expect(j.systemMonitoring).toBe(true);
 
   // Explicit off.
   res = await watchPost({
@@ -338,7 +325,7 @@ test('POST /api/watch { system:true } enables compliance monitoring; omit preser
     env,
   });
   j = await res.json();
-  assert.equal(j.systemMonitoring, false);
+  expect(j.systemMonitoring).toBe(false);
 });
 
 test('re-subscribing does not erase the system baseline; publicWatch exposes it sans email', async () => {
@@ -364,10 +351,10 @@ test('re-subscribing does not erase the system baseline; publicWatch exposes it 
     env,
   });
   const j = await res.json();
-  assert.equal(j.system.baseline.score, 95, 'baseline preserved across re-subscribe');
-  assert.equal(j.system.drifted, true);
-  assert.equal(j.system.drift[0].id, 'colors.cta');
-  assert.ok(!JSON.stringify(j).includes('o@x.io'), 'email never leaks');
+  expect(j.system.baseline.score, 'baseline preserved across re-subscribe').toBe(95);
+  expect(j.system.drifted).toBe(true);
+  expect(j.system.drift[0].id).toBe('colors.cta');
+  expect(JSON.stringify(j).includes('o@x.io'), 'email never leaks').toBeFalsy();
 });
 
 // ── /report/:domain (P2b-lite) ───────────────────────────────────────────────
@@ -421,16 +408,16 @@ test('/report renders scores, system compliance, drift, and history — without 
     request: { url: 'https://slop-detect.com/report/example.com' },
     env: { RESULTS: kv },
   });
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
   const html = await res.text();
-  assert.match(html, /B\+/);
-  assert.match(html, /Drifting/);
-  assert.match(html, /inter undeclared/);
-  assert.match(html, /History/);
-  assert.match(html, /@media print/, 'print stylesheet present (the PDF substitute)');
-  assert.ok(!html.includes('secret@x.io'), 'email never appears in the report');
+  expect(html).toMatch(/B\+/);
+  expect(html).toMatch(/Drifting/);
+  expect(html).toMatch(/inter undeclared/);
+  expect(html).toMatch(/History/);
+  expect(html, 'print stylesheet present (the PDF substitute)').toMatch(/@media print/);
+  expect(html.includes('secret@x.io'), 'email never appears in the report').toBeFalsy();
   // Anti-slop self-check.
-  assert.doesNotMatch(html, /Inter,|Geist|Space Grotesk/);
+  expect(html).not.toMatch(/Inter,|Geist|Space Grotesk/);
 });
 
 test('/report shows an honest empty state for an unknown domain', async () => {
@@ -440,5 +427,5 @@ test('/report shows an honest empty state for an unknown domain', async () => {
     env: { RESULTS: makeKv() },
   });
   const html = await res.text();
-  assert.match(html, /No scan data/i);
+  expect(html).toMatch(/No scan data/i);
 });

--- a/apps/web/test/inline-scripts.test.js
+++ b/apps/web/test/inline-scripts.test.js
@@ -7,12 +7,11 @@
 // `new Function`, which throws on a syntax error. Regression: the dashboard login
 // script lost its addEventListener close (Cursor Bugbot, PR #26).
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { onRequestGet as dashGet } from '../functions/dashboard.js';
-import { onRequestGet as scoreGet } from '../functions/score/[domain].js';
-import { onRequestGet as rGet } from '../functions/r/[id].js';
-import { saveResult, recordScan } from '../functions/_shared.js';
+import { test, expect } from 'vitest';
+import { onRequestGet as dashGet } from '../functions/dashboard.tsx';
+import { onRequestGet as scoreGet } from '../functions/score/[domain].tsx';
+import { onRequestGet as rGet } from '../functions/r/[id].tsx';
+import { saveResult, recordScan } from '../functions/_shared.ts';
 
 function makeKv(seed = {}) {
   const store = new Map(Object.entries(seed));
@@ -34,9 +33,9 @@ function makeKv(seed = {}) {
 // blocks carry a type=, so they're skipped).
 function assertScriptsParse(html, label) {
   const blocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
-  assert.ok(blocks.length > 0, `${label}: expected at least one inline <script>`);
+  expect(blocks.length > 0, `${label}: expected at least one inline <script>`).toBeTruthy();
   for (const body of blocks) {
-    assert.doesNotThrow(() => new Function(body), `${label}: inline <script> must parse`);
+    expect(() => new Function(body), `${label}: inline <script> must parse`).not.toThrow();
   }
 }
 
@@ -140,8 +139,8 @@ test('hostile field values cannot break out of inline scripts', async () => {
     ).text();
     const opens = (html.match(/<script\b/gi) || []).length;
     const closes = (html.match(/<\/script>/gi) || []).length;
-    assert.equal(opens, closes, `${name}: unbalanced <script> tags → breakout`);
-    assert.ok(!html.includes('</script><img'), `${name}: raw </script> breakout present`);
-    assert.ok(html.includes('\\u003c'), `${name}: payload should be \\u003c-escaped`);
+    expect(opens, `${name}: unbalanced <script> tags → breakout`).toBe(closes);
+    expect(html.includes('</script><img'), `${name}: raw </script> breakout present`).toBeFalsy();
+    expect(html.includes('\\u003c'), `${name}: payload should be \\u003c-escaped`).toBeTruthy();
   }
 });

--- a/apps/web/test/landing.test.js
+++ b/apps/web/test/landing.test.js
@@ -2,86 +2,83 @@
 // The deep review found the page frozen at v0.5.1 with no conversion path —
 // these assertions stop that class of drift from recurring.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { onRequestGet as directoryGet } from '../functions/directory.js';
-import { onRequestGet as leaderboardGet } from '../functions/leaderboard.js';
-import { onRequestGet as reportGet } from '../functions/report/[domain].js';
+import { onRequestGet as directoryGet } from '../functions/directory.tsx';
+import { onRequestGet as leaderboardGet } from '../functions/leaderboard.tsx';
+import { onRequestGet as reportGet } from '../functions/report/[domain].tsx';
 
 const html = readFileSync(new URL('../public/index.html', import.meta.url), 'utf8');
 
 // ── staleness guards ─────────────────────────────────────────────────────────
 test('landing page carries no stale version or definitions strings', () => {
-  assert.ok(!html.includes('0.5.1'), 'JSON-LD softwareVersion must track releases');
-  assert.ok(!html.includes('2026.08'), 'defs label must not lag DEFINITIONS_VERSION');
+  expect(html.includes('0.5.1'), 'JSON-LD softwareVersion must track releases').toBeFalsy();
+  expect(html.includes('2026.08'), 'defs label must not lag DEFINITIONS_VERSION').toBeFalsy();
 });
 
 test('JSON-LD softwareVersion matches the released package version', () => {
   // Kills the drift class for good: the landing page can never again claim an
   // old version once package.json moves.
   const pkg = JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'));
-  assert.match(
-    html,
-    new RegExp(`"softwareVersion":\\s*"${pkg.version.replace(/\./g, '\\.')}"`),
-    `landing must advertise v${pkg.version}`
+  expect(html, `landing must advertise v${pkg.version}`).toMatch(
+    new RegExp(`"softwareVersion":\\s*"${pkg.version.replace(/\./g, '\\.')}"`)
   );
 });
 
 test('the dashboard is reachable from nav and footer', () => {
-  assert.ok(
+  expect(
     (html.match(/href="\/dashboard"/g) || []).length >= 2,
     'topbar + footer dashboard links'
-  );
+  ).toBeTruthy();
 });
 
 test('landing page mentions the full current tool surface', () => {
-  assert.ok(
+  expect(
     html.includes('check_design_system'),
     'MCP tool list must include the system-axis tool'
-  );
-  assert.match(html, /DESIGN\.md/, 'the system axis must be presented');
+  ).toBeTruthy();
+  expect(html, 'the system axis must be presented').toMatch(/DESIGN\.md/);
 });
 
 // ── conversion bridge (§04) ──────────────────────────────────────────────────
 test('the monitoring conversion section exists and posts to /api/watch', () => {
-  assert.match(html, /id="monitor"/, 'the #monitor section anchor');
-  assert.match(html, /id="watchForm"/);
-  assert.match(html, /id="watchDomain"/);
-  assert.match(html, /id="watchEmail"/);
-  assert.match(html, /id="watchSystem"/, 'system-axis opt-in checkbox');
-  assert.match(html, /id="watchList"/, 'directory opt-in checkbox');
-  assert.match(html, /\/api\/watch/, 'form submits to the watch API');
-  assert.match(html, /monitorNudgeLink/, 'post-scan nudge into the funnel');
+  expect(html, 'the #monitor section anchor').toMatch(/id="monitor"/);
+  expect(html).toMatch(/id="watchForm"/);
+  expect(html).toMatch(/id="watchDomain"/);
+  expect(html).toMatch(/id="watchEmail"/);
+  expect(html, 'system-axis opt-in checkbox').toMatch(/id="watchSystem"/);
+  expect(html, 'directory opt-in checkbox').toMatch(/id="watchList"/);
+  expect(html, 'form submits to the watch API').toMatch(/\/api\/watch/);
+  expect(html, 'post-scan nudge into the funnel').toMatch(/monitorNudgeLink/);
 });
 
 test('the section is honest: double opt-in, privacy, free engine', () => {
-  assert.match(html, /[Dd]ouble opt-in/);
-  assert.match(html, /href="\/privacy\.md"/, 'privacy policy linked');
-  assert.match(html, /MIT/, 'free-engine promise stated');
+  expect(html).toMatch(/[Dd]ouble opt-in/);
+  expect(html, 'privacy policy linked').toMatch(/href="\/privacy\.md"/);
+  expect(html, 'free-engine promise stated').toMatch(/MIT/);
 });
 
 test('monitor opt-ins are additive — an unchecked box never delists on resubmit', () => {
   // Regression (Bugbot #12): sending list:false/system:false on every submit
   // would delist a domain the owner had listed. Flags must only be SENT when checked.
-  assert.ok(
-    !/list:\s*\$\('watchList'\)\.checked/.test(html),
+  expect(
+    /list:\s*\$\('watchList'\)\.checked/.test(html),
     'list must not be sent unconditionally'
-  );
-  assert.ok(
-    !/system:\s*\$\('watchSystem'\)\.checked/.test(html),
+  ).toBeFalsy();
+  expect(
+    /system:\s*\$\('watchSystem'\)\.checked/.test(html),
     'system must not be sent unconditionally'
+  ).toBeFalsy();
+  expect(html, 'list opt-in only when checked').toMatch(
+    /watchList'\)\.checked \? \{ list: true \}/
   );
-  assert.match(html, /watchList'\)\.checked \? \{ list: true \}/, 'list opt-in only when checked');
-  assert.match(
-    html,
-    /watchSystem'\)\.checked \? \{ system: true \}/,
-    'system opt-in only when checked'
+  expect(html, 'system opt-in only when checked').toMatch(
+    /watchSystem'\)\.checked \? \{ system: true \}/
   );
 });
 
 test('exactly one domainOf helper (no shadowed duplicate)', () => {
-  assert.equal((html.match(/function domainOf/g) || []).length, 1);
+  expect((html.match(/function domainOf/g) || []).length).toBe(1);
 });
 
 // ── agent-discovery files list the full tool surface ─────────────────────────
@@ -94,25 +91,31 @@ test('every agent-discovery surface advertises check_design_system', () => {
   ];
   for (const f of files) {
     const txt = readFileSync(new URL(f, import.meta.url), 'utf8');
-    assert.ok(txt.includes('scan_page') && txt.includes('check_aeo'), `${f}: base tools present`);
-    assert.ok(txt.includes('check_design_system'), `${f}: must list the system-axis tool`);
+    expect(
+      txt.includes('scan_page') && txt.includes('check_aeo'),
+      `${f}: base tools present`
+    ).toBeTruthy();
+    expect(
+      txt.includes('check_design_system'),
+      `${f}: must list the system-axis tool`
+    ).toBeTruthy();
   }
 });
 
 // ── navigation to the product surfaces ───────────────────────────────────────
 test('nav/footer link the directory, leaderboard, monitor, and privacy', () => {
-  assert.match(html, /href="\/directory"/);
-  assert.match(html, /href="\/leaderboard"/);
-  assert.match(html, /href="#monitor"/);
-  assert.match(html, /href="\/privacy\.md"/);
+  expect(html).toMatch(/href="\/directory"/);
+  expect(html).toMatch(/href="\/leaderboard"/);
+  expect(html).toMatch(/href="#monitor"/);
+  expect(html).toMatch(/href="\/privacy\.md"/);
 });
 
 // ── anti-slop: fonts stay system-distinct ────────────────────────────────────
 test('the Google Fonts request loads only the brand faces (no Inter/Geist)', () => {
   const fontsUrl = (html.match(/https:\/\/fonts\.googleapis\.com\/css2[^"]+/) || [''])[0];
-  assert.ok(fontsUrl.includes('Hanken+Grotesk'), 'brand prose face present');
-  assert.ok(fontsUrl.includes('Martian+Mono'), 'brand mono face present');
-  assert.ok(!/Inter|Geist|Space\+Grotesk/.test(fontsUrl), 'no slop faces requested');
+  expect(fontsUrl.includes('Hanken+Grotesk'), 'brand prose face present').toBeTruthy();
+  expect(fontsUrl.includes('Martian+Mono'), 'brand mono face present').toBeTruthy();
+  expect(/Inter|Geist|Space\+Grotesk/.test(fontsUrl), 'no slop faces requested').toBeFalsy();
 });
 
 // ── brand unification: sub-pages share the landing identity ─────────────────
@@ -148,7 +151,7 @@ test('/directory wears the landing brand (fonts, accent, registration mark)', as
     env: { RESULTS: makeKv() },
   });
   const out = await res.text();
-  for (const re of BRAND_MARKS) assert.match(out, re);
+  for (const re of BRAND_MARKS) expect(out).toMatch(re);
 });
 
 test('/leaderboard wears the landing brand', async () => {
@@ -157,8 +160,8 @@ test('/leaderboard wears the landing brand', async () => {
   try {
     const res = await leaderboardGet({ request: { url: 'https://slop-detect.com/leaderboard' } });
     const out = await res.text();
-    for (const re of BRAND_MARKS) assert.match(out, re);
-    assert.match(out, /#monitor/, 'leaderboard CTA routes into the monitoring funnel');
+    for (const re of BRAND_MARKS) expect(out).toMatch(re);
+    expect(out, 'leaderboard CTA routes into the monitoring funnel').toMatch(/#monitor/);
   } finally {
     globalThis.fetch = orig;
   }
@@ -171,6 +174,6 @@ test('/report wears the landing brand and keeps its print stylesheet', async () 
     env: { RESULTS: makeKv() },
   });
   const out = await res.text();
-  for (const re of BRAND_MARKS) assert.match(out, re);
-  assert.match(out, /@media print/);
+  for (const re of BRAND_MARKS) expect(out).toMatch(re);
+  expect(out).toMatch(/@media print/);
 });

--- a/apps/web/test/leaderboard.test.js
+++ b/apps/web/test/leaderboard.test.js
@@ -2,9 +2,8 @@
 // research-framed page: corpus headline + a live counter + category rankings +
 // by-builder, anti-slop. Each name links into its /score hub.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { onRequestGet } from '../functions/leaderboard.js';
+import { test, expect } from 'vitest';
+import { onRequestGet } from '../functions/leaderboard.tsx';
 
 const SAMPLE = {
   generatedAt: '2026-06-05T00:00:00.000Z',
@@ -82,20 +81,20 @@ test('/leaderboard renders the headline, category rankings, and by-builder', asy
     async () => new Response(JSON.stringify(SAMPLE), { status: 200 }),
     async () => {
       const res = await onRequestGet({ request: req, env: {} });
-      assert.equal(res.status, 200);
+      expect(res.status).toBe(200);
       const html = await res.text();
-      assert.match(html, /33%/, 'shows corpus slop share');
-      assert.match(html, /AI builders/);
-      assert.match(html, /SaaS &amp; dev tools|SaaS & dev tools/);
-      assert.match(html, /Classic/);
-      assert.match(html, /By builder/);
-      assert.match(html, /v0/, 'builder breakdown present');
+      expect(html, 'shows corpus slop share').toMatch(/33%/);
+      expect(html).toMatch(/AI builders/);
+      expect(html).toMatch(/SaaS &amp; dev tools|SaaS & dev tools/);
+      expect(html).toMatch(/Classic/);
+      expect(html).toMatch(/By builder/);
+      expect(html, 'builder breakdown present').toMatch(/v0/);
       // Names link into the score hub (closing the loop), not dead-ending elsewhere.
-      assert.match(html, /href="https:\/\/slop-detect\.com\/score\/stripe\.com"/);
+      expect(html).toMatch(/href="https:\/\/slop-detect\.com\/score\/stripe\.com"/);
       // Anti-slop self-check + framing caveat.
-      assert.doesNotMatch(html, /Inter|Geist|Space Grotesk/i);
-      assert.doesNotMatch(html, /background-clip:\s*text/i);
-      assert.match(html, /fingerprint, not a verdict/i);
+      expect(html).not.toMatch(/Inter|Geist|Space Grotesk/i);
+      expect(html).not.toMatch(/background-clip:\s*text/i);
+      expect(html).toMatch(/fingerprint, not a verdict/i);
     }
   );
 });
@@ -105,10 +104,10 @@ test('/leaderboard shows a graceful "generating" state when data is missing', as
     async () => new Response('not found', { status: 404 }),
     async () => {
       const res = await onRequestGet({ request: req, env: {} });
-      assert.equal(res.status, 200);
+      expect(res.status).toBe(200);
       const html = await res.text();
-      assert.match(html, /being generated/i);
-      assert.doesNotMatch(html, /undefined/);
+      expect(html).toMatch(/being generated/i);
+      expect(html).not.toMatch(/undefined/);
     }
   );
 });
@@ -120,11 +119,11 @@ test('/leaderboard shows the live scan counter once enough scans exist', async (
       const withData = await (
         await onRequestGet({ request: req, env: { RESULTS: kvWithScans(120) } })
       ).text();
-      assert.match(withData, /120<\/strong>\s*scans|>120<\/strong>/);
+      expect(withData).toMatch(/120<\/strong>\s*scans|>120<\/strong>/);
       const tooFew = await (
         await onRequestGet({ request: req, env: { RESULTS: kvWithScans(10) } })
       ).text();
-      assert.doesNotMatch(tooFew, /scans,\s*\n?\s*average/);
+      expect(tooFew).not.toMatch(/scans,\s*\n?\s*average/);
     }
   );
 });

--- a/apps/web/test/middleware.test.js
+++ b/apps/web/test/middleware.test.js
@@ -2,9 +2,8 @@
 // behavior for the scan route (#5). These drive onRequest() with hand-built
 // context mocks so no real KV / browser / network is involved.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { onRequest } from '../functions/api/_middleware.js';
+import { test, expect } from 'vitest';
+import { onRequest } from '../functions/api/_middleware.ts';
 
 const ALLOWED = 'https://slop-detect.com';
 
@@ -55,23 +54,23 @@ test('#6 foreign browser origin is rejected with 403 origin_not_allowed', async 
     body: { url: 'https://x.com' },
   });
   const res = await onRequest(makeContext(req));
-  assert.equal(res.status, 403);
+  expect(res.status).toBe(403);
   const j = await res.json();
-  assert.equal(j.error, 'origin_not_allowed');
+  expect(j.error).toBe('origin_not_allowed');
 });
 
 test('#6 trusted origin is NOT rejected as foreign (passes the origin gate)', async () => {
   // No RATE_LIMIT, no TURNSTILE_SECRET → should fall through to next() = 200.
   const req = makeRequest({ headers: { Origin: ALLOWED }, body: { url: 'https://x.com' } });
   const res = await onRequest(makeContext(req, {}));
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
 });
 
 test('#6 no-origin caller (CLI/curl) is NOT treated as foreign', async () => {
   const req = makeRequest({ headers: {}, body: { url: 'https://x.com' } });
   const res = await onRequest(makeContext(req, {}));
   // First scan with no KV binding is allowed (under the in-memory ceiling).
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
 });
 
 test('#5 RATE_LIMIT binding MISSING still caps the scan route (fail-closed)', async () => {
@@ -92,8 +91,8 @@ test('#5 RATE_LIMIT binding MISSING still caps the scan route (fail-closed)', as
     }
     if (res.status === 200) allowed++;
   }
-  assert.ok(got429, 'expected the scan route to start 429ing without a KV binding');
-  assert.ok(allowed <= 3, `expected <=3 scans before the ceiling, got ${allowed}`);
+  expect(got429, 'expected the scan route to start 429ing without a KV binding').toBeTruthy();
+  expect(allowed <= 3, `expected <=3 scans before the ceiling, got ${allowed}`).toBeTruthy();
 });
 
 test('#5 KV outage (binding present, reads throw) fails CLOSED on scan route', async () => {
@@ -110,7 +109,7 @@ test('#5 KV outage (binding present, reads throw) fails CLOSED on scan route', a
       break;
     }
   }
-  assert.ok(got429, 'expected scan to fail-closed under a KV outage');
+  expect(got429, 'expected scan to fail-closed under a KV outage').toBeTruthy();
 });
 
 test('#5 KV outage on cheap fix-prompt (assemble) fails OPEN', async () => {
@@ -122,7 +121,7 @@ test('#5 KV outage on cheap fix-prompt (assemble) fails OPEN', async () => {
     body: { result: { score: 10, patterns: [] } },
   });
   const res = await onRequest(makeContext(req, { RATE_LIMIT: throwingKv }));
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
 });
 
 test('global daily cap returns 503 daily_capacity_reached for scans', async () => {
@@ -136,8 +135,8 @@ test('global daily cap returns 503 daily_capacity_reached for scans', async () =
     body: { url: 'https://x.com' },
   });
   const res = await onRequest(makeContext(req, { RATE_LIMIT: cappedKv, SCAN_DAILY_CAP: '10000' }));
-  assert.equal(res.status, 503);
-  assert.equal((await res.json()).error, 'daily_capacity_reached');
+  expect(res.status).toBe(503);
+  expect((await res.json()).error).toBe('daily_capacity_reached');
 });
 
 test('SCAN_DISABLED kill switch returns 503 scanning_paused', async () => {
@@ -147,8 +146,8 @@ test('SCAN_DISABLED kill switch returns 503 scanning_paused', async () => {
     body: { url: 'https://x.com' },
   });
   const res = await onRequest(makeContext(req, { RATE_LIMIT: okKv, SCAN_DISABLED: '1' }));
-  assert.equal(res.status, 503);
-  assert.equal((await res.json()).error, 'scanning_paused');
+  expect(res.status).toBe(503);
+  expect((await res.json()).error).toBe('scanning_paused');
 });
 
 test('a failed Turnstile 403s WITHOUT incrementing the global daily cap', async () => {
@@ -168,16 +167,16 @@ test('a failed Turnstile 403s WITHOUT incrementing the global daily cap', async 
     body: { url: 'https://x.com' },
   });
   const res = await onRequest(makeContext(req, { RATE_LIMIT: kv, TURNSTILE_SECRET: 'secret' }));
-  assert.equal(res.status, 403);
-  assert.equal((await res.json()).error, 'turnstile_required');
-  assert.ok(
-    !puts.some((k) => k.startsWith('rl:global:scan:')),
+  expect(res.status).toBe(403);
+  expect((await res.json()).error).toBe('turnstile_required');
+  expect(
+    puts.some((k) => k.startsWith('rl:global:scan:')),
     'global daily cap must NOT be incremented when Turnstile fails'
-  );
+  ).toBeFalsy();
 });
 
 test('OPTIONS preflight returns 204 regardless of origin', async () => {
   const req = makeRequest({ method: 'OPTIONS', headers: { Origin: 'https://evil.example.com' } });
   const res = await onRequest(makeContext(req));
-  assert.equal(res.status, 204);
+  expect(res.status).toBe(204);
 });

--- a/apps/web/test/score.test.js
+++ b/apps/web/test/score.test.js
@@ -1,10 +1,9 @@
 // Tests for the per-domain score hub (GET /score/:domain). Renders the handler
 // against an in-memory KV mock and asserts on the produced HTML, no browser.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { saveResult, recordScan, setListing } from '../functions/_shared.js';
-import { onRequestGet } from '../functions/score/[domain].js';
+import { test, expect } from 'vitest';
+import { saveResult, recordScan, setListing } from '../functions/_shared.ts';
+import { onRequestGet } from '../functions/score/[domain].tsx';
 
 function makeKv(seed = {}) {
   const store = new Map(Object.entries(seed));
@@ -55,14 +54,14 @@ async function render(kv, domainParam) {
 
 test('invalid domain returns 400', async () => {
   const { status } = await render(makeKv(), 'not a domain');
-  assert.equal(status, 400);
+  expect(status).toBe(400);
 });
 
 test('unknown domain renders the empty state with a scan CTA', async () => {
   const { status, html } = await render(makeKv(), 'never-scanned.com');
-  assert.equal(status, 404);
-  assert.match(html, /No scan recorded/);
-  assert.match(html, /\/\?url=never-scanned\.com/);
+  expect(status).toBe(404);
+  expect(html).toMatch(/No scan recorded/);
+  expect(html).toMatch(/\/\?url=never-scanned\.com/);
 });
 
 test('a scanned domain renders score, grade, verdict, JSON-LD, canonical', async () => {
@@ -71,12 +70,12 @@ test('a scanned domain renders score, grade, verdict, JSON-LD, canonical', async
   await saveResult(kv, s);
   await recordScan(kv, s);
   const { status, html } = await render(kv, 'ex.com');
-  assert.equal(status, 200);
-  assert.match(html, />D</); // grade
-  assert.match(html, /30<small>\/100<\/small>/); // score
-  assert.match(html, /Heavy slop/); // verdict
-  assert.match(html, /application\/ld\+json/); // AEO structured data
-  assert.match(html, /rel="canonical" href="https:\/\/slop-detect\.com\/score\/ex\.com"/);
+  expect(status).toBe(200);
+  expect(html).toMatch(/>D</); // grade
+  expect(html).toMatch(/30<small>\/100<\/small>/); // score
+  expect(html).toMatch(/Heavy slop/); // verdict
+  expect(html).toMatch(/application\/ld\+json/); // AEO structured data
+  expect(html).toMatch(/rel="canonical" href="https:\/\/slop-detect\.com\/score\/ex\.com"/);
 });
 
 test('an UNCLAIMED domain shows the claim form, no dofollow backlink', async () => {
@@ -85,9 +84,9 @@ test('an UNCLAIMED domain shows the claim form, no dofollow backlink', async () 
   await saveResult(kv, s);
   await recordScan(kv, s);
   const { html } = await render(kv, 'ex.com');
-  assert.match(html, /id="claimForm"/);
-  assert.match(html, /Claim this page/);
-  assert.doesNotMatch(html, /rel="dofollow"/);
+  expect(html).toMatch(/id="claimForm"/);
+  expect(html).toMatch(/Claim this page/);
+  expect(html).not.toMatch(/rel="dofollow"/);
 });
 
 test('a CLAIMED (listed) domain shows a dofollow backlink, not the claim form', async () => {
@@ -97,9 +96,9 @@ test('a CLAIMED (listed) domain shows a dofollow backlink, not the claim form', 
   await recordScan(kv, s);
   await setListing(kv, s); // owner claimed + listed
   const { html } = await render(kv, 'ex.com');
-  assert.match(html, /rel="dofollow"/);
-  assert.match(html, /Listed in the/);
-  assert.doesNotMatch(html, /id="claimForm"/);
+  expect(html).toMatch(/rel="dofollow"/);
+  expect(html).toMatch(/Listed in the/);
+  expect(html).not.toMatch(/id="claimForm"/);
 });
 
 test('peer percentile appears only once enough sites are scanned', async () => {
@@ -109,13 +108,13 @@ test('peer percentile appears only once enough sites are scanned', async () => {
   await recordScan(kv, target);
   // only 1 site so far -> no peer line
   let r = await render(kv, 'ex.com');
-  assert.doesNotMatch(r.html, /Cleaner than/);
+  expect(r.html).not.toMatch(/Cleaner than/);
   // seed four more scans so the corpus crosses the >=5 threshold
   for (let i = 0; i < 4; i++) {
     await recordScan(kv, slim({ id: 'x' + i, domain: `d${i}.com`, score: 40 + i, tier: 'Heavy' }));
   }
   r = await render(kv, 'ex.com');
-  assert.match(r.html, /Cleaner than <strong>/);
+  expect(r.html).toMatch(/Cleaner than <strong>/);
 });
 
 test('the page links to this scan, the printable report, and a re-scan', async () => {
@@ -124,7 +123,7 @@ test('the page links to this scan, the printable report, and a re-scan', async (
   await saveResult(kv, s);
   await recordScan(kv, s);
   const { html } = await render(kv, 'ex.com');
-  assert.match(html, /href="https:\/\/slop-detect\.com\/r\/sc0re001"/);
-  assert.match(html, /href="https:\/\/slop-detect\.com\/report\/ex\.com"/);
-  assert.match(html, /\/\?url=ex\.com/);
+  expect(html).toMatch(/href="https:\/\/slop-detect\.com\/r\/sc0re001"/);
+  expect(html).toMatch(/href="https:\/\/slop-detect\.com\/report\/ex\.com"/);
+  expect(html).toMatch(/\/\?url=ex\.com/);
 });

--- a/apps/web/test/sites.test.js
+++ b/apps/web/test/sites.test.js
@@ -3,8 +3,7 @@
 // server-rendered /directory page, and the `list` opt-in flag on /api/watch.
 // Driven against an in-memory KV mock that supports list() + metadata.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
 import {
   setListing,
   getListing,
@@ -13,10 +12,10 @@ import {
   listAllSites,
   recordScanForWatch,
   getWatch,
-} from '../functions/_shared.js';
-import { onRequestGet as sitesGet } from '../functions/api/sites.js';
-import { onRequestGet as directoryGet } from '../functions/api/../directory.js';
-import { onRequestPost as watchPost } from '../functions/api/watch.js';
+} from '../functions/_shared.ts';
+import { onRequestGet as sitesGet } from '../functions/api/sites.ts';
+import { onRequestGet as directoryGet } from '../functions/directory.tsx';
+import { onRequestPost as watchPost } from '../functions/api/watch.ts';
 
 // CF-KV-shaped mock with metadata + list({ prefix }).
 function makeKv(seed = {}) {
@@ -70,13 +69,13 @@ function postReq(body) {
 test('setListing writes a record + display metadata, getListing reads it back', async () => {
   const kv = makeKv();
   const rec = await setListing(kv, slim());
-  assert.equal(rec.domain, 'example.com');
-  assert.equal(rec.url, 'https://example.com');
+  expect(rec.domain).toBe('example.com');
+  expect(rec.url).toBe('https://example.com');
 
   const got = await getListing(kv, 'example.com');
-  assert.equal(got.score, 8);
+  expect(got.score).toBe(8);
   // The compact summary must live in KV metadata so the directory enumerates cheaply.
-  assert.equal(kv.store.get('l:example.com').metadata.g, 'A-');
+  expect(kv.store.get('l:example.com').metadata.g).toBe('A-');
 });
 
 test('setListing preserves listedAt across refreshes but updates the score', async () => {
@@ -84,8 +83,8 @@ test('setListing preserves listedAt across refreshes but updates the score', asy
   const first = await setListing(kv, slim({ score: 8, tier: 'Clean' }));
   await new Promise((r) => setTimeout(r, 2));
   const second = await setListing(kv, slim({ score: 40, grade: 'D', tier: 'Heavy' }));
-  assert.equal(second.listedAt, first.listedAt, 'listedAt is sticky');
-  assert.equal(second.score, 40, 'score refreshes');
+  expect(second.listedAt, 'listedAt is sticky').toBe(first.listedAt);
+  expect(second.score, 'score refreshes').toBe(40);
 });
 
 test('listSites derives rows from metadata; deleteListing removes them', async () => {
@@ -94,15 +93,12 @@ test('listSites derives rows from metadata; deleteListing removes them', async (
   await setListing(kv, slim({ domain: 'b.com', score: 55, grade: 'F', tier: 'Heavy' }));
 
   let { sites } = await listSites(kv);
-  assert.equal(sites.length, 2);
-  assert.deepEqual(sites.map((s) => s.domain).sort(), ['a.com', 'b.com']);
+  expect(sites.length).toBe(2);
+  expect(sites.map((s) => s.domain).sort()).toEqual(['a.com', 'b.com']);
 
   await deleteListing(kv, 'b.com');
   ({ sites } = await listSites(kv));
-  assert.deepEqual(
-    sites.map((s) => s.domain),
-    ['a.com']
-  );
+  expect(sites.map((s) => s.domain)).toEqual(['a.com']);
 });
 
 // ── GET /api/sites ───────────────────────────────────────────────────────────
@@ -114,12 +110,12 @@ test('GET /api/sites sorts cleanest-first by default and sloppiest-first on dema
 
   let res = await sitesGet({ request: { url: 'https://slop-detect.com/api/sites' }, env });
   let j = await res.json();
-  assert.equal(j.sites[0].domain, 'clean.com');
+  expect(j.sites[0].domain).toBe('clean.com');
 
   res = await sitesGet({ request: { url: 'https://slop-detect.com/api/sites?sort=slop' }, env });
   j = await res.json();
-  assert.equal(j.sites[0].domain, 'dirty.com');
-  assert.equal(j.sort, 'slop');
+  expect(j.sites[0].domain).toBe('dirty.com');
+  expect(j.sort).toBe('slop');
 });
 
 test('GET /api/sites: pending (unscored) sites sink to the end in BOTH sorts', async () => {
@@ -141,17 +137,15 @@ test('GET /api/sites: pending (unscored) sites sink to the end in BOTH sorts', a
       env,
     });
     const j = await res.json();
-    assert.equal(
-      j.sites[j.sites.length - 1].domain,
-      'pending.com',
-      `pending last when sort=${sort}`
+    expect(j.sites[j.sites.length - 1].domain, `pending last when sort=${sort}`).toBe(
+      'pending.com'
     );
   }
 });
 
 test('GET /api/sites returns 503 without storage', async () => {
   const res = await sitesGet({ request: { url: 'https://slop-detect.com/api/sites' }, env: {} });
-  assert.equal(res.status, 503);
+  expect(res.status).toBe(503);
 });
 
 // ── GET /directory (server-rendered HTML) ────────────────────────────────────
@@ -162,14 +156,14 @@ test('/directory renders a DOFOLLOW backlink to each listed site', async () => {
     request: { url: 'https://slop-detect.com/directory' },
     env: { RESULTS: kv },
   });
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
   const html = await res.text();
-  assert.match(html, /href="https:\/\/example\.com"/, 'links out to the site');
-  assert.doesNotMatch(html, /rel=["']?nofollow/i, 'the backlink must be dofollow');
-  assert.match(html, /application\/ld\+json/, 'emits ItemList JSON-LD for SEO');
+  expect(html, 'links out to the site').toMatch(/href="https:\/\/example\.com"/);
+  expect(html, 'the backlink must be dofollow').not.toMatch(/rel=["']?nofollow/i);
+  expect(html, 'emits ItemList JSON-LD for SEO').toMatch(/application\/ld\+json/);
   // Anti-slop self-check: the directory must not wear the tells it detects.
-  assert.doesNotMatch(html, /Inter|Geist|Space Grotesk/i, 'no slop fonts');
-  assert.doesNotMatch(html, /background-clip:\s*text/i, 'no gradient text');
+  expect(html, 'no slop fonts').not.toMatch(/Inter|Geist|Space Grotesk/i);
+  expect(html, 'no gradient text').not.toMatch(/background-clip:\s*text/i);
 });
 
 test('/directory shows an empty state with a claim CTA when nothing is listed', async () => {
@@ -178,8 +172,8 @@ test('/directory shows an empty state with a claim CTA when nothing is listed', 
     env: { RESULTS: makeKv() },
   });
   const html = await res.text();
-  assert.match(html, /No sites listed yet/i);
-  assert.match(html, /claim it/i);
+  expect(html).toMatch(/No sites listed yet/i);
+  expect(html).toMatch(/claim it/i);
 });
 
 // ── /api/watch list opt-in ───────────────────────────────────────────────────
@@ -203,9 +197,9 @@ test('POST /api/watch { list:true } lists the domain; { list:false } delists it'
     env,
   });
   let j = await res.json();
-  assert.equal(j.listed, true);
-  assert.ok(j.directoryUrl.endsWith('/directory'));
-  assert.ok(await getListing(kv, 'example.com'), 'listing created');
+  expect(j.listed).toBe(true);
+  expect(j.directoryUrl.endsWith('/directory')).toBeTruthy();
+  expect(await getListing(kv, 'example.com'), 'listing created').toBeTruthy();
 
   // Re-subscribe with list:false → delisted, monitoring intact.
   res = await watchPost({
@@ -213,9 +207,9 @@ test('POST /api/watch { list:true } lists the domain; { list:false } delists it'
     env,
   });
   j = await res.json();
-  assert.equal(j.listed, false);
-  assert.equal(await getListing(kv, 'example.com'), null, 'listing removed');
-  assert.ok(await getWatch(kv, 'example.com'), 'still monitored');
+  expect(j.listed).toBe(false);
+  expect(await getListing(kv, 'example.com'), 'listing removed').toBe(null);
+  expect(await getWatch(kv, 'example.com'), 'still monitored').toBeTruthy();
 });
 
 test('omitting `list` on re-subscribe preserves the listing state', async () => {
@@ -240,8 +234,8 @@ test('omitting `list` on re-subscribe preserves the listing state', async () => 
     env,
   });
   const j = await res.json();
-  assert.equal(j.listed, true);
-  assert.ok(await getListing(kv, 'example.com'));
+  expect(j.listed).toBe(true);
+  expect(await getListing(kv, 'example.com')).toBeTruthy();
 });
 
 test('unsubscribing a listed domain also delists it', async () => {
@@ -264,7 +258,7 @@ test('unsubscribing a listed domain also delists it', async () => {
     request: postReq({ domain: 'example.com', email: 'o@x.io', unsubscribe: true }),
     env,
   });
-  assert.equal(await getListing(kv, 'example.com'), null);
+  expect(await getListing(kv, 'example.com')).toBe(null);
 });
 
 test('a claimed domain cannot be listed/hijacked by a different email', async () => {
@@ -286,12 +280,12 @@ test('a claimed domain cannot be listed/hijacked by a different email', async ()
     request: postReq({ domain: 'example.com', email: 'attacker@evil.io', list: false }),
     env,
   });
-  assert.equal(res.status, 403);
+  expect(res.status).toBe(403);
 
   // The watch + listing are untouched.
   const watch = await getWatch(kv, 'example.com');
-  assert.equal(watch.email, 'owner@x.io');
-  assert.ok(await getListing(kv, 'example.com'), 'listing survives the hijack attempt');
+  expect(watch.email).toBe('owner@x.io');
+  expect(await getListing(kv, 'example.com'), 'listing survives the hijack attempt').toBeTruthy();
 });
 
 test('/directory labels a listed-but-unscored domain "Pending", not "Unlisted"', async () => {
@@ -310,8 +304,8 @@ test('/directory labels a listed-but-unscored domain "Pending", not "Unlisted"',
     env: { RESULTS: kv },
   });
   const html = await res.text();
-  assert.match(html, /Pending/, 'pending rows are labeled Pending');
-  assert.doesNotMatch(html, /Unlisted/, 'a listed row is never labeled Unlisted');
+  expect(html, 'pending rows are labeled Pending').toMatch(/Pending/);
+  expect(html, 'a listed row is never labeled Unlisted').not.toMatch(/Unlisted/);
 });
 
 // ── re-scan refreshes a listed domain's directory entry ──────────────────────
@@ -335,8 +329,8 @@ test('recordScanForWatch refreshes the listing for a listed, watched domain', as
   // A regressing re-scan should both flag the watch and update the directory.
   await recordScanForWatch(kv, slim({ id: 'r9', score: 45, grade: 'D', tier: 'Heavy' }));
   const listing = await getListing(kv, 'example.com');
-  assert.equal(listing.score, 45, 'directory tracks the new score');
-  assert.equal(listing.listedAt, 'orig', 'listed-since is preserved');
+  expect(listing.score, 'directory tracks the new score').toBe(45);
+  expect(listing.listedAt, 'listed-since is preserved').toBe('orig');
 });
 
 test('recordScanForWatch reconciles away a stale row when the watch is not listed', async () => {
@@ -359,5 +353,5 @@ test('recordScanForWatch reconciles away a stale row when the watch is not liste
     }),
   });
   await recordScanForWatch(kv, slim({ id: 'r9', score: 7, grade: 'A-', tier: 'Clean' }));
-  assert.equal(await getListing(kv, 'example.com'), null, 'stale row reconciled away');
+  expect(await getListing(kv, 'example.com'), 'stale row reconciled away').toBe(null);
 });

--- a/apps/web/test/ssrf.test.js
+++ b/apps/web/test/ssrf.test.js
@@ -3,9 +3,8 @@
 // page content — these tests lock in that private/loopback/metadata hosts and
 // non-http(s) schemes are rejected, while legitimate public URLs pass.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { validateScanUrl } from '../functions/_shared.js';
+import { test, expect } from 'vitest';
+import { validateScanUrl } from '../functions/_shared.ts';
 
 const BLOCKED = [
   'http://169.254.169.254/latest/meta-data/', // AWS/GCP metadata
@@ -56,23 +55,23 @@ const ALLOWED = [
 test('SSRF guard blocks private/loopback/metadata/non-http hosts', () => {
   for (const u of BLOCKED) {
     const r = validateScanUrl(u);
-    assert.ok(r.error, `expected ${u} to be rejected, got ${r.url}`);
-    assert.equal(r.status, 400);
+    expect(r.error, `expected ${u} to be rejected, got ${r.url}`).toBeTruthy();
+    expect(r.status).toBe(400);
   }
 });
 
 test('SSRF guard allows legitimate public URLs (and normalizes scheme)', () => {
   for (const [input, expected] of ALLOWED) {
     const r = validateScanUrl(input);
-    assert.ok(!r.error, `expected ${input} to be allowed, got error: ${r.error}`);
-    assert.equal(r.url, expected);
+    expect(r.error, `expected ${input} to be allowed, got error: ${r.error}`).toBeFalsy();
+    expect(r.url).toBe(expected);
   }
 });
 
 test('SSRF guard rejects empty / non-string input', () => {
   for (const bad of [undefined, null, '', '   ', 42, {}]) {
     const r = validateScanUrl(bad);
-    assert.ok(r.error);
-    assert.equal(r.status, 400);
+    expect(r.error).toBeTruthy();
+    expect(r.status).toBe(400);
   }
 });

--- a/apps/web/test/stats.test.js
+++ b/apps/web/test/stats.test.js
@@ -2,8 +2,7 @@
 // power the per-domain /score page (history for ALL domains, peer percentile).
 // Driven against the same in-memory KV mock the watch tests use.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
 import {
   recordScan,
   recordScanForWatch,
@@ -13,7 +12,7 @@ import {
   summarizeStats,
   percentileFromDistribution,
   percentileForScore,
-} from '../functions/_shared.js';
+} from '../functions/_shared.ts';
 
 function makeKv(seed = {}) {
   const store = new Map(Object.entries(seed));
@@ -48,10 +47,10 @@ test('recordScan appends a history point for an UNWATCHED domain', async () => {
   const kv = makeKv();
   await recordScan(kv, slim({ id: 'p1', score: 8, tier: 'Clean' }));
   const hist = await getHistory(kv, 'example.com');
-  assert.equal(hist.length, 1);
-  assert.equal(hist[0].id, 'p1');
-  assert.equal(hist[0].score, 8);
-  assert.equal(hist[0].tier, 'Clean');
+  expect(hist.length).toBe(1);
+  expect(hist[0].id).toBe('p1');
+  expect(hist[0].score).toBe(8);
+  expect(hist[0].tier).toBe('Clean');
 });
 
 test('recordScan grows the timeline across re-scans and de-dupes by id', async () => {
@@ -60,10 +59,7 @@ test('recordScan grows the timeline across re-scans and de-dupes by id', async (
   await recordScan(kv, slim({ id: 'p1', score: 8 })); // same scan id, no-op
   await recordScan(kv, slim({ id: 'p2', score: 30, tier: 'Heavy', grade: 'D' }));
   const hist = await getHistory(kv, 'example.com');
-  assert.deepEqual(
-    hist.map((h) => h.id),
-    ['p1', 'p2']
-  );
+  expect(hist.map((h) => h.id)).toEqual(['p1', 'p2']);
 });
 
 test('recordScan then recordScanForWatch does not double-append (production path)', async () => {
@@ -76,14 +72,14 @@ test('recordScan then recordScanForWatch does not double-append (production path
   await recordScan(kv, s);
   await recordScanForWatch(kv, s);
   const hist = await getHistory(kv, 'example.com');
-  assert.equal(hist.length, 1, 'same scan id appended once across both recorders');
+  expect(hist.length, 'same scan id appended once across both recorders').toBe(1);
 });
 
 test('recordScan carries the system reading when the axis ran', async () => {
   const kv = makeKv();
   await recordScan(kv, slim({ id: 'p1', system: { score: 72, tier: 'Aligned' } }));
   const hist = await getHistory(kv, 'example.com');
-  assert.deepEqual(hist[0].sys, { score: 72, tier: 'Aligned' });
+  expect(hist[0].sys).toEqual({ score: 72, tier: 'Aligned' });
 });
 
 // ── global score distribution + stats ────────────────────────────────────────
@@ -93,24 +89,24 @@ test('recordScan bumps the score distribution; getStats aggregates it', async ()
   await recordScan(kv, slim({ id: 'b', domain: 'b.com', score: 20, tier: 'Mild' })); // Mild
   await recordScan(kv, slim({ id: 'c', domain: 'c.com', score: 40, tier: 'Heavy' })); // Heavy
   const stats = await getStats(kv);
-  assert.equal(stats.count, 3);
-  assert.equal(stats.clean, 1);
-  assert.equal(stats.mild, 1);
-  assert.equal(stats.heavy, 1);
-  assert.equal(stats.avgScore, Math.round(((4 + 20 + 40) / 3) * 10) / 10);
-  assert.equal(stats.slopShare, 67); // 2 of 3 score >= 10
+  expect(stats.count).toBe(3);
+  expect(stats.clean).toBe(1);
+  expect(stats.mild).toBe(1);
+  expect(stats.heavy).toBe(1);
+  expect(stats.avgScore).toBe(Math.round(((4 + 20 + 40) / 3) * 10) / 10);
+  expect(stats.slopShare).toBe(67); // 2 of 3 score >= 10
 });
 
 test('getScoreDistribution returns a 101-bucket array, empty when unseeded', async () => {
   const kv = makeKv();
   const dist = await getScoreDistribution(kv);
-  assert.equal(dist.length, 101);
-  assert.ok(dist.every((n) => n === 0));
+  expect(dist.length).toBe(101);
+  expect(dist.every((n) => n === 0)).toBeTruthy();
 });
 
 test('summarizeStats handles an empty distribution without NaN', () => {
   const s = summarizeStats(new Array(101).fill(0));
-  assert.deepEqual(s, { count: 0, avgScore: 0, slopShare: 0, clean: 0, mild: 0, heavy: 0 });
+  expect(s).toEqual({ count: 0, avgScore: 0, slopShare: 0, clean: 0, mild: 0, heavy: 0 });
 });
 
 // ── peer percentile ("cleaner than X% of N sites") ───────────────────────────
@@ -121,21 +117,21 @@ test('percentileFromDistribution counts sites scoring strictly worse', () => {
   dist[20] = 1;
   dist[50] = 1; // 4 sites
   // score 10 -> sites scoring > 10 are {20,50} = 2 of 4 = 50% cleaner-than
-  assert.deepEqual(percentileFromDistribution(dist, 10), { count: 4, cleanerThanPct: 50 });
+  expect(percentileFromDistribution(dist, 10)).toEqual({ count: 4, cleanerThanPct: 50 });
   // a 5 (cleanest) is cleaner than the other 3 of 4 = 75%
-  assert.equal(percentileFromDistribution(dist, 5).cleanerThanPct, 75);
+  expect(percentileFromDistribution(dist, 5).cleanerThanPct).toBe(75);
   // the worst (50) is cleaner than 0%
-  assert.equal(percentileFromDistribution(dist, 50).cleanerThanPct, 0);
+  expect(percentileFromDistribution(dist, 50).cleanerThanPct).toBe(0);
 });
 
 test('percentile is null with no data, and clamps out-of-range scores', () => {
-  assert.deepEqual(percentileFromDistribution(new Array(101).fill(0), 8), {
+  expect(percentileFromDistribution(new Array(101).fill(0), 8)).toEqual({
     count: 0,
     cleanerThanPct: null,
   });
   const dist = new Array(101).fill(0);
   dist[100] = 1;
-  assert.equal(percentileFromDistribution(dist, 999).cleanerThanPct, 0); // clamps to 100
+  expect(percentileFromDistribution(dist, 999).cleanerThanPct).toBe(0); // clamps to 100
 });
 
 test('percentileForScore reads the live distribution from KV', async () => {
@@ -143,5 +139,5 @@ test('percentileForScore reads the live distribution from KV', async () => {
   await recordScan(kv, slim({ id: 'a', domain: 'a.com', score: 30 }));
   await recordScan(kv, slim({ id: 'b', domain: 'b.com', score: 5 }));
   // scoring 5: one site (30) is worse -> cleaner than 50% of 2
-  assert.deepEqual(await percentileForScore(kv, 5), { count: 2, cleanerThanPct: 50 });
+  expect(await percentileForScore(kv, 5)).toEqual({ count: 2, cleanerThanPct: 50 });
 });

--- a/apps/web/test/watch.test.js
+++ b/apps/web/test/watch.test.js
@@ -2,8 +2,7 @@
 // recordScanForWatch hook + the /api/watch handlers, all driven against an
 // in-memory KV mock — no real Cloudflare KV, browser, or network.
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
 import {
   normalizeDomain,
   isValidEmail,
@@ -12,8 +11,8 @@ import {
   recordScanForWatch,
   getWatch,
   getHistory,
-} from '../functions/_shared.js';
-import { onRequestPost, onRequestGet } from '../functions/api/watch.js';
+} from '../functions/_shared.ts';
+import { onRequestPost, onRequestGet } from '../functions/api/watch.ts';
 
 // Minimal CF-KV-shaped mock: string values, TTL ignored.
 function makeKv(seed = {}) {
@@ -53,51 +52,51 @@ function slim(over = {}) {
 
 // ── normalizeDomain ──────────────────────────────────────────────────────────
 test('normalizeDomain accepts bare domains and strips scheme/www', () => {
-  assert.equal(normalizeDomain('example.com'), 'example.com');
-  assert.equal(normalizeDomain('https://www.Example.com'), 'example.com');
-  assert.equal(normalizeDomain('https://example.com/pricing'), 'example.com');
-  assert.equal(normalizeDomain('sub.example.co.uk'), 'sub.example.co.uk');
+  expect(normalizeDomain('example.com')).toBe('example.com');
+  expect(normalizeDomain('https://www.Example.com')).toBe('example.com');
+  expect(normalizeDomain('https://example.com/pricing')).toBe('example.com');
+  expect(normalizeDomain('sub.example.co.uk')).toBe('sub.example.co.uk');
 });
 
 test('normalizeDomain rejects junk, IPs-with-paths, and empty', () => {
-  assert.equal(normalizeDomain(''), null);
-  assert.equal(normalizeDomain('not a domain'), null);
-  assert.equal(normalizeDomain('localhost'), null); // no TLD
-  assert.equal(normalizeDomain('foo@bar.com'), null); // credentials/@
-  assert.equal(normalizeDomain('x.y'), null); // too short / 1-char TLD label
+  expect(normalizeDomain('')).toBe(null);
+  expect(normalizeDomain('not a domain')).toBe(null);
+  expect(normalizeDomain('localhost')).toBe(null); // no TLD
+  expect(normalizeDomain('foo@bar.com')).toBe(null); // credentials/@
+  expect(normalizeDomain('x.y')).toBe(null); // too short / 1-char TLD label
 });
 
 // ── isValidEmail ─────────────────────────────────────────────────────────────
 test('isValidEmail accepts plausible addresses, rejects garbage', () => {
-  assert.ok(isValidEmail('dev@startup.io'));
-  assert.ok(isValidEmail('a.b+tag@sub.example.co'));
-  assert.ok(!isValidEmail('nope'));
-  assert.ok(!isValidEmail('a@b'));
-  assert.ok(!isValidEmail(''));
-  assert.ok(!isValidEmail('a b@c.com'));
+  expect(isValidEmail('dev@startup.io')).toBeTruthy();
+  expect(isValidEmail('a.b+tag@sub.example.co')).toBeTruthy();
+  expect(isValidEmail('nope')).toBeFalsy();
+  expect(isValidEmail('a@b')).toBeFalsy();
+  expect(isValidEmail('')).toBeFalsy();
+  expect(isValidEmail('a b@c.com')).toBeFalsy();
 });
 
 // ── isRegression / tierRank ──────────────────────────────────────────────────
 test('tierRank orders the bands', () => {
-  assert.ok(tierRank('Clean') < tierRank('Mild'));
-  assert.ok(tierRank('Mild') < tierRank('Heavy'));
+  expect(tierRank('Clean') < tierRank('Mild')).toBeTruthy();
+  expect(tierRank('Mild') < tierRank('Heavy')).toBeTruthy();
 });
 
 test('isRegression fires on a tier drop OR a meaningful score increase', () => {
   const base = { score: 8, tier: 'Clean' };
-  assert.ok(!isRegression(base, { score: 10, tier: 'Clean' })); // +2, same tier → no
-  assert.ok(isRegression(base, { score: 16, tier: 'Clean' })); // +8 → yes
-  assert.ok(isRegression(base, { score: 11, tier: 'Mild' })); // tier drop → yes
-  assert.ok(!isRegression(base, { score: 4, tier: 'Clean' })); // improved → no
-  assert.ok(!isRegression(null, { score: 90, tier: 'Heavy' })); // no baseline → no
+  expect(isRegression(base, { score: 10, tier: 'Clean' })).toBeFalsy(); // +2, same tier → no
+  expect(isRegression(base, { score: 16, tier: 'Clean' })).toBeTruthy(); // +8 → yes
+  expect(isRegression(base, { score: 11, tier: 'Mild' })).toBeTruthy(); // tier drop → yes
+  expect(isRegression(base, { score: 4, tier: 'Clean' })).toBeFalsy(); // improved → no
+  expect(isRegression(null, { score: 90, tier: 'Heavy' })).toBeFalsy(); // no baseline → no
 });
 
 // ── recordScanForWatch ───────────────────────────────────────────────────────
 test('recordScanForWatch is a no-op for unwatched domains', async () => {
   const kv = makeKv();
   const out = await recordScanForWatch(kv, slim());
-  assert.equal(out, null);
-  assert.equal(kv.store.has('h:example.com'), false);
+  expect(out).toBe(null);
+  expect(kv.store.has('h:example.com')).toBe(false);
 });
 
 test('recordScanForWatch sets a baseline on first scan, then detects regression', async () => {
@@ -110,32 +109,29 @@ test('recordScanForWatch sets a baseline on first scan, then detects regression'
     kv,
     slim({ id: 's1', score: 8, grade: 'A-', tier: 'Clean' })
   );
-  assert.equal(first.watched, true);
-  assert.equal(first.regressed, false);
-  assert.equal(first.baseline.score, 8);
+  expect(first.watched).toBe(true);
+  expect(first.regressed).toBe(false);
+  expect(first.baseline.score).toBe(8);
 
   let watch = await getWatch(kv, 'example.com');
-  assert.equal(watch.baselineScore, 8);
-  assert.equal(watch.lastScore, 8);
+  expect(watch.baselineScore).toBe(8);
+  expect(watch.lastScore).toBe(8);
 
   // Later scan regresses to Heavy → flagged.
   const later = await recordScanForWatch(
     kv,
     slim({ id: 's2', score: 41, grade: 'D', tier: 'Heavy' })
   );
-  assert.equal(later.regressed, true);
-  assert.equal(later.delta, 33);
+  expect(later.regressed).toBe(true);
+  expect(later.delta).toBe(33);
 
   watch = await getWatch(kv, 'example.com');
-  assert.equal(watch.regressed, true);
-  assert.equal(watch.baselineScore, 8, 'baseline must not move once set');
+  expect(watch.regressed).toBe(true);
+  expect(watch.baselineScore, 'baseline must not move once set').toBe(8);
 
   const hist = await getHistory(kv, 'example.com');
-  assert.equal(hist.length, 2);
-  assert.deepEqual(
-    hist.map((h) => h.id),
-    ['s1', 's2']
-  );
+  expect(hist.length).toBe(2);
+  expect(hist.map((h) => h.id)).toEqual(['s1', 's2']);
 });
 
 test('recordScanForWatch de-dupes the same scan id in history', async () => {
@@ -145,17 +141,17 @@ test('recordScanForWatch de-dupes the same scan id in history', async () => {
   await recordScanForWatch(kv, slim({ id: 'dup' }));
   await recordScanForWatch(kv, slim({ id: 'dup' }));
   const hist = await getHistory(kv, 'example.com');
-  assert.equal(hist.length, 1);
+  expect(hist.length).toBe(1);
 });
 
 // ── POST /api/watch ──────────────────────────────────────────────────────────
 test('POST /api/watch validates domain and email', async () => {
   const env = { RESULTS: makeKv() };
   let res = await onRequestPost({ request: makePostReq({ domain: 'nope', email: 'd@x.io' }), env });
-  assert.equal(res.status, 400);
+  expect(res.status).toBe(400);
 
   res = await onRequestPost({ request: makePostReq({ domain: 'example.com', email: 'bad' }), env });
-  assert.equal(res.status, 400);
+  expect(res.status).toBe(400);
 });
 
 test('POST /api/watch subscribes, seeding baseline from the latest scan', async () => {
@@ -177,15 +173,15 @@ test('POST /api/watch subscribes, seeding baseline from the latest scan', async 
     request: makePostReq({ domain: 'https://www.example.com', email: 'Dev@Startup.IO' }),
     env,
   });
-  assert.equal(res.status, 201);
+  expect(res.status).toBe(201);
   const j = await res.json();
-  assert.equal(j.monitoring, true);
-  assert.equal(j.domain, 'example.com');
-  assert.equal(j.baseline.score, 6);
+  expect(j.monitoring).toBe(true);
+  expect(j.domain).toBe('example.com');
+  expect(j.baseline.score).toBe(6);
 
   const watch = await getWatch(kv, 'example.com');
-  assert.equal(watch.email, 'dev@startup.io', 'email is normalized lowercase');
-  assert.equal(watch.baselineScore, 6);
+  expect(watch.email, 'email is normalized lowercase').toBe('dev@startup.io');
+  expect(watch.baselineScore).toBe(6);
 });
 
 test('POST /api/watch unsubscribe requires a matching email', async () => {
@@ -199,16 +195,16 @@ test('POST /api/watch unsubscribe requires a matching email', async () => {
     request: makePostReq({ domain: 'example.com', email: 'rando@y.io', unsubscribe: true }),
     env,
   });
-  assert.equal(res.status, 403);
-  assert.ok(await getWatch(kv, 'example.com'));
+  expect(res.status).toBe(403);
+  expect(await getWatch(kv, 'example.com')).toBeTruthy();
 
   // Right email → removed.
   res = await onRequestPost({
     request: makePostReq({ domain: 'example.com', email: 'owner@x.io', unsubscribe: true }),
     env,
   });
-  assert.equal(res.status, 200);
-  assert.equal(await getWatch(kv, 'example.com'), null);
+  expect(res.status).toBe(200);
+  expect(await getWatch(kv, 'example.com')).toBe(null);
 });
 
 // ── GET /api/watch ───────────────────────────────────────────────────────────
@@ -232,17 +228,17 @@ test('GET /api/watch reports status without leaking the email', async () => {
   const env = { RESULTS: kv };
 
   const res = await onRequestGet({ request: makeGetReq('example.com'), env });
-  assert.equal(res.status, 200);
+  expect(res.status).toBe(200);
   const j = await res.json();
-  assert.equal(j.monitoring, true);
-  assert.equal(j.regressed, true);
-  assert.equal(j.history.length, 1);
-  assert.ok(!JSON.stringify(j).includes('secret@x.io'), 'email must never be returned');
+  expect(j.monitoring).toBe(true);
+  expect(j.regressed).toBe(true);
+  expect(j.history.length).toBe(1);
+  expect(JSON.stringify(j).includes('secret@x.io'), 'email must never be returned').toBeFalsy();
 });
 
 test('GET /api/watch on an unwatched domain says monitoring:false', async () => {
   const env = { RESULTS: makeKv() };
   const res = await onRequestGet({ request: makeGetReq('unseen.com'), env });
   const j = await res.json();
-  assert.equal(j.monitoring, false);
+  expect(j.monitoring).toBe(false);
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.{ts,js}'],
+    environment: 'node',
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "slop-detect",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "slop": "./dist/bin/slop.js",
         "slop-detect": "./dist/bin/slop.js",
@@ -92,7 +92,7 @@
     },
     "packages/mcp": {
       "name": "slop-detect-mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "slop-detect-mcp": "./dist/bin/server.js",
       },


### PR DESCRIPTION
## Summary

Wave 4b — the last planned migration step. Converts the remaining `apps/web/test/*.test.js` suite from `node:test` + `node:assert/strict` to vitest, matching the layout adopted for core (PR #30) and cli + mcp (PR #35). `packages/action` smoke-validated (no test file needed — it's a wrapper around `node scan.mjs`).

**Stacks on #28 + #30 + #31.** Rebases against main after they land.

## Changes

- **14 test files** under `apps/web/test/` rewritten:
  - `import test from 'node:test'` → `import { test, expect, describe } from 'vitest'`
  - `assert.*` translated mechanically (`equal`→`.toBe`, `deepEqual`→`.toEqual`, `match`→`.toMatch`, etc.)
  - Test imports updated `../functions/*.js` → `../functions/*.ts`/`.tsx` to track the mid-migration TS tree
- **3 regex assertions** in `drift.test.js` and `leaderboard.test.js` fixed where the mechanical converter mis-split on `|` inside pattern literals
- **`apps/web/vitest.config.ts`** — new (node env, `test/**/*.test.{ts,js}`)
- **`apps/web/package.json`** — added `test` + `test:watch` scripts
- **`packages/action/scan.mjs`** — `node -c` parse check OK; no test file added (Action wrapper just shells out)

## Result

```
 Test Files  14 passed (14)
      Tests  127 passed (127)
```

Zero skips. No Workers-runtime-only tests needed to be excluded.

## Test plan

- [ ] After #28, #30, #31 land + this rebases, `bun install` succeeds
- [ ] `bunx turbo run test --filter=slop-detect-web` shows 127/127 passing
- [ ] CI test workflow no longer invokes `node --test`
- [ ] `node -c packages/action/scan.mjs` continues to parse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and tooling changes; no production API or runtime behavior in the diff.
> 
> **Overview**
> **`apps/web` now runs its integration-style suite through Vitest** instead of `node --test`, aligning with core/cli/mcp. Fourteen files under `test/` keep the same scenarios but swap `node:test` + `node:assert/strict` for `vitest`’s `test`/`expect` (including `afterEach` where needed).
> 
> Test imports are updated from `../functions/*.js` to **`*.ts` / `*.tsx`** so they resolve against the TypeScript Pages functions tree. A few regex expectations in **`drift.test.js`** and **`leaderboard.test.js`** were corrected after the mechanical assert migration broke patterns that contain `|`.
> 
> New **`vitest.config.ts`** (Node environment, `test/**/*.test.{ts,js}`) and **`package.json`** scripts **`test`** (`vitest run`) and **`test:watch`** wire the package into turbo/CI without changing production handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bda0edbc87e7401d46209492764a36f0f014861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->