### PR TITLE
feat(web): foundation — light editorial-instrument theme + _theme/_ui groundwork

### DIFF
--- a/apps/web/functions/_badge.tsx
+++ b/apps/web/functions/_badge.tsx
@@ -1,0 +1,54 @@
+/** @jsxRuntime automatic @jsxImportSource hono/jsx */
+// Self-rendered badge SVG (shields-style, so we don't depend on shields.io).
+//
+// Relocated here from _render.tsx by foundation task 00. The visual treatment is
+// untouched — the new two-segment editorial badge is task 12's job. Tier colors
+// come from the centralized resolver in _theme.ts.
+
+import { tierColors } from './_theme.js';
+
+export function badgeSvg(domain, slim) {
+  const label = 'slop';
+  const score = slim ? slim.score : '?';
+  const grade = slim ? slim.grade : '—';
+  const tier = slim ? slim.tier : 'Unknown';
+  const c = tierColors(tier);
+
+  const value = slim ? `${grade} · ${score}` : 'no scan';
+  // Rough text-width estimate (monospace-ish, 6.6px/char + padding).
+  const labelW = 38;
+  const valueW = Math.max(46, value.length * 6.8 + 16);
+  const total = labelW + valueW;
+  const fill = slim ? c.fg : '#8a8a92';
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={total}
+      height="20"
+      role="img"
+      aria-label={`${label}: ${value}`}
+    >
+      <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+      </linearGradient>
+      <clipPath id="r">
+        <rect width={total} height="20" rx="3" fill="#fff" />
+      </clipPath>
+      <g clip-path="url(#r)">
+        <rect width={labelW} height="20" fill="#1a1a1d" />
+        <rect x={labelW} width={valueW} height="20" fill={fill} />
+        <rect width={total} height="20" fill="url(#s)" />
+      </g>
+      <g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+        <text x={labelW / 2} y="14" fill="#fff">
+          {label}
+        </text>
+        <text x={labelW + valueW / 2} y="14" fill="#0a0a0b" font-weight="bold">
+          {value}
+        </text>
+      </g>
+    </svg>
+  ).toString();
+}

--- a/apps/web/functions/_brand.ts
+++ b/apps/web/functions/_brand.ts
@@ -1,36 +1,132 @@
-// Shared brand identity for server-rendered pages (/directory, /leaderboard,
-// /report/:domain) so they read as the SAME product as the landing page: the
-// forensic-instrument register — Hanken Grotesk prose, Martian Mono readouts,
-// cold-blue accent, blue-tinted neutrals, §-registration marks. One source of
-// truth; pages interpolate these constants instead of hand-rolling tokens.
-// Anti-slop by construction, like everything else here.
+// Shared brand identity for server-rendered pages (/score, /directory,
+// /leaderboard, /report, /dashboard, /blog) so they read as the SAME product as
+// the landing page: the light editorial-instrument register — Newsreader serif
+// display, Libre Franklin body, JetBrains Mono data voice, near-black ink on cool
+// paper, and the verdict scale (green / amber / red) carrying every score.
+//
+// One source of truth: pages embed BRAND_FONTS_HEAD and BRAND_CSS instead of
+// hand-rolling tokens. The names are kept stable so the seven current importers
+// keep compiling; the values are the new light system (see docs/design-extract.md).
+//
+// Dogfood by construction: no AI-default faces, no purple CTA, no gradient text or
+// gradient surfaces, flat 1px-bordered cards, and the structural 1.5px ink ledger
+// rule as the only ruled device. This file must itself score Clean on the detector.
 
 export const BRAND_FONTS_HEAD = `
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=Martian+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">`;
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=Libre+Franklin:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">`;
 
 export const BRAND_CSS = `
   :root{
-    color-scheme:dark;
-    --bg:#0a0b0e; --bg-2:#0e1014; --panel:#131620; --panel-2:#1a1e2a;
-    --border:#262b38; --border-2:#353c4d;
-    --text:#f2f4f8; --text-2:#c2c7d2; --muted:#9aa1b1; --dim:#6f7689;
-    --accent:#5b9dff; --accent-soft:rgba(91,157,255,0.10); --accent-ink:#06080d;
-    --green:#4ade80; --yellow:#fbbf24; --red:#f87171;
-    --sans:"Hanken Grotesk",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
-    --mono:"Martian Mono",ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    color-scheme:light;
+    /* surfaces + dark register */
+    --bg:#F4F5F2; --bg-2:#EEF0EB; --panel:#FBFBF9; --panel-2:#FBFBF9;
+    --ink-deep:#16170F; --ink-deeper:#0F0F0B;
+    /* borders + hairlines (light) */
+    --border:#DBDDD6; --border-2:#E4E6DF; --row:#E7E8E2; --row-inner:#EDEEE8;
+    --border-btn:#C9CBC3; --border-chip:#D7D9D2; --track:#E2E4DD; --neutral:#CDCFC8;
+    /* ink tints on light, high contrast first */
+    --text:#181815; --text-2:#3A3B33; --text-3:#46473F; --text-4:#6E6F63;
+    --text-5:#7E7F72; --text-6:#9A9B8E;
+    /* verdict core hues (fills + dots) */
+    --clean:#1FA85E; --mild:#D89A2E; --heavy:#C9402E;
+    /* verdict text hues (AA on paper) */
+    --clean-text:#15824A; --mild-text:#9A6B12; --heavy-text:#B23A2A;
+    --system-text:#2C6E8F; --clean-dark:#3FBE7A;
+    /* ink tints on the dark register */
+    --d-text:#F4F5F2; --d-text-2:#C9CABF; --d-text-3:#B6B7AC; --d-text-4:#8A8B7E;
+    --d-border:#2A2B22; --d-border-2:#3A3B30;
+    /* families: serif display, grotesque body, mono data voice */
+    --serif:'Newsreader',Georgia,'Times New Roman',serif;
+    --sans:'Libre Franklin',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+    --mono:'JetBrains Mono',ui-monospace,'SF Mono',Menlo,Consolas,monospace;
+    /* legacy aliases so pre-rebuild pages keep resolving until their restyle task */
+    --accent:#1FA85E; --accent-soft:rgba(31,168,94,0.10); --accent-ink:#0A2A18;
+    --muted:#6E6F63; --dim:#9A9B8E;
+    --green:#1FA85E; --yellow:#D89A2E; --red:#C9402E;
+    /* spacing scale (GAP-FILL): named 4px-based steps quantizing the export's set */
+    --sp-1:4px; --sp-2:8px; --sp-3:12px; --sp-4:16px; --sp-5:20px; --sp-6:24px;
+    --sp-7:28px; --sp-8:32px; --sp-10:40px; --sp-12:48px; --sp-14:56px;
+    --sp-16:64px; --sp-20:80px; --sp-24:96px;
+    --pad-x:32px;
+    /* radii */
+    --r-1:2px; --r-2:3px; --r-3:4px; --r-4:5px; --r-5:6px; --r-6:8px; --r-7:10px;
+    --r-pill:999px; --r-round:50%;
+    /* type sizes */
+    --fs-display-hero:clamp(44px,6.2vw,88px);
+    --fs-display-1:clamp(40px,5.4vw,76px);
+    --fs-display-2:clamp(38px,5vw,64px);
+    --fs-display-3:clamp(38px,5vw,60px);
+    --fs-h2-a:clamp(30px,4vw,52px);
+    --fs-h2-b:clamp(28px,3.6vw,42px);
+    --fs-h2-c:clamp(26px,3.2vw,38px);
+    --fs-h2-static:32px; --fs-h3:28px; --fs-serif-row:21px;
+    --fs-score:120px; --fs-quote-lg:clamp(20px,2.4vw,26px);
+    --fs-lead:19px; --fs-body:16px; --fs-body-sm:14px; --fs-body-xs:13px;
+    --fs-wordmark:15px; --fs-mono:13px; --fs-mono-label:11px; --fs-code:12.5px;
+    /* one subtle motion token (GAP-FILL) */
+    --t:140ms ease;
+    /* the only allowed shadow — the live badge */
+    --shadow-badge:0 1px 2px rgba(0,0,0,0.1);
   }
+
   *{margin:0;padding:0;box-sizing:border-box}
-  body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.55}
-  a{color:inherit}
-  .eyebrow{display:flex;align-items:center;gap:10px;margin-bottom:10px}
-  .eyebrow .reg{
-    font-family:var(--mono);font-size:11px;font-weight:600;color:var(--accent);
-    border:1px solid var(--border-2);background:var(--accent-soft);
-    border-radius:5px;padding:3px 7px;letter-spacing:-0.04em;
+  html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+  body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.6}
+  a{color:inherit;text-decoration:none}
+  input{outline:none;font-family:inherit}
+  ::selection{background:#1FA85E;color:#fff}
+
+  /* ── type scale ─────────────────────────────────────────────────────────── */
+  /* Newsreader weight 500 for display, never for body; Libre Franklin for prose;
+     JetBrains Mono for any data, label, score, or code. */
+  .serif{font-family:var(--serif)}
+  .mono{font-family:var(--mono)}
+  .display-hero{font-family:var(--serif);font-weight:500;font-size:var(--fs-display-hero);line-height:0.98;letter-spacing:-0.02em;color:var(--text)}
+  .display{font-family:var(--serif);font-weight:500;line-height:1.0;letter-spacing:-0.02em;color:var(--text)}
+  .score-numeral{font-family:var(--serif);font-weight:500;font-size:var(--fs-score);line-height:0.8;letter-spacing:-0.03em}
+  .voice{font-family:var(--serif);font-style:italic;line-height:1.3}
+  .mono-eyebrow{font-family:var(--mono);font-size:var(--fs-mono);color:var(--clean-text);letter-spacing:0}
+  .mono-label{font-family:var(--mono);font-size:var(--fs-mono-label);color:var(--text-4);letter-spacing:0}
+  .lead{font-size:var(--fs-lead);line-height:1.6;color:var(--text-2)}
+
+  /* ── the signature section-ledger rule device ──────────────────────────── */
+  /* A 1.5px ink top rule above a mono label. Structural print-grade hierarchy,
+     not a decorative accent stripe (which the detector flags). */
+  .section-ledger{border-top:1.5px solid #181815;padding-top:14px}
+  .section-ledger .mono-label,.ledger-label{font-family:var(--mono);font-size:12px;font-weight:500;color:var(--text-4);letter-spacing:0}
+
+  /* ── focus, press, and disabled states (GAP-FILL: a11y) ─────────────────── */
+  /* Never ship a bare outline:none. A keyboard focus ring on every focusable. */
+  :focus-visible{outline:2px solid #1FA85E;outline-offset:2px;border-radius:2px}
+  button:active,a.btn:active{filter:brightness(0.92)}
+  button:disabled,button[disabled],input:disabled,input[disabled]{
+    opacity:0.5;cursor:not-allowed;filter:saturate(0.7);
   }
-  .eyebrow .reg-label{
-    font-family:var(--mono);font-size:11.5px;color:var(--dim);
-    text-transform:uppercase;letter-spacing:0.04em;
-  }`;
+
+  /* ── motion (GAP-FILL) ──────────────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce){
+    *,*::before,*::after{
+      animation-duration:0.001ms !important;animation-iteration-count:1 !important;
+      transition-duration:0.001ms !important;scroll-behavior:auto !important;
+    }
+  }
+
+  /* ── responsive helpers (GAP-FILL: the export ships no @media) ───────────── */
+  /* Opt-in stacking classes the rebuilt screens apply to their grids. */
+  @media (max-width:900px){
+    .stack-900{grid-template-columns:1fr !important}
+    .axes-900{grid-template-columns:1fr 1fr !important}
+    .nowrap{white-space:nowrap}
+  }
+  @media (max-width:640px){
+    .stack-640{grid-template-columns:1fr !important}
+    .bars-640{grid-template-columns:repeat(2,1fr) !important}
+    .pad-640{padding-left:20px !important;padding-right:20px !important}
+  }
+
+  /* ── legacy eyebrow chip kept renderable until pages migrate to the ledger ── */
+  .eyebrow{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+  .eyebrow .reg{font-family:var(--mono);font-size:12px;color:var(--clean-text);letter-spacing:0}
+  .eyebrow .reg-label{font-family:var(--mono);font-size:11.5px;color:var(--text-4);letter-spacing:0}`;

--- a/apps/web/functions/_card.tsx
+++ b/apps/web/functions/_card.tsx
@@ -1,0 +1,90 @@
+/** @jsxRuntime automatic @jsxImportSource hono/jsx */
+// Share-card HTML (1200×630) — rasterized to PNG by /og/:id.png.
+//
+// Relocated here from _render.tsx by foundation task 00. The visual treatment is
+// untouched — re-theming the OG card to the new light palette is task 13's job.
+// Tier colors come from the centralized resolver in _theme.ts; escaping stays in
+// _render.tsx.
+
+import { raw } from 'hono/html';
+import { escapeHtml } from './_render.js';
+import { tierColors } from './_theme.js';
+
+export function cardHtml(slim) {
+  const c = tierColors(slim.tier);
+  const tells = (slim.triggered || [])
+    .slice(0, 4)
+    .map((t) => t.short || t.label)
+    .join(' · ');
+
+  const CARD_CSS = `
+  *{margin:0;padding:0;box-sizing:border-box}
+  html,body{width:1200px;height:630px;overflow:hidden}
+  body{
+    background:radial-gradient(1200px 630px at 78% 22%, ${c.bg} 0%, #0a0a0b 60%);
+    color:#f5f5f7;
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Arial,sans-serif;
+    padding:64px 72px;display:flex;flex-direction:column;justify-content:space-between;
+  }
+  .top{display:flex;justify-content:space-between;align-items:flex-start}
+  .brand{font-size:26px;font-weight:700;letter-spacing:-0.02em}
+  .brand .slash{color:#5a5a62;font-weight:400}
+  .defs{font-size:15px;color:#5a5a62;font-family:ui-monospace,Menlo,monospace}
+  .mid{display:flex;align-items:center;gap:48px;margin-top:8px}
+  .grade{font-size:240px;font-weight:800;line-height:.82;letter-spacing:-0.05em;color:${c.fg}}
+  .meta{display:flex;flex-direction:column;gap:14px}
+  .score{font-size:64px;font-weight:700;letter-spacing:-0.03em}
+  .score small{font-size:30px;color:#8a8a92;font-weight:500}
+  .tier{align-self:flex-start;font-size:24px;font-weight:700;padding:6px 20px;border-radius:999px;
+        border:2px solid ${c.fg};color:${c.fg}}
+  .flagged{font-size:20px;color:#8a8a92}
+  .bottom{display:flex;flex-direction:column;gap:10px}
+  .domain{font-size:30px;font-weight:600}
+  .verdict{font-size:26px;color:#d4d4d8;max-width:1000px;line-height:1.3}
+  .tells{font-size:17px;color:#6b6b73;font-family:ui-monospace,Menlo,monospace}
+  .foot{font-size:18px;color:#5a5a62;margin-top:6px}
+`;
+
+  const brandTail = slim.patternsTotal
+    ? escapeHtml(String(slim.patternsTotal)) + '&#8209;rule'
+    : '';
+
+  const doc = (
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <style>{raw(CARD_CSS)}</style>
+      </head>
+      <body>
+        <div class="top">
+          <div class="brand">
+            {raw('slop&#8209;detect')}{' '}
+            <span class="slash">{raw(`/ ${brandTail} AI&#8209;design fingerprint`)}</span>
+          </div>
+          <div class="defs">defs {slim.definitionsVersion || ''}</div>
+        </div>
+        <div class="mid">
+          <div class="grade">{slim.grade}</div>
+          <div class="meta">
+            <div class="score">
+              {slim.score}
+              <small>/100</small>
+            </div>
+            <div class="tier">{slim.tier}</div>
+            <div class="flagged">
+              {slim.patternsFlagged}/{slim.patternsTotal} patterns triggered
+            </div>
+          </div>
+        </div>
+        <div class="bottom">
+          <div class="domain">{slim.domain}</div>
+          <div class="verdict">{slim.verdict || ''}</div>
+          {tells ? <div class="tells">{tells}</div> : null}
+          <div class="foot">slop-detect.com</div>
+        </div>
+      </body>
+    </html>
+  );
+
+  return '<!doctype html>' + doc.toString();
+}

--- a/apps/web/functions/_render.tsx
+++ b/apps/web/functions/_render.tsx
@@ -1,12 +1,14 @@
 /** @jsxRuntime automatic @jsxImportSource hono/jsx */
-// Presentation helpers: tier→color mapping, the self-rendered badge SVG, the
-// share-card HTML (rasterized to PNG by /og/:id.png), and HTML/XML escaping.
+// Presentation helpers: HTML/XML escaping and the JSON-for-<script> serializer.
 //
-// The badge + card are now hono/jsx components rendered to strings (JSX auto-
-// escapes text). The escape helpers stay exported for the remaining raw-string
-// callers (e.g. SVG/XML built outside JSX).
+// The tier→color resolver now lives in _theme.ts; this file re-exports `tierColors`
+// so existing callers (`import { tierColors } from '../_shared.js'`) keep working
+// unchanged. The self-rendered badge SVG moved to _badge.tsx (owned by task 12) and
+// the share-card HTML moved to _card.tsx (owned by task 13), so those restyle tasks
+// do not have to touch this file.
 
-import { raw } from 'hono/html';
+// Re-export the centralized tier color resolver for the existing call sites.
+export { tierColors } from './_theme.js';
 
 // ── escaping ──────────────────────────────────────────────────────────────────
 export function escapeHtml(s) {
@@ -41,153 +43,15 @@ export function escapeXml(s) {
 // inline JS (`const x = ${jsonForScript(v)}`) and JSON-LD blocks. JSON.stringify
 // does NOT escape `<`, so a value containing `</script>` (or `<!--`) would break
 // out of the element and become live markup. Escaping `<`/`>`/`&` to their \u
-// forms (still valid JSON and JS) closes that, plus the JS line separators.
+// forms (still valid JSON and JS) closes that, plus the U+2028 / U+2029 JS line
+// separators (legal in JSON strings but not in JS source).
+const LINE_SEP = new RegExp(String.fromCharCode(0x2028), 'g');
+const PARA_SEP = new RegExp(String.fromCharCode(0x2029), 'g');
 export function jsonForScript(value) {
   return JSON.stringify(value)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
     .replace(/&/g, '\\u0026')
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
-}
-
-// ── Tier → color ──────────────────────────────────────────────────────────────
-export function tierColors(tier) {
-  switch (tier) {
-    case 'Clean':
-      return { fg: '#4ade80', bg: '#0b2014', label: '#bbf7d0' };
-    case 'Mild':
-      return { fg: '#fbbf24', bg: '#241a06', label: '#fde68a' };
-    case 'Heavy':
-      return { fg: '#f87171', bg: '#240c0c', label: '#fecaca' };
-    default:
-      return { fg: '#8a8a92', bg: '#161618', label: '#d4d4d8' };
-  }
-}
-
-// ── Badge SVG (shields-style, self-rendered so we don't depend on shields.io) ─
-export function badgeSvg(domain, slim) {
-  const label = 'slop';
-  const score = slim ? slim.score : '?';
-  const grade = slim ? slim.grade : '—';
-  const tier = slim ? slim.tier : 'Unknown';
-  const c = tierColors(tier);
-
-  const value = slim ? `${grade} · ${score}` : 'no scan';
-  // Rough text-width estimate (monospace-ish, 6.6px/char + padding).
-  const labelW = 38;
-  const valueW = Math.max(46, value.length * 6.8 + 16);
-  const total = labelW + valueW;
-  const fill = slim ? c.fg : '#8a8a92';
-
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={total}
-      height="20"
-      role="img"
-      aria-label={`${label}: ${value}`}
-    >
-      <linearGradient id="s" x2="0" y2="100%">
-        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
-        <stop offset="1" stop-opacity=".1" />
-      </linearGradient>
-      <clipPath id="r">
-        <rect width={total} height="20" rx="3" fill="#fff" />
-      </clipPath>
-      <g clip-path="url(#r)">
-        <rect width={labelW} height="20" fill="#1a1a1d" />
-        <rect x={labelW} width={valueW} height="20" fill={fill} />
-        <rect width={total} height="20" fill="url(#s)" />
-      </g>
-      <g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
-        <text x={labelW / 2} y="14" fill="#fff">
-          {label}
-        </text>
-        <text x={labelW + valueW / 2} y="14" fill="#0a0a0b" font-weight="bold">
-          {value}
-        </text>
-      </g>
-    </svg>
-  ).toString();
-}
-
-// ── Share-card HTML (1200×630) — rendered to PNG by /og/:id.png ───────────────
-export function cardHtml(slim) {
-  const c = tierColors(slim.tier);
-  const tells = (slim.triggered || [])
-    .slice(0, 4)
-    .map((t) => t.short || t.label)
-    .join(' · ');
-
-  const CARD_CSS = `
-  *{margin:0;padding:0;box-sizing:border-box}
-  html,body{width:1200px;height:630px;overflow:hidden}
-  body{
-    background:radial-gradient(1200px 630px at 78% 22%, ${c.bg} 0%, #0a0a0b 60%);
-    color:#f5f5f7;
-    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Arial,sans-serif;
-    padding:64px 72px;display:flex;flex-direction:column;justify-content:space-between;
-  }
-  .top{display:flex;justify-content:space-between;align-items:flex-start}
-  .brand{font-size:26px;font-weight:700;letter-spacing:-0.02em}
-  .brand .slash{color:#5a5a62;font-weight:400}
-  .defs{font-size:15px;color:#5a5a62;font-family:ui-monospace,Menlo,monospace}
-  .mid{display:flex;align-items:center;gap:48px;margin-top:8px}
-  .grade{font-size:240px;font-weight:800;line-height:.82;letter-spacing:-0.05em;color:${c.fg}}
-  .meta{display:flex;flex-direction:column;gap:14px}
-  .score{font-size:64px;font-weight:700;letter-spacing:-0.03em}
-  .score small{font-size:30px;color:#8a8a92;font-weight:500}
-  .tier{align-self:flex-start;font-size:24px;font-weight:700;padding:6px 20px;border-radius:999px;
-        border:2px solid ${c.fg};color:${c.fg}}
-  .flagged{font-size:20px;color:#8a8a92}
-  .bottom{display:flex;flex-direction:column;gap:10px}
-  .domain{font-size:30px;font-weight:600}
-  .verdict{font-size:26px;color:#d4d4d8;max-width:1000px;line-height:1.3}
-  .tells{font-size:17px;color:#6b6b73;font-family:ui-monospace,Menlo,monospace}
-  .foot{font-size:18px;color:#5a5a62;margin-top:6px}
-`;
-
-  const brandTail = slim.patternsTotal
-    ? escapeHtml(String(slim.patternsTotal)) + '&#8209;rule'
-    : '';
-
-  const doc = (
-    <html>
-      <head>
-        <meta charset="utf-8" />
-        <style>{raw(CARD_CSS)}</style>
-      </head>
-      <body>
-        <div class="top">
-          <div class="brand">
-            {raw('slop&#8209;detect')}{' '}
-            <span class="slash">{raw(`/ ${brandTail} AI&#8209;design fingerprint`)}</span>
-          </div>
-          <div class="defs">defs {slim.definitionsVersion || ''}</div>
-        </div>
-        <div class="mid">
-          <div class="grade">{slim.grade}</div>
-          <div class="meta">
-            <div class="score">
-              {slim.score}
-              <small>/100</small>
-            </div>
-            <div class="tier">{slim.tier}</div>
-            <div class="flagged">
-              {slim.patternsFlagged}/{slim.patternsTotal} patterns triggered
-            </div>
-          </div>
-        </div>
-        <div class="bottom">
-          <div class="domain">{slim.domain}</div>
-          <div class="verdict">{slim.verdict || ''}</div>
-          {tells ? <div class="tells">{tells}</div> : null}
-          <div class="foot">slop-detect.com</div>
-        </div>
-      </body>
-    </html>
-  );
-
-  return '<!doctype html>' + doc.toString();
+    .replace(LINE_SEP, '\\u2028')
+    .replace(PARA_SEP, '\\u2029');
 }

--- a/apps/web/functions/_shared.ts
+++ b/apps/web/functions/_shared.ts
@@ -7,7 +7,9 @@
 //   _util.js    — ids, domain normalization, email check, tier ranking
 //   _ssrf.js    — the scan-URL SSRF guard (private/loopback/internal blocking)
 //   _data.js    — RESULTS KV: results, watches, tokens, history, stats, listings
-//   _render.js  — tier colors, badge SVG, share-card HTML, HTML/XML escaping
+//   _render.js  — HTML/XML escaping + the tier color resolver (from _theme)
+//   _badge.js   — the self-rendered badge SVG
+//   _card.js    — the share-card HTML rasterized by /og
 //
 // Prefer importing from the specific module in new code; this barrel is kept for
 // the existing call sites and convenience.
@@ -15,3 +17,5 @@ export * from './_util.js';
 export * from './_ssrf.js';
 export * from './_data.js';
 export * from './_render.js';
+export * from './_badge.js';
+export * from './_card.js';

--- a/apps/web/functions/_theme.ts
+++ b/apps/web/functions/_theme.ts
@@ -1,0 +1,148 @@
+// Centralized tier / grade / verdict color resolvers.
+//
+// The palette is the product: color encodes the score. Every surface that shows a
+// tier, grade, or axis — the TSX pages, the OG card generator (/og), and the badge
+// generator (/badge) — reads these maps so there is ONE source of truth. The maps
+// are extracted verbatim from docs/design-extract.md > "Tier, grade, and verdict
+// logic"; the engine's gradeForScore / verdictFor / GRADE_BANDS are wrapped here so
+// callers reach the score→grade→verdict pipeline through this one module too.
+//
+// Lower score is cleaner: Clean < 10, Mild 10–27, Heavy ≥ 28.
+
+import { gradeForScore, verdictFor, GRADE_BANDS } from '@slop-detect/core';
+
+// Re-export the engine scorers so pages read grade/verdict logic from one place.
+export { gradeForScore, verdictFor, GRADE_BANDS };
+
+export type Tier = 'Clean' | 'Mild' | 'Heavy';
+
+// score (0–100, lower is cleaner) → tier. Mirrors the engine's design bands.
+export function tierFor(score: number): Tier {
+  const s = Math.max(0, Math.min(100, Number(score) || 0));
+  if (s >= 28) return 'Heavy';
+  if (s >= 10) return 'Mild';
+  return 'Clean';
+}
+
+// dot / fill — the core verdict hues, used for fills, dots, bars, badges.
+export function tierFill(tier: string): string {
+  switch (tier) {
+    case 'Clean':
+      return '#1FA85E';
+    case 'Mild':
+      return '#D89A2E';
+    case 'Heavy':
+      return '#C9402E';
+    default:
+      return '#6E6F63';
+  }
+}
+
+// text (the `Fg`) — AA-darkened hues for type on paper.
+export function tierText(tier: string): string {
+  switch (tier) {
+    case 'Clean':
+      return '#15824A';
+    case 'Mild':
+      return '#9A6B12';
+    case 'Heavy':
+      return '#B23A2A';
+    default:
+      return '#6E6F63';
+  }
+}
+
+// status-pill background (the `chipBg`): a faint tint behind a tier label.
+export function tierPillBg(tier: string): string {
+  switch (tier) {
+    case 'Clean':
+      return 'rgba(31,168,94,0.12)';
+    case 'Mild':
+      return 'rgba(216,154,46,0.14)';
+    case 'Heavy':
+      return 'rgba(201,64,46,0.12)';
+    default:
+      return 'rgba(110,111,99,0.12)';
+  }
+}
+
+// The embeddable SVG badge: dark left segment, tier-colored right segment.
+export function badgeColors(tier: string): { bg: string; ink: string } {
+  switch (tier) {
+    case 'Clean':
+      return { bg: '#1FA85E', ink: '#0A2A18' };
+    case 'Mild':
+      return { bg: '#D89A2E', ink: '#3A2705' };
+    case 'Heavy':
+      return { bg: '#C9402E', ink: '#FFFFFF' };
+    default:
+      return { bg: '#6E6F63', ink: '#F4F5F2' };
+  }
+}
+
+// The {fg, bg, label} resolver the existing callers consume via _shared/_render.
+// fg = tier text hue, bg = status-pill tint, fill = core hue, label kept for
+// back-compat (no current caller reads it). _render.tierColors delegates here.
+export function tierColors(tier: string): {
+  fg: string;
+  bg: string;
+  fill: string;
+  label: string;
+} {
+  return {
+    fg: tierText(tier),
+    bg: tierPillBg(tier),
+    fill: tierFill(tier),
+    label: tierText(tier),
+  };
+}
+
+// System (DESIGN.md) axis: higher is better.
+//   Aligned ≥ 80 · Drifting ≥ 50 · Off-system < 50 · no system declared → grey.
+export function systemAxisColor(score: number | null | undefined): string {
+  if (score == null) return '#6E6F63';
+  const s = Number(score) || 0;
+  if (s >= 80) return '#15824A';
+  if (s >= 50) return '#9A6B12';
+  return '#B23A2A';
+}
+
+// AEO (agent-readable) axis: higher is better.
+//   AI-Ready ≥ 80 · Partial ≥ 50 · Invisible < 50.
+export function aeoAxisColor(score: number): string {
+  const s = Number(score) || 0;
+  if (s >= 80) return '#15824A';
+  if (s >= 50) return '#9A6B12';
+  return '#B23A2A';
+}
+
+// Pass / fail marks for the AEO checklist.
+export const AEO_PASS_COLOR = '#15824A';
+export const AEO_FAIL_COLOR = '#C9402E';
+
+// Letter-avatar chip palette (deterministic per name). The one purple (#7A4D9A)
+// appears ONLY here, as 1 of 6 data backgrounds — never a CTA, accent, or brand
+// color (the brand forbids purple on CTAs).
+export const chipPalette = ['#C9402E', '#9A6B12', '#15824A', '#46473F', '#2C6E8F', '#7A4D9A'];
+
+// Deterministic name → chip color (stable FNV-1a-ish hash so a name always maps
+// to the same swatch).
+export function avatarColor(name: string): string {
+  const s = String(name || '');
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return chipPalette[Math.abs(h) % chipPalette.length];
+}
+
+// grade letter → color bucket. A* → clean, B/C → mild, D/F → heavy.
+export function gradeColorBucket(grade: string): Tier {
+  const g = String(grade || '')
+    .trim()
+    .toUpperCase();
+  if (g.startsWith('A')) return 'Clean';
+  if (g.startsWith('B') || g.startsWith('C')) return 'Mild';
+  return 'Heavy';
+}

--- a/apps/web/functions/badge/[domain].ts
+++ b/apps/web/functions/badge/[domain].ts
@@ -8,7 +8,8 @@
 // Embed:
 //   [![slop](https://slop-detect.com/badge/example.com.svg)](https://slop-detect.com)
 
-import { getLatestForDomain, badgeSvg, BADGE_TTL } from '../_shared.js';
+import { getLatestForDomain, BADGE_TTL } from '../_shared.js';
+import { badgeSvg } from '../_badge.js';
 
 export async function onRequestGet({ params, env }) {
   let domain = String(params.domain || '')

--- a/apps/web/functions/og/[id].ts
+++ b/apps/web/functions/og/[id].ts
@@ -6,7 +6,8 @@
 // worse than a generic one).
 
 import puppeteer from '@cloudflare/puppeteer';
-import { getResult, cardHtml } from '../_shared.js';
+import { getResult } from '../_shared.js';
+import { cardHtml } from '../_card.js';
 
 const OG_TTL = 60 * 60 * 24 * 30; // 30 days
 

--- a/apps/web/test/brand-tokens.test.js
+++ b/apps/web/test/brand-tokens.test.js
@@ -1,0 +1,85 @@
+// Foundation guardrail (build task 00): the shared theme IS the new light
+// editorial-instrument system, and it dogfoods its own detector. These assertions
+// pin the identity (fonts, color-scheme, the five core hexes) and the anti-slop +
+// a11y dodges, so a regression to the old dark Hanken/Martian theme — or a slop
+// tell creeping into the tokens — fails the build instead of shipping.
+
+import { test, expect } from 'vitest';
+import { BRAND_FONTS_HEAD, BRAND_CSS } from '../functions/_brand.ts';
+
+const ALL = BRAND_FONTS_HEAD + '\n' + BRAND_CSS;
+
+// ── the new faces are loaded, the old ones are gone ──────────────────────────
+test('the brand loads the three new faces (Newsreader, Libre Franklin, JetBrains Mono)', () => {
+  expect(BRAND_FONTS_HEAD, 'serif display face').toMatch(/Newsreader/);
+  expect(BRAND_FONTS_HEAD, 'grotesque body face').toMatch(/Libre\+Franklin/);
+  expect(BRAND_FONTS_HEAD, 'mono data face').toMatch(/JetBrains\+Mono/);
+  // and the families are wired into the CSS custom properties
+  expect(BRAND_CSS).toMatch(/--serif:\s*'Newsreader'/);
+  expect(BRAND_CSS).toMatch(/--sans:\s*'Libre Franklin'/);
+  expect(BRAND_CSS).toMatch(/--mono:\s*'JetBrains Mono'/);
+});
+
+test('the old dark theme faces are absent (no Hanken, no Martian)', () => {
+  expect(ALL, 'old prose face dropped').not.toMatch(/Hanken/i);
+  expect(ALL, 'old mono face dropped').not.toMatch(/Martian/i);
+});
+
+test('no AI-default faces requested (no Inter / Geist / Space Grotesk)', () => {
+  expect(ALL).not.toMatch(/Inter|Geist|Space\s*Grotesk/i);
+});
+
+// ── light-first ──────────────────────────────────────────────────────────────
+test(':root declares color-scheme:light (the page is light-first)', () => {
+  expect(BRAND_CSS).toMatch(/color-scheme:\s*light/);
+  expect(BRAND_CSS, 'no leftover dark color-scheme').not.toMatch(/color-scheme:\s*dark/);
+});
+
+// ── the five core brand hexes ────────────────────────────────────────────────
+test('the five core brand hexes are present', () => {
+  const cores = {
+    paper: '#F4F5F2',
+    ink: '#181815',
+    clean: '#1FA85E',
+    mild: '#D89A2E',
+    heavy: '#C9402E',
+  };
+  for (const [name, hex] of Object.entries(cores)) {
+    expect(BRAND_CSS, `${name} ${hex}`).toContain(hex);
+  }
+  // accent token + ledger device exactly as the brand-unification marks expect
+  expect(BRAND_CSS, 'green accent token').toMatch(/--clean:\s*#1FA85E/);
+  expect(BRAND_CSS, 'section-ledger rule device').toMatch(/border-top:1\.5px solid #181815/);
+});
+
+// ── a11y GAP-FILL: a keyboard focus ring, never a bare outline:none ───────────
+test('a :focus-visible ring exists (bare outline:none is not the whole story)', () => {
+  expect(BRAND_CSS).toMatch(/:focus-visible\s*\{[^}]*outline/);
+});
+
+test('a single transition token and a reduced-motion guard are defined', () => {
+  expect(BRAND_CSS, 'one subtle motion token').toMatch(/--t:\s*140ms ease/);
+  expect(BRAND_CSS, 'reduced-motion media query').toMatch(/prefers-reduced-motion/);
+});
+
+test('responsive breakpoint helpers exist (the export shipped no @media)', () => {
+  expect(BRAND_CSS).toMatch(/@media \(max-width:\s*900px\)/);
+  expect(BRAND_CSS).toMatch(/@media \(max-width:\s*640px\)/);
+});
+
+// ── dogfood: the tokens themselves carry no slop tells ───────────────────────
+test('no gradient text — there is no background-clip:text anywhere', () => {
+  expect(BRAND_CSS).not.toMatch(/background-clip:\s*text/i);
+  expect(BRAND_CSS).not.toMatch(/-webkit-background-clip:\s*text/i);
+});
+
+test('no purple as a brand/accent token (purple is bounded to data avatars)', () => {
+  // The old cold-blue accent is gone and no VibeCode purple is introduced as a
+  // brand color. (#7A4D9A lives only in the _theme avatar palette, not here.)
+  expect(BRAND_CSS).not.toMatch(/5b9dff/i);
+  expect(BRAND_CSS).not.toMatch(/--accent:\s*#7A4D9A/i);
+});
+
+test('shadow policy: the only shadow token is the flat badge shadow', () => {
+  expect(BRAND_CSS, 'badge shadow token').toMatch(/0 1px 2px rgba\(0,0,0,0\.1\)/);
+});

--- a/apps/web/test/landing.test.js
+++ b/apps/web/test/landing.test.js
@@ -143,7 +143,17 @@ function makeKv(seed = {}) {
   };
 }
 
-const BRAND_MARKS = [/Hanken\+Grotesk/, /Martian\+Mono/, /--accent:#5b9dff/, /class="eyebrow"/];
+// The shared light editorial-instrument identity: the three new faces (loaded by
+// BRAND_FONTS_HEAD), the green verdict accent token, and the signature 1.5px ink
+// section-ledger rule (both in BRAND_CSS). Every server-rendered page embeds these,
+// so /directory, /leaderboard, /report must all carry them.
+const BRAND_MARKS = [
+  /Newsreader/,
+  /Libre\+Franklin/,
+  /JetBrains\+Mono/,
+  /--clean:\s*#1FA85E/,
+  /border-top:1\.5px solid #181815/,
+];
 
 test('/directory wears the landing brand (fonts, accent, registration mark)', async () => {
   const res = await directoryGet({


### PR DESCRIPTION
Phase C foundation (parity-spec Build task 00). Gates all downstream screen builds.

What:
- Rewrites apps/web/functions/_brand.ts to the new light editorial-instrument system (Newsreader / Libre Franklin / JetBrains Mono; color-scheme:light; paper #F4F5F2, ink #181815, accent green #1FA85E/#15824A; section-ledger rule, :focus-visible ring, press/disabled states, --t transition, reduced-motion guard, <=900/<=640 helpers). Keeps BRAND_FONTS_HEAD + BRAND_CSS export names so all 7 importers compile.
- Adds _theme.ts as the single tier/grade/verdict color source (all design maps + engine gradeForScore/verdictFor/GRADE_BANDS); _render.tsx delegates tierColors.
- Relocates badgeSvg -> _badge.tsx and cardHtml -> _card.tsx (importers badge/[domain].ts, og/[id].ts updated); visuals unchanged (tasks 12/13 restyle).
- Adds brand-tokens.test.js; flips landing.test.js BRAND_MARKS (line 146 only; 116-117 untouched, owned by task 02).

Why: shared foundation for the full re-skin; dark Hanken/Martian theme replaced, not layered.

Acceptance (parity-spec task 00):
- [x] _brand.ts matches design tokens; :root color-scheme:light; core hexes; section-ledger rule
- [x] Export names kept; _theme.ts reproduces tier/grade/verdict maps wrapping the engine (MNR-1/26)
- [x] badge/card relocated, importers updated
- [x] brand-tokens.test.js asserts new fonts present, Hanken/Martian absent, color-scheme:light, :focus-visible, no background-clip:text, core hexes
- [x] Full web vitest suite green (138/138), web + monorepo typecheck green, prettier clean
- [x] Dogfood: no slop fonts / gradient text / old marks; new marks present
- [x] Clean commit (Ravindra Kumar, no trailers)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide visual token swap affects every server-rendered page that embeds BRAND_CSS; badge/OG visuals are unchanged but tier color semantics shifted to the new palette via _theme.
> 
> **Overview**
> **Foundation PR (build task 00)** for the full web re-skin: shared tokens and theme plumbing land first so later screen tasks can compile against stable exports.
> 
> **`_brand.ts`** is rewritten from the old dark Hanken Grotesk / Martian Mono / blue-accent stack to a **light editorial-instrument** system: Newsreader, Libre Franklin, JetBrains Mono; `color-scheme: light`; paper/ink and green–amber–red verdict tokens; spacing, type, and radius scales; **section-ledger** hierarchy; `:focus-visible`, press/disabled states, reduced-motion, and responsive helper classes. **`BRAND_FONTS_HEAD`** and **`BRAND_CSS`** names are unchanged so existing page importers keep working.
> 
> **`_theme.ts`** is new and becomes the single source for tier/grade/verdict colors (design-extract palette), axis colors, avatar chips, and re-exports of **`gradeForScore` / `verdictFor`** from core. **`tierColors`** moves here; **`_render.tsx`** re-exports it and shrinks to escaping plus **`jsonForScript`** (U+2028/U+2029 handling tightened).
> 
> **`badgeSvg`** and **`cardHtml`** move to **`_badge.tsx`** and **`_card.tsx`** (behavior unchanged; restyle deferred). **`_shared`**, **`badge/[domain].ts`**, and **`og/[id].ts`** import paths are updated accordingly.
> 
> **Tests:** new **`brand-tokens.test.js`** guards fonts, light scheme, core hexes, a11y/motion, and anti-slop rules; **`landing.test.js`** **`BRAND_MARKS`** now assert the new identity on directory/leaderboard/report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994fe3476f9ed6c9d48cd94cdf0f40f8b675d398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->