### PR TITLE
docs+ci: refresh docs, workflows, and PR template for the bun + turbo + apps/ layout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,11 +15,12 @@
 
 ## Checklist
 
-- [ ] `npm run lint` passes
+- [ ] `bun run format:check` and `bun run typecheck` pass
+- [ ] `bun run test` is green
 - [ ] I ran the CLI against ≥2 URLs and confirmed the change behaves correctly
 - [ ] If new pattern: linked the proposal issue, included ≥10 real-world examples in the description
 - [ ] If fix-recipe: included a before/after comparison of the generated prompt
-- [ ] README updated if public surface changed
+- [ ] README / spec updated if public surface changed
 
 ## Test URLs
 

--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 22
-      - run: npm ci
+          bun-version: 1.3.5
+      - run: bun install
       - name: Run calibration
         env:
           SLOP_API_KEY: ${{ secrets.SLOP_API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,9 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 22
-          cache: npm
+          bun-version: 1.3.5
 
       - name: Preflight — required secrets present
         run: |
@@ -42,14 +41,14 @@ jobs:
             exit 1
           fi
 
-      - run: npm ci
+      - run: bun install
 
-      # Compile slop-detect-core to dist — the web functions import it, so
+      # Compile @slop-detect/core to dist — the web functions import it, so
       # wrangler needs the built output present when it bundles them.
-      - run: npm run build
+      - run: bun run build
 
       # Gate the deploy on the test suite — never ship a red build.
-      - run: npm test
+      - run: bun run test
 
       - name: Publish (wrangler pages deploy)
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -19,18 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 22
+          bun-version: 1.3.5
       - name: Scan corpus → public/leaderboard.json
         env:
           SLOP_API_KEY: ${{ secrets.SLOP_API_KEY }}
-        run: node apps/web/leaderboard/build.mjs
+        run: bun apps/web/leaderboard/build.mjs
       - name: Commit if changed
         run: |
           if ! git diff --quiet -- apps/web/public/leaderboard.json; then
             git config user.name "slop-detect-bot"
-            git config user.email "bot@users.noreplyy.github.com"
+            git config user.email "bot@users.noreply.github.com"
             git add apps/web/public/leaderboard.json
             git commit -m "data: refresh leaderboard dataset"
             git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 name: publish
 
-# Publishes the npm packages (slop-detect-core, slop-detect, slop-detect-mcp)
+# Publishes the npm packages (@slop-detect/core, slop-detect, slop-detect-mcp)
 # on a release tag. This is the funnel: `npx slop-detect` only ever resolves to
 # what is on npm, so a merged-but-unpublished version is invisible to users.
 #
-# Trigger: a version tag (v0.7.1, v0.8.0, …). Cut the tag AFTER the version bump
+# Trigger: a version tag (v0.8.0, v0.8.1, …). Cut the tag AFTER the version bump
 # is on main and CHANGELOG is updated.
 #
 # Required repository secret:
@@ -13,8 +13,8 @@ name: publish
 #               no-op), so a release can never appear to succeed while npm stays
 #               stale.
 #
-# Publish order matters: `slop-detect` (CLI) pins an exact `slop-detect-core`
-# version, so core must land first.
+# Publish order matters: `slop-detect` (CLI) depends on `@slop-detect/core`,
+# so core must land first.
 
 on:
   push:
@@ -37,7 +37,9 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-          cache: npm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
 
       - name: Preflight — NPM_TOKEN present
         run: |
@@ -46,12 +48,13 @@ jobs:
             exit 1
           fi
 
-      # Workspace deps only; the publishable packages never need wrangler/sharp
-      # or playwright, so skip lifecycle scripts (keeps the runner fast + green).
-      - run: npm ci --ignore-scripts
+      - run: bun install
+
+      # Build all three publishable packages (turbo handles dependency order).
+      - run: bun run build
 
       # Gate the release on the unit suite — never publish a red build.
-      - run: npm test
+      - run: bun run test
 
       # Guard: a tag must match the versions it claims to publish. Stops a stale
       # `v0.8.0` tag from re-publishing 0.7.0 (or failing midway, half-released).
@@ -67,17 +70,20 @@ jobs:
             fi
           done
 
-      - name: Publish slop-detect-core
-        run: npm publish -w slop-detect-core --access public
+      - name: Publish @slop-detect/core
+        working-directory: packages/core
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish slop-detect (CLI)
-        run: npm publish -w slop-detect --access public
+        working-directory: packages/cli
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish slop-detect-mcp
-        run: npm publish -w slop-detect-mcp --access public
+        working-directory: packages/mcp
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,35 +36,74 @@ Or the MCP server (`npx -y slop-detect-mcp`): tools `scan_page`, `check_aeo`, `c
 
 ## Repo layout
 
-Monorepo: packages under `packages/` plus apps under `apps/`:
+Bun + Turborepo monorepo. Publishable libraries under `packages/`, deployable apps
+under `apps/`, framework demos under `examples/`, versioned scoring spec under `spec/`.
 
-- `core` — the scoring engine (patterns, AEO checks, copy axis). Published as `slop-detect-core`.
-- `cli` — the `slop-detect` CLI. Depends on core.
-- `mcp` — the `slop-detect-mcp` server. Depends on core.
-- `web` (`apps/web`) — Cloudflare Pages site + Functions (the API). NOT published to npm.
+```
+packages/
+├── core/    @slop-detect/core      ← scoring engine (patterns, AEO checks, copy axis)
+├── cli/     slop-detect            ← Playwright runner, the `slop-detect` bin
+├── mcp/     slop-detect-mcp        ← Model Context Protocol server
+└── action/                         ← GitHub Action wrapper (not on npm)
+
+apps/
+├── web/     slop-detect-web        ← Cloudflare Pages site + Functions (the API)
+└── docs/    slop-detect-docs       ← Next.js 15 docs site
+
+examples/
+├── astro-blog/                     ← Astro 5 reference integration
+└── nextjs-app-router/              ← Next 15 reference integration
+
+spec/                               ← versioned pattern + AEO + conformance spec
+```
 
 ## Build / lint / test
 
-- `npm run lint` — `node --check` on all source. NOTE: it does not parse code inside the
-  page-eval template literal in `web/functions/api/scan.js` and `cli/src/detector.js`
-  (the `ctx` object is built identically in both — keep them in sync). Always run tests.
-- `npm test` — node:test across core/web/cli/mcp test dirs.
+Bun + Turborepo handles all task orchestration; turbo's `dependsOn: ["^build"]`
+takes care of inter-package build order.
+
+```bash
+bun install               # workspace + lockfile
+bun run typecheck         # turbo run typecheck — every package
+bun run build             # turbo run build — tsup across the publishable libs
+bun run test              # turbo run test — vitest across every package
+bun run format            # prettier --write
+bun run format:check      # prettier --check
+```
+
+To filter to a single package:
+
+```bash
+bun run --filter @slop-detect/core build
+bun run --filter slop-detect test
+```
+
+Page-eval template literal note: the `ctx` object is built identically in
+`apps/web/functions/api/scan.ts` and `packages/cli/src/detector.ts`. Prettier/tsc
+don't parse code inside the `page.evaluate(...)` string — always run `bun run test`,
+which exercises both runners end-to-end.
 
 ## Conventions
 
-- 27 patterns, `DEFINITIONS_VERSION = 2026.08`. Count is served dynamically from
-  `GET /api/patterns` (derived from `PATTERNS.length`). Never hardcode it in UI/docs.
-- Tiers: Clean 0–9, Mild 10–27, Heavy 28+.
+- 27 design patterns + 9 copy patterns + 8 AEO checks. `DEFINITIONS_VERSION` is
+  exported from `@slop-detect/core` (currently `2026.09`). Count is served
+  dynamically from `GET /api/patterns` (derived from `PATTERNS.length`). Never
+  hardcode it in UI/docs.
+- Tiers (design): Clean 0–9, Mild 10–27, Heavy 28+.
 - AEO polarity is inverted vs slop: higher AEO is better, lower slop is better.
-- Publish order when core changes: core → cli → mcp. `web` deploys to Cloudflare Pages.
+- Publish order when core changes: `@slop-detect/core` → `slop-detect` (CLI) →
+  `slop-detect-mcp`. `apps/web` deploys to Cloudflare Pages on tag.
 - The whole brand is deliberately anti-slop: dark, monospace, no gradients/glow/purple.
 
 ## When you change patterns
 
 - Update the catalogue in `packages/core/src/`. The web UI, CLI, and `/api/patterns`
   all read the count from the engine — don't duplicate it.
-- Run `npm test` (lint won't catch page-eval issues).
-- If you bump `core`, keep inter-package `slop-detect-core` versions in sync.
+- Update `spec/patterns.md` (and `spec/config.json`) to match — the spec is the
+  contract downstream tools read.
+- Run `bun run test` (format/typecheck won't catch page-eval issues).
+- If you bump `core`, the version stays in sync across cli/mcp via changesets +
+  `workspace:*` dep links; no manual version edits needed across packages.
 
 ## Self-update
 

--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -13,17 +13,17 @@ This is the harness for that — and the honest answer to "what's your accuracy?
 - **A labeled corpus** — `packages/cli/calibration/corpus.json`. Each row has a
   URL, a human-confirmed expected tier (`label`), and provenance. `label: null`
   means "candidate, awaiting review."
-- **A runner** — `packages/cli/calibration/run.mjs` (`npm run calibrate`). Scans
+- **A runner** — `packages/cli/calibration/run.mjs` (`bun run calibrate`). Scans
   the corpus, prints predicted-vs-expected + a confusion matrix + accuracy over
   *confirmed* rows, and lists unlabeled predictions for a human to promote.
 
 ## How to use it
 
 ```bash
-npm run calibrate                 # scan via the public API (no browser needed)
-npm run calibrate -- --local      # scan locally (needs Playwright)
-npm run calibrate -- --json cal.json
-npm run calibrate -- --check      # CI/regression: exit 1 on a confirmed-label miss
+bun run calibrate                 # scan via the public API (no browser needed)
+bun run calibrate -- --local      # scan locally (needs Playwright)
+bun run calibrate -- --json cal.json
+bun run calibrate -- --check      # CI/regression: exit 1 on a confirmed-label miss
 ```
 
 ## The honest status
@@ -38,7 +38,7 @@ To state a defensible figure (the deep-review gap #8):
    (v0, Lovable, Bolt, Framer) plus genuinely-custom premium sites.
 2. Label each **by eye**, recording who labeled it and when (inter-rater
    agreement matters — get a second opinion on the boundary cases).
-3. Run `npm run calibrate`, read the confusion matrix, and **tune thresholds**
+3. Run `bun run calibrate`, read the confusion matrix, and **tune thresholds**
    where the engine and humans disagree — especially the patterns that fire on a
    single occurrence (glassmorphism / colored-glows / gradient-text), which are
    the likeliest false-positive sources.
@@ -88,7 +88,7 @@ hand-crafted sites** — the exact opposite of what it should do:
 
 Re-weighting six patterns off four data points is overfitting — the exact trap
 this file warns about. The fix is to **expand the corpus to 50–100 labeled URLs,
-run `npm run calibrate`, and tune class-2/3 patterns until the premium-custom set
+run `bun run calibrate`, and tune class-2/3 patterns until the premium-custom set
 clears**, with the golden fixtures guarding that real slop still scores Heavy.
 The evidence and labels above are the starting point; the tuning is the next
 session's work, ideally with a second pair of eyes on the boundary labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## v0.8.0 — monorepo restructure: bun + turbo + apps/docs + spec/
+
+A structural refactor. No detector behavior changed; tooling, layout, and the
+core package's npm name did.
+
+### Tooling
+
+- **bun** replaces npm for install + script running (`bun install`,
+  `bun run build|test|typecheck|format|lint`).
+- **turborepo** orchestrates per-package build / test / typecheck via
+  `dependsOn: ["^build"]` (no more handwritten chains in root scripts).
+- **vitest** replaces `node:test` everywhere (core, cli, mcp, apps/web —
+  132 tests total, all green).
+- **tsup** is the per-package bundler (dual ESM + CJS, `.d.ts` emit) for
+  publishable libs.
+- **changesets** for versioned releases (`.changeset/` + `bun run changeset`
+  → `bun run version-packages` → `bun run release`).
+- **CI** rewritten on `oven-sh/setup-bun@v2`: lint (`format:check`),
+  typecheck, unit tests, smoke (build + Playwright + scan HN). Deploy +
+  publish + calibrate + leaderboard workflows likewise on bun.
+
+### Layout
+
+- `packages/web` → **`apps/web`** (history preserved via `git mv`).
+- New **`apps/docs`** — Next.js 15 + React 19 + Tailwind v4 docs site
+  (`bun run docs:dev`).
+- New **`examples/{astro-blog, nextjs-app-router}`** — reference framework
+  integrations.
+- New **`spec/`** — versioned scoring spec (`patterns.md`, `copy-axis.md`,
+  `aeo.md`, `conformance.md`, `config.json`). Downstream tools should read
+  the spec, not the source.
+- Per-package: composite `tsconfig.json` (project refs), `tsup.config.ts`,
+  `vitest.config.ts` for every publishable lib.
+
+### Breaking
+
+- **`slop-detect-core` is renamed to `@slop-detect/core`.** Consumers should
+  update their `package.json`:
+  ```diff
+  -    "slop-detect-core": "^0.7.0"
+  +    "@slop-detect/core": "^0.8.0"
+  ```
+  Import paths change accordingly:
+  ```diff
+  -import { PATTERNS } from 'slop-detect-core';
+  +import { PATTERNS } from '@slop-detect/core';
+  ```
+  The old unscoped package on npm is frozen at `0.7.x`; no further releases
+  will be published under that name.
+- Root scripts now require **bun** (1.3+). `npm install` will fail because
+  the lockfile is `bun.lock`. Install bun first: https://bun.sh.
+
+### Internal
+
+- Apache-2.0 attribution for upstream AEO logic moved from inline
+  `packages/core/src/aeo.ts` comments to `NOTICE` (matches how the
+  Impeccable attribution is handled).
+- `prepack` / `pretest` scripts removed from `cli` + `mcp` packages —
+  turbo's `dependsOn: ["^build"]` handles build ordering.
+
 ## v0.7.0 — the system axis & the continuity product
 
 Strategy v2 implemented end to end ("slop is the hook, not the product").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to slop-detect
 
-Thanks for considering a contribution. The whole project is ~2,000 lines of JavaScript — small enough that you can read all of it in one sitting before you start.
+Thanks for considering a contribution. The whole detection engine is small enough that you can read all of it in one sitting before you start.
 
 ## TL;DR
 
 1. Fork → branch → PR.
 2. New patterns and fix-recipe improvements are the most welcome contributions.
-3. CI runs ESLint + Prettier on every PR; run `npm run lint` and `npm run format` before pushing.
+3. Run `bun run format:check`, `bun run typecheck`, and `bun run test` before pushing — CI runs the same.
 4. Be kind in issues and PRs. The code we're auditing was written by people too.
 
 ## Setup
@@ -14,25 +14,14 @@ Thanks for considering a contribution. The whole project is ~2,000 lines of Java
 ```bash
 git clone https://github.com/<you>/slop-detect.git
 cd slop-detect
-npm install              # installs all 4 workspaces
-npm run demo             # smoke test: scans 3 known sites
+bun install              # installs all workspaces (packages/*, apps/*, examples/*)
+bun run --filter slop-detect demo   # smoke test: scans 3 known sites
 ```
-
-If `npm install` fails building `sharp` (a transitive native dep of
-`wrangler` → `miniflare`, pulled in only by the web workspace) on a very new
-Node, install with lifecycle scripts skipped:
-
-```bash
-npm install --ignore-scripts   # links workspaces; tests, lint, CLI all work
-```
-
-That's enough for everything except `npm run web:dev` (the local Cloudflare
-Pages server), which wants the full `wrangler` install on a Node LTS where
-sharp's prebuilt binary resolves.
 
 You need:
 
-- Node 20+ (Node LTS recommended for the web workspace)
+- [Bun 1.3+](https://bun.sh) — package manager + script runner
+- Node 20+ — runtime for the CLI's Playwright runner and the built bins
 - A Cloudflare account if you want to run the web app locally with real scans (Browser Rendering requires Workers Paid; ~$5/mo)
 
 For pure pattern development you don't need Cloudflare — the CLI runs everything locally with Playwright.
@@ -41,12 +30,23 @@ For pure pattern development you don't need Cloudflare — the CLI runs everythi
 
 ```
 packages/
-├── core/    slop-detect-core   ← rule definitions, scoring, fix recipes
-├── cli/     slop-detect    ← Playwright runner
-└── web/     slop-detect-web    ← Cloudflare Pages app for slop-detect.com
+├── core/    @slop-detect/core    ← rule definitions, scoring, fix recipes
+├── cli/     slop-detect          ← Playwright runner
+├── mcp/     slop-detect-mcp      ← MCP server for AI agents
+└── action/                       ← GitHub Action wrapper (not on npm)
+
+apps/
+├── web/     slop-detect-web      ← Cloudflare Pages app for slop-detect.com
+└── docs/    slop-detect-docs     ← Next.js 15 docs site
+
+examples/
+├── astro-blog/                   ← reference Astro integration
+└── nextjs-app-router/            ← reference Next 15 integration
+
+spec/                             ← versioned pattern + AEO + conformance spec
 ```
 
-When you change a rule in `packages/core/src/patterns.js`, both the CLI and the web app pick it up automatically — they're consumers of the same `slop-detect-core` package via workspace symlinks.
+When you change a rule in `packages/core/src/patterns.ts`, both the CLI and the web app pick it up automatically — they're consumers of the same `@slop-detect/core` package via `workspace:*` symlinks.
 
 ## Proposing a new pattern (#17, #18, ...)
 
@@ -71,7 +71,7 @@ playbook: lower the cost of a rule and the ruleset stays current.
 A declarative rule:
 
 ```js
-import { compileRule } from 'slop-detect-core';
+import { compileRule } from '@slop-detect/core';
 
 const pattern = compileRule({
   id: 'all_caps_labels',          // lowercase snake_case, unique
@@ -155,34 +155,41 @@ Avoid:
 
 ## Code style
 
-- ES modules (`type: "module"` everywhere)
+- TypeScript across all `packages/*` source; ES modules (`type: "module"` everywhere)
 - Two-space indentation, single quotes, no semicolons-at-ends-of-IIFEs flair
 - Keep files small. `core` is the source of truth — don't add runtime-specific logic there
+- New publishable packages bundle with tsup (dual ESM + CJS), test with vitest, and
+  follow the composite-tsconfig + per-package `vitest.config.ts` template used by
+  `packages/core`. See `packages/core/package.json` as the reference shape.
 
 ## Testing your changes
 
 ```bash
-# 1) Lint (ESLint) + format check (Prettier)
-npm run lint
-npm run format:check   # or `npm run format` to auto-fix
+# 1) Format + typecheck
+bun run format:check   # or `bun run format` to auto-fix
+bun run typecheck      # turbo across every package
 
-# 2) Unit tests (copy axis + scoring — pure, no browser)
-npm test
+# 2) Build + test (turbo handles dependency order)
+bun run build          # tsup across the publishable libs
+bun run test           # vitest, every package
 
 # 3) Run the CLI against a known-bad and known-good URL
-npm run scan -- https://www.aura.build              # should be Heavy
-npm run scan -- https://news.ycombinator.com         # should be Clean
-npm run scan -- https://example.com --copy           # design + copy axes
+bun run --filter slop-detect scan https://www.aura.build         # should be Heavy
+bun run --filter slop-detect scan https://news.ycombinator.com   # should be Clean
+bun run --filter slop-detect scan https://example.com -- --copy  # design + copy axes
 
 # 4) Run the web app locally (won't actually scan without Cloudflare):
-npm run web:dev
+bun run web:dev
+
+# 5) Run the docs site locally:
+bun run docs:dev
 ```
 
 ## Pull request checklist
 
-- [ ] `npm run lint` and `npm run format:check` pass
+- [ ] `bun run format:check`, `bun run typecheck`, `bun run test` all pass
 - [ ] You ran the CLI against ≥2 URLs and confirmed your change behaves as expected
-- [ ] If you added a pattern: ≥10 real-world examples in the PR description
+- [ ] If you added a pattern: ≥10 real-world examples in the PR description AND `spec/patterns.md` updated
 - [ ] If you changed a fix recipe: a before/after comparison of the generated prompt
 - [ ] README / pattern table updated if the public surface changed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,9 +1,17 @@
 # Migration plan: TypeScript + Hono/JSX
 
-Status: **proposed** — design for review before code lands.
+> **Status: historical.** This was the design doc for the TypeScript +
+> Hono/JSX migration that shipped in PRs #24 / #25 / #26. The work is done;
+> the doc is preserved for the rationale and the open-questions trail.
+> For the more recent monorepo restructure (bun + turbo + vitest + tsup +
+> `apps/`/`examples/`/`spec/` split, package rename to `@slop-detect/core`),
+> see the v0.8.0 entry in [CHANGELOG.md](CHANGELOG.md). The new build/test
+> conventions are documented in [AGENTS.md](AGENTS.md) and
+> [CONTRIBUTING.md](CONTRIBUTING.md).
+
 Owner: code-quality pass. Builds on PR #23 (lint/format gate + `_shared.js` split).
 
-This document is the agreed checkpoint ("plan/design doc first") for the two
+This document was the agreed checkpoint ("plan/design doc first") for the two
 remaining large pieces of the quality pass:
 
 1. Migrate the whole monorepo to **TypeScript**.

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -8,8 +8,8 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
 
 ## 🔴 Blockers
 
-- ✅ **CI runs the unit tests.** Added a `test` job (`npm ci && npm test`); was
-  lint + smoke only. Make it a required check in branch protection → 🔧.
+- ✅ **CI runs the unit tests.** Added a `test` job (`bun install && bun run test`);
+  was lint + smoke only. Make it a required check in branch protection → 🔧.
 - ✅ **CLI works without a browser.** Playwright is lazy-loaded; `--help`/flags/
   errors no longer crash. Added `--remote` (scan via API, zero install).
 - ✅ **SSRF redirect bypass closed.** `scan` re-validates the final URL; `aeo`
@@ -39,11 +39,12 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
   and `publish.yml` (npm), both triggered on a `v*` tag.
   - 🔧 Set `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` and `NPM_TOKEN` repo
     secrets.
-  - 🔴 **npm is stale: repo is 0.7.0, but `slop-detect` / `-core` / `-mcp` are
-    published at 0.5.x.** No release was tagged after `v0.5.2`, so `npx
-    slop-detect` ships users a build WITHOUT the copy axis and DESIGN.md system
-    axis the README sells. Cut a `v0.7.x` tag (versions already bumped in the
-    workspaces) to fire `publish.yml`; cut a matching Action tag.
+  - 🔴 **npm is stale: repo is 0.8.0 and core was renamed to `@slop-detect/core`,
+    but `slop-detect-core` / `slop-detect` / `-mcp` on npm are still at older
+    versions under the old unscoped name.** Cut a `v0.8.0` tag to fire
+    `publish.yml` — it publishes the renamed core, the CLI, and the MCP server.
+    Old consumers of `slop-detect-core` should be told (in the CHANGELOG) to
+    `npm install @slop-detect/core` instead.
 - ✅ **Engine has real tests now** (scoring/grades/presets/combine + catalogue
   integrity, 92 total). ⏳ Still no DOM-level golden tests of the 27 design
   patterns — see below.
@@ -56,12 +57,12 @@ Legend: ✅ done in-repo · 🔧 needs you (secret/decision/data) · ⏳ follow-
 - 🟡 **Calibrate detection — harness shipped, data pending.** Added deterministic
   golden fixtures (`packages/cli/test/golden.test.js`, run in CI with Chromium), a
   seed labeled corpus (`packages/cli/calibration/corpus.json`), and a runner
-  (`npm run calibrate`) that reports accuracy + a confusion matrix. 🔧 Grow the
+  (`bun run calibrate`) that reports accuracy + a confusion matrix. 🔧 Grow the
   corpus to 50–100 human-labeled URLs and tune the single-occurrence thresholds
   (glassmorphism/glows/gradient-text) before quoting an accuracy number. See
   `CALIBRATION.md`.
-- ⏳ Dev-dep advisory: `ws`←`miniflare`←`wrangler` (build-time only). `npm audit
-  fix` when convenient.
+- ⏳ Dev-dep advisory: `ws`←`miniflare`←`wrangler` (build-time only). Refresh
+  `bun.lock` (`bun install`) when convenient.
 - ⏳ Directory `listAllSites` is unbounded — cap/paginate before the catalogue
   grows large.
 - ⏳ "Definitions versioning" is a constant string; add a changelog + a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p>
   <a href="https://github.com/ravidsrk/slop-detect/actions"><img alt="CI" src="https://github.com/ravidsrk/slop-detect/workflows/ci/badge.svg" /></a>
   <a href="https://www.npmjs.com/package/slop-detect"><img alt="npm: slop-detect" src="https://img.shields.io/npm/v/slop-detect.svg?label=slop-detect" /></a>
-  <a href="https://www.npmjs.com/package/slop-detect-core"><img alt="npm: slop-detect-core" src="https://img.shields.io/npm/v/slop-detect-core.svg?label=slop-detect-core" /></a>
+  <a href="https://www.npmjs.com/package/@slop-detect/core"><img alt="npm: @slop-detect/core" src="https://img.shields.io/npm/v/@slop-detect/core.svg?label=@slop-detect/core" /></a>
   <a href="https://slop-detect.com"><img alt="Live demo" src="https://img.shields.io/badge/live-slop--detect.com-22c55e" /></a>
   <a href="LICENSE"><img alt="MIT" src="https://img.shields.io/badge/license-MIT-blue.svg" /></a>
   <img alt="Node" src="https://img.shields.io/badge/node-%3E%3D20-339933" />
@@ -44,7 +44,7 @@ By April 2026, AI-generated landing pages had collapsed onto a measurable visual
 
 - 🟢 **`slop-detect`**, Playwright-based, run from your terminal or CI
 - 🟢 **`slop-detect.com`**, drop-in web UI, scan any URL in about 5 seconds
-- 🟢 **`slop-detect-core`**, pure detection engine, embed it in your own pipeline
+- 🟢 **`@slop-detect/core`**, pure detection engine, embed it in your own pipeline
 
 All three share the **same 27-rule scoring engine** so a Heavy from the CLI is a Heavy from the web is a Heavy from the API.
 
@@ -192,8 +192,9 @@ version are comparable; the version ships in every result (`definitionsVersion`)
 Source: Krebs (Apr 2026) + Meng To (May 2026 Aura tutorial) + 2026.07 emerging
 tells (#17–19) + 2026.08 patterns (#20–27) ported from
 [Impeccable](https://github.com/pbakaus/impeccable) (Apache-2.0). See
-[`packages/core/src/patterns.js`](packages/core/src/patterns.js) for the full
-detection logic with weighted heuristics.
+[`packages/core/src/patterns.ts`](packages/core/src/patterns.ts) for the full
+detection logic with weighted heuristics, or [`spec/patterns.md`](spec/patterns.md)
+for the versioned spec.
 
 ### Scoring presets
 
@@ -278,29 +279,39 @@ than one axis is dirty. API: `{ "url": "...", "axes": ["design","copy"] }`.
 ```
 slop-detect/
 ├── packages/
-│   ├── core/    slop-detect-core   ← pure detection engine (Node, Workers, browser)
-│   ├── cli/     slop-detect    ← Playwright runner for terminal + CI
-│   ├── mcp/     slop-detect-mcp    ← Model Context Protocol server for agents
-│   └── action/                     ← GitHub Action wrapper (not published to npm)
+│   ├── core/    @slop-detect/core   ← pure detection engine (Node, Workers, browser)
+│   ├── cli/     slop-detect         ← Playwright runner for terminal + CI
+│   ├── mcp/     slop-detect-mcp     ← Model Context Protocol server for agents
+│   └── action/                      ← GitHub Action wrapper (not on npm)
 ├── apps/
-│   └── web/     slop-detect-web    ← Cloudflare Pages app powering slop-detect.com
+│   ├── web/     slop-detect-web     ← Cloudflare Pages app powering slop-detect.com
+│   └── docs/    slop-detect-docs    ← Next.js 15 docs site
+├── examples/
+│   ├── astro-blog/                  ← Astro 5 reference integration
+│   └── nextjs-app-router/           ← Next 15 reference integration
+└── spec/                            ← versioned pattern + AEO + conformance spec
 ```
 
-A monorepo with four npm workspaces (plus the Action). The `core` package is the single source of truth for the 27 rules; `cli`, `web`, and `mcp` are thin runtime adapters around it.
+A bun + turborepo monorepo. `core` is the single source of truth for the 27 design
+patterns, 9 copy patterns, and 8 AEO checks; `cli`, `web`, and `mcp` are thin
+runtime adapters around it.
 
 ## Quickstart: contributing
 
 ```bash
 git clone https://github.com/ravidsrk/slop-detect.git
 cd slop-detect
-npm install                     # installs all 4 workspaces
+bun install                              # installs all workspaces
 
 # Run the CLI locally
-npm run demo                    # scans 3 example sites
-npm run scan -- https://your-url.com
+bun run --filter slop-detect demo        # scans 3 example sites
+bun run --filter slop-detect scan -- https://your-url.com
 
 # Run the web app locally
-npm run web:dev                 # http://localhost:8788
+bun run web:dev                          # http://localhost:8788
+
+# Run the docs site locally
+bun run docs:dev
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide, including how to propose a 17th pattern or improve a fix recipe.
@@ -327,7 +338,7 @@ Plus cross-cutting guidance ("don't replace one slop pattern with another", "emp
 ## Programmatic use
 
 ```js
-import { PATTERNS, scorePatterns } from 'slop-detect-core';
+import { PATTERNS, scorePatterns } from '@slop-detect/core';
 
 // PATTERNS is the array of 27 rule definitions.
 // Each has { id, label, weight, extract, detect } where:


### PR DESCRIPTION
## Summary

After PRs #28–#37 restructured the monorepo (bun + turbo + vitest + tsup + apps/docs + examples/ + spec/, core renamed to `@slop-detect/core`), several docs and workflow files were still on npm + node:test + packages/web. This catches them up and adds the v0.8.0 CHANGELOG entry.

## Workflows (all now on bun + turbo)

| File | Change |
|---|---|
| `ci.yml` | _no change — already done in #37_ |
| `calibrate.yml` | `actions/setup-node` + `npm ci` → `oven-sh/setup-bun` + `bun install` |
| `deploy.yml` | `npm ci/build/test` → `bun install / bun run build / bun run test`; comment refreshed for `@slop-detect/core` |
| `publish.yml` | `npm ci --ignore-scripts` + `npm publish -w` → `bun install` + `bun run build/test` + per-package `working-directory: packages/<pkg>` `npm publish` (npm CLI still needed for the registry auth flow) |
| `leaderboard.yml` | `actions/setup-node` → `oven-sh/setup-bun`; also fixes a bot email typo (`noreplyy` → `noreply.github.com`) |

## Docs

- **AGENTS.md** — rewritten layout (`packages/` + `apps/` + `examples/` + `spec/`), build/lint block on bun + turbo, file extensions updated to `.ts`, `DEFINITIONS_VERSION` bumped to `2026.09` to match source, publish order + spec-sync rule
- **CONTRIBUTING.md** — bun setup + script flow, new layout tree, TypeScript code-style note, `@slop-detect/core` in declarative-rule example, `docs:dev` mention
- **README.md** — npm badge points at `@slop-detect/core`; layout tree includes `apps/{web,docs}`, `examples/`, `spec/`; quickstart switched to bun; programmatic-use example uses `@slop-detect/core`
- **CALIBRATION.md** — `npm run calibrate` → `bun run calibrate` (6 hits)
- **PRODUCTION.md** — npm refs swept to bun; "npm is stale" note refreshed for v0.8.0 + the `@slop-detect/core` rename
- **MIGRATION.md** — historical-status header pointing at the v0.8.0 CHANGELOG entry and the new AGENTS / CONTRIBUTING docs
- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist swapped to `bun run format:check` / `typecheck` / `test`, plus a `spec/` update line

## CHANGELOG

Fresh v0.8.0 entry documenting the tooling swap, the new layout, and the breaking `@slop-detect/core` rename with the diff consumers need.

## Local sanity (all green)

```
bun install                                ok
bun run format:check                       all clean
bun run typecheck   (turbo, 7 packages)    7/7 ok (fully cached)
```

## Test plan

- [ ] All 4 CI jobs green (lint, typecheck, test, smoke)
- [ ] Workflow YAML still parses (`actionlint` if you run it locally)
- [ ] Calibration / deploy / leaderboard / publish workflows can still be triggered manually from the Actions tab (they're dispatch-gated)
- [ ] README renders correctly on github.com (layout tree, badges, code fences)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI script changes only; no scoring or API behavior. Publish workflow changes affect release mechanics but mirror the new package layout and still gate on tests.
> 
> **Overview**
> Brings **docs, PR template, and non-CI workflows** in line with the v0.8.0 monorepo layout after the bun + turbo restructure (CI itself was already updated elsewhere).
> 
> **GitHub Actions** swap `setup-node` / `npm ci` for **`oven-sh/setup-bun`** and **`bun install`**, and gate deploy/publish on **`bun run build`** and **`bun run test`**. **`publish.yml`** drops `npm publish -w` in favor of per-package **`npm publish`** under `packages/{core,cli,mcp}` (Node still used for registry auth), adds an explicit **build** step before publish, and updates comments for **`@slop-detect/core`**. **`leaderboard.yml`** runs the build script with **`bun`** and fixes the bot commit email typo.
> 
> **Contributor-facing docs** (`AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `CALIBRATION.md`, `PRODUCTION.md`) replace npm/node:test/`slop-detect-core`/`packages/web` references with **bun**, **turbo**, **`apps/`**, **`examples/`**, **`spec/`**, and **`@slop-detect/core`**. **`MIGRATION.md`** is marked historical with pointers to v0.8.0. **`.github/PULL_REQUEST_TEMPLATE.md`** checklist now expects **`bun run format:check`**, **typecheck**, and **test**, plus **spec** updates when the public surface changes.
> 
> **`CHANGELOG.md`** adds the **v0.8.0** entry (tooling, layout, breaking rename, bun lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53aeabca8d9fbb0263fa3912cb67ec50caaff95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->