### PR TITLE
feat(web): restyle badge to the two-segment editorial pill

### DIFF
--- a/apps/web/functions/_badge.tsx
+++ b/apps/web/functions/_badge.tsx
@@ -1,51 +1,82 @@
 /** @jsxRuntime automatic @jsxImportSource hono/jsx */
-// Self-rendered badge SVG (shields-style, so we don't depend on shields.io).
+// Self-rendered embeddable badge SVG — no shields.io dependency.
 //
-// Relocated here from _render.tsx by foundation task 00. The visual treatment is
-// untouched — the new two-segment editorial badge is task 12's job. Tier colors
-// come from the centralized resolver in _theme.ts.
+// The two-segment editorial pill from design "Components > Live badge" + the
+// "Tier, grade, and verdict logic > Badge colors" table: a dark left segment
+// ("slop") and a tier-colored right segment ("grade · score"). Right-segment
+// colors come from the centralized resolver in _theme.ts so the badge, OG card,
+// and pages all read one source of truth.
+//
+// Relocated here from _render.tsx by foundation task 00; restyled to the new
+// editorial system by task 12. The old shields-style linear-gradient overlay is
+// dropped — a gradient is a slop tell, so the badge now passes its own detector.
 
-import { tierColors } from './_theme.js';
+import { badgeColors } from './_theme.js';
 
 export function badgeSvg(domain, slim) {
   const label = 'slop';
-  const score = slim ? slim.score : '?';
-  const grade = slim ? slim.grade : '—';
-  const tier = slim ? slim.tier : 'Unknown';
-  const c = tierColors(tier);
+  const value = slim ? `${slim.grade} · ${slim.score}` : 'no scan';
+  // Right segment: tier bg + ink from the badge-colors table; the neutral grey
+  // default (badgeColors('Unknown')) carries the "no scan" state.
+  const { bg, ink } = badgeColors(slim ? slim.tier : 'Unknown');
 
-  const value = slim ? `${grade} · ${score}` : 'no scan';
-  // Rough text-width estimate (monospace-ish, 6.6px/char + padding).
-  const labelW = 38;
-  const valueW = Math.max(46, value.length * 6.8 + 16);
-  const total = labelW + valueW;
-  const fill = slim ? c.fg : '#8a8a92';
+  // JetBrains Mono geometry. The face advances ≈ 0.6em, so ~7.25px per glyph at
+  // 12px; each segment gets 8px of horizontal breathing room on each side.
+  const fontSize = 12;
+  const charW = 7.25;
+  const padX = 8;
+  const height = 22;
+  const radius = 4; // design "Radii": 4px badge corners.
+
+  const leftW = Math.round(label.length * charW) + padX * 2;
+  const rightW = Math.round(value.length * charW) + padX * 2;
+  const pillW = leftW + rightW;
+
+  // The badge is the one surface the system allows a shadow (design "Shadows":
+  // 0 1px 2px rgba(0,0,0,0.1)). feDropShadow bleeds ~3px down and ~2px sideways,
+  // so the pill is inset inside a slightly larger canvas to avoid clipping it.
+  const mx = 2;
+  const mTop = 1;
+  const mBottom = 3;
+  const w = pillW + mx * 2;
+  const h = height + mTop + mBottom;
+  const baseline = mTop + Math.round(height / 2 + fontSize * 0.355);
+  const name = domain ? `slop score for ${domain}: ${value}` : `slop: ${value}`;
 
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width={total}
-      height="20"
+      width={w}
+      height={h}
+      viewBox={`0 0 ${w} ${h}`}
       role="img"
-      aria-label={`${label}: ${value}`}
+      aria-label={name}
     >
-      <linearGradient id="s" x2="0" y2="100%">
-        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
-        <stop offset="1" stop-opacity=".1" />
-      </linearGradient>
-      <clipPath id="r">
-        <rect width={total} height="20" rx="3" fill="#fff" />
-      </clipPath>
-      <g clip-path="url(#r)">
-        <rect width={labelW} height="20" fill="#1a1a1d" />
-        <rect x={labelW} width={valueW} height="20" fill={fill} />
-        <rect width={total} height="20" fill="url(#s)" />
+      <title>{name}</title>
+      <defs>
+        <clipPath id="r">
+          <rect x={mx} y={mTop} width={pillW} height={height} rx={radius} />
+        </clipPath>
+        <filter id="sh" x="-20%" y="-20%" width="140%" height="160%">
+          <feDropShadow dx="0" dy="1" stdDeviation="1" flood-color="#000000" flood-opacity="0.1" />
+        </filter>
+      </defs>
+      <g filter="url(#sh)">
+        <g clip-path="url(#r)">
+          <rect x={mx} y={mTop} width={leftW} height={height} fill="#16170F" />
+          <rect x={mx + leftW} y={mTop} width={rightW} height={height} fill={bg} />
+        </g>
       </g>
-      <g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
-        <text x={labelW / 2} y="14" fill="#fff">
+      <g
+        font-family="'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace"
+        font-size={fontSize}
+        font-weight="700"
+        text-anchor="middle"
+      >
+        <text x={mx + leftW / 2} y={baseline} fill="#F4F5F2">
           {label}
         </text>
-        <text x={labelW + valueW / 2} y="14" fill="#0a0a0b" font-weight="bold">
+        <text x={mx + leftW + rightW / 2} y={baseline} fill={ink}>
           {value}
         </text>
       </g>

--- a/apps/web/test/badge.test.js
+++ b/apps/web/test/badge.test.js
@@ -1,0 +1,130 @@
+// Tests for the embeddable slop badge (the two-segment editorial pill).
+//
+// Two layers: the pure `badgeSvg` renderer (segments, tier colors, no-scan
+// fallback, no gradient tell) and the GET /badge/:domain.svg route (MNR-8
+// functional parity: svg content-type, 3h cache, `.svg` + `www.` stripping).
+
+import { test, expect } from 'vitest';
+import { badgeSvg } from '../functions/_badge.tsx';
+import { badgeColors } from '../functions/_theme.ts';
+import { saveResult, BADGE_TTL } from '../functions/_shared.ts';
+import { onRequestGet } from '../functions/badge/[domain].ts';
+
+function slim(over = {}) {
+  return {
+    id: 'badge001',
+    domain: 'ex.com',
+    score: 30,
+    tier: 'Heavy',
+    grade: 'D',
+    ...over,
+  };
+}
+
+function makeKv(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    async get(k) {
+      return store.has(k) ? store.get(k) : null;
+    },
+    async put(k, v) {
+      store.set(k, v);
+    },
+    async delete(k) {
+      store.delete(k);
+    },
+  };
+}
+
+test('renders two segments: dark left "slop" + tier-colored right grade · score', () => {
+  const svg = badgeSvg('ex.com', slim());
+  const { bg, ink } = badgeColors('Heavy');
+  // Left segment: the dark ink panel with the "slop" wordmark.
+  expect(svg).toMatch(/fill="#16170F"/);
+  expect(svg).toMatch(/>slop</);
+  // Right segment: the Heavy bg fill, with grade · score in the Heavy ink.
+  expect(svg).toContain(`fill="${bg}"`);
+  expect(svg).toContain(`fill="${ink}"`);
+  expect(svg).toMatch(/>D · 30</);
+});
+
+test('right-segment colors come from _theme.badgeColors for every tier', () => {
+  const cases = [
+    { tier: 'Clean', grade: 'A', score: 5 },
+    { tier: 'Mild', grade: 'C', score: 18 },
+    { tier: 'Heavy', grade: 'F', score: 60 },
+  ];
+  for (const { tier, grade, score } of cases) {
+    const svg = badgeSvg('ex.com', slim({ tier, grade, score }));
+    const { bg, ink } = badgeColors(tier);
+    // The exact table values (Clean #1FA85E/#0A2A18, Mild #D89A2E/#3A2705,
+    // Heavy #C9402E/#FFFFFF) are reached through the resolver, never inlined.
+    expect(svg).toContain(`fill="${bg}"`);
+    expect(svg).toContain(`fill="${ink}"`);
+    expect(svg).toContain(`${grade} · ${score}`);
+  }
+});
+
+test('no-scan fallback: neutral grey badge, "no scan", no grade · score', () => {
+  const svg = badgeSvg('never.dev', null);
+  const neutral = badgeColors('Unknown');
+  expect(svg).toMatch(/>no scan</);
+  expect(svg).toContain(`fill="${neutral.bg}"`); // #6E6F63 neutral right segment
+  expect(svg).toMatch(/fill="#16170F"/); // still the dark left segment
+  expect(svg).not.toMatch(/ · /); // no grade · score divider
+});
+
+test('contains no gradient tell (the dropped shields linear-gradient overlay)', () => {
+  const scanned = badgeSvg('ex.com', slim());
+  const empty = badgeSvg('ex.com', null);
+  for (const svg of [scanned, empty]) {
+    expect(svg).not.toMatch(/gradient/i); // no linearGradient / radialGradient
+    expect(svg).not.toContain('url(#s)'); // the old overlay reference
+  }
+});
+
+test('a11y + tokens: role=img, aria-label, 4px radius, JetBrains Mono, one sanctioned shadow', () => {
+  const svg = badgeSvg('ex.com', slim());
+  expect(svg).toMatch(/role="img"/);
+  expect(svg).toMatch(/aria-label="slop score for ex\.com: D · 30"/);
+  expect(svg).toMatch(/rx="4"/); // design "Radii": 4px badge corners
+  expect(svg).toContain('JetBrains Mono');
+  // The badge is the only surface allowed a shadow (design "Shadows":
+  // 0 1px 2px rgba(0,0,0,0.1)) — rendered once, as a subtle drop shadow.
+  expect(svg).toMatch(/feDropShadow/);
+  expect(svg).toMatch(/flood-opacity="0\.1"/);
+  expect(svg.match(/<feDropShadow/g)).toHaveLength(1); // exactly one shadow element
+});
+
+test('GET /badge route: svg content-type, 3h cache, tier-colored body', async () => {
+  const kv = makeKv();
+  await saveResult(kv, slim());
+  const res = await onRequestGet({ params: { domain: 'ex.com' }, env: { RESULTS: kv } });
+  expect(res.headers.get('Content-Type')).toMatch(/image\/svg\+xml/);
+  expect(BADGE_TTL).toBe(60 * 60 * 3); // 3 hours
+  expect(res.headers.get('Cache-Control')).toContain(`max-age=${BADGE_TTL}`);
+  const body = await res.text();
+  expect(body).toContain(`fill="${badgeColors('Heavy').bg}"`);
+});
+
+test('GET /badge route strips `.svg` and `www.` before lookup', async () => {
+  const kv = makeKv();
+  await saveResult(kv, slim()); // stored under d:ex.com
+  const res = await onRequestGet({ params: { domain: 'www.EX.com.svg' }, env: { RESULTS: kv } });
+  const body = await res.text();
+  // Normalized to ex.com, so the stored Heavy scan is found (not the no-scan badge).
+  expect(body).toContain(`fill="${badgeColors('Heavy').bg}"`);
+  expect(body).not.toMatch(/>no scan</);
+});
+
+test('GET /badge route: an unscanned domain returns a valid no-scan badge', async () => {
+  const res = await onRequestGet({
+    params: { domain: 'unscanned.io.svg' },
+    env: { RESULTS: makeKv() },
+  });
+  const body = await res.text();
+  expect(body).toMatch(/>no scan</);
+  expect(body).toContain(`fill="${badgeColors('Unknown').bg}"`);
+  expect(body).toMatch(/role="img"/);
+});


### PR DESCRIPTION
Phase C task 12 (parity-spec). Rebuilds the self-rendered badge SVG in the new design.

What: rewrites apps/web/functions/_badge.tsx as the two-segment editorial pill (dark #16170F left 'slop' + tier-colored right grade·score from _theme badge colors; JetBrains Mono; 4px radius; the one sanctioned shadow; drops the old shields linearGradient overlay). Adds apps/web/test/badge.test.js (8 tests). Behavior preserved (MNR-8): neutral 'no scan' badge, no shields.io dep, route caches 3h/BADGE_TTL, strips .svg + www.

Acceptance (task 12):
- [x] Two-segment pill + badge color table from _theme.ts; no linearGradient/gradient fill
- [x] no-scan fallback; cache/normalization parity; role=img + aria-label
- [x] badge.test.js real assertions; full web suite green (16 files, 146 tests), typecheck 0
- [x] Clean commit (Ravindra Kumar, no trailers)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only SVG and test coverage; embed route caching and domain normalization behavior are explicitly locked by tests.
> 
> **Overview**
> Replaces the shields-style badge SVG with a **two-segment editorial pill**: dark `#16170F` **slop** on the left and a tier-colored **grade · score** (or **no scan**) on the right, using `badgeColors` from `_theme.ts` instead of the old `tierColors` fill.
> 
> Visual system updates drop the linear-gradient overlay, switch to **JetBrains Mono** at 12px with computed segment widths, **4px** corners, and a single sanctioned **feDropShadow**; accessibility uses `role="img"`, `<title>`, and domain-aware `aria-label`.
> 
> Adds **`badge.test.js`** (eight tests) covering segment markup, per-tier colors, no-scan neutral state, no gradients, a11y tokens, and **GET /badge** parity (SVG content-type, 3h cache, `.svg` / `www.` normalization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf3577006e98cf1e6d032ed32169ef1f4556a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->