### PR TITLE
feat(web): score-hub (parity-spec build task 03)

### DIFF
--- a/apps/web/functions/_result.tsx
+++ b/apps/web/functions/_result.tsx
@@ -1,0 +1,1051 @@
+/** @jsxRuntime automatic @jsxImportSource hono/jsx */
+// Result composite components — the shared body of the Result screen.
+//
+// The /score/:domain hub (task 03) is the canonical caller; the /r/:id permalink
+// (task 04) and the printable /report/:domain (task 05) compose the SAME pieces so
+// the three surfaces render one Result. Everything here is driven by the persisted
+// "slim" scan record (see _data.ts > slimResult) joined to the engine's STATIC
+// metadata (PATTERNS / FIXES / AEO_CHECKS): the slim keeps triggered patterns as
+// { id, label, short, weight } but drops per-pattern evidence and the full pattern
+// list, so the category bars, breakdown, radar, and fix cards are RECONSTRUCTED by
+// joining the triggered ids back to the engine — never fabricated. Where a datum
+// genuinely isn't persisted (per-scan AEO pass/fail, same-category neighbours), the
+// dogfood rule wins: show the checklist or omit the chart, don't invent a number.
+//
+// Tokens come from _brand.ts (BRAND_CSS) and the shared shell from _ui.tsx; color
+// is resolved through _theme.ts so every tier/grade hue has one source. Pages embed
+// RESULT_CSS alongside BRAND_CSS + UI_CSS. This file imports the foundation but does
+// not edit it (foundation acceptance gate).
+
+import { PATTERNS, FIXES, AEO_CHECKS } from '@slop-detect/core';
+import { jsonForScript } from './_render.js';
+import { tierFill, tierText, tierPillBg, systemAxisColor } from './_theme.js';
+import { LetterAvatar, ScoreTierBadge, LiveBadge, Button, SectionLedger } from './_ui.js';
+
+// ── category taxonomy ─────────────────────────────────────────────────────────
+// The five overview bars map the engine's pattern categories to the design's
+// display names (design "Category overview bars" / Result inventory section 4).
+const CATS = [
+  { key: 'fonts', label: 'Type' },
+  { key: 'colors', label: 'Color' },
+  { key: 'layout', label: 'Layout' },
+  { key: 'css', label: 'Effects' },
+  { key: 'images', label: 'Imagery' },
+];
+
+// Precompute, once, the maximum slop weight each category can contribute and an
+// id → pattern lookup, so the view-model join is O(triggered).
+const CAT_MAX: Record<string, number> = {};
+for (const p of PATTERNS as any[]) CAT_MAX[p.category] = (CAT_MAX[p.category] || 0) + p.weight;
+const PATTERN_BY_ID = new Map((PATTERNS as any[]).map((p) => [p.id, p]));
+
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
+const firstSentence = (s: string) => {
+  const t = String(s || '').trim();
+  if (!t) return '';
+  const m = t.match(/^.*?[.!?](?:\s|$)/);
+  return (m ? m[0] : t).trim();
+};
+
+// ── view-model ──────────────────────────────────────────────────────────────
+// Pure: turn a slim record into everything the components render. Exported so the
+// permalink/report pages (and tests) can build the same model.
+export function buildResultView(slim: any) {
+  const triggered = (slim?.triggered || []).filter(Boolean);
+
+  // Per-category rollup, in the fixed display order.
+  const categories = CATS.map((c) => {
+    const hits = triggered.filter((t: any) => PATTERN_BY_ID.get(t.id)?.category === c.key);
+    const weight = hits.reduce((s: number, t: any) => s + (t.weight || 0), 0);
+    const max = CAT_MAX[c.key] || 0;
+    const ratio = max > 0 ? clamp01(weight / max) : 0;
+    const tier = hits.length === 0 ? 'Clean' : ratio >= 0.5 ? 'Heavy' : 'Mild';
+    return {
+      key: c.key,
+      label: c.label,
+      flagged: hits.length,
+      weight,
+      cleanPct: Math.round((1 - ratio) * 100),
+      cleanFraction: 1 - ratio,
+      tier,
+      patterns: hits
+        .slice()
+        .sort((a: any, b: any) => (b.weight || 0) - (a.weight || 0))
+        .map((t: any) => ({
+          id: t.id,
+          label: t.label || t.short || t.id,
+          short: t.short || '',
+          weight: t.weight || 0,
+          why: firstSentence(FIXES[t.id]?.problem || ''),
+        })),
+    };
+  });
+
+  // Fix cards: the heaviest design tells that have a remediation recipe.
+  const fixes = triggered
+    .filter((t: any) => FIXES[t.id])
+    .slice()
+    .sort((a: any, b: any) => (b.weight || 0) - (a.weight || 0))
+    .map((t: any) => ({
+      id: t.id,
+      label: t.label || t.short || t.id,
+      weight: t.weight || 0,
+      why: FIXES[t.id].problem,
+      fix: FIXES[t.id].fix,
+      rule: FIXES[t.id].rule,
+    }));
+
+  return {
+    triggered,
+    categories,
+    fixes,
+    flaggedTotal: slim?.patternsFlagged ?? triggered.length,
+    patternsTotal: slim?.patternsTotal ?? PATTERNS.length,
+  };
+}
+
+// Assemble the copyable fix prompt from the triggered patterns' recipes. Built
+// from the persisted ids + FIXES (the engine's buildFixPrompt needs the full
+// pattern list + evidence, which the slim record does not keep).
+export function assembleFixPrompt(slim: any, view: any) {
+  const url = slim.finalUrl || slim.url || `https://${slim.domain}`;
+  if (!view.fixes.length) {
+    return `${slim.domain} scored ${slim.score}/100 (tier ${slim.tier}) on the AI-design-slop detector and triggered 0 of ${view.patternsTotal} patterns. Nothing to fix on the design axis.`;
+  }
+  const lines = [
+    `# Landing page slop fix prompt`,
+    ``,
+    `${url} scored ${slim.score}/100 on the AI-design-slop detector — tier ${slim.tier} — triggering ${view.flaggedTotal} of ${view.patternsTotal} patterns. Reduce the score below 10 (Clean) by addressing each pattern below.`,
+    ``,
+    `## Issues to fix (highest weight first)`,
+  ];
+  view.fixes.forEach((f: any, i: number) => {
+    lines.push(
+      ``,
+      `### ${i + 1}. ${f.label} (+${f.weight})`,
+      ``,
+      `Why this reads as AI-slop: ${f.why}`,
+      ``,
+      `Fix: ${f.fix}`,
+      ``,
+      `Hard rule: ${f.rule}`
+    );
+  });
+  lines.push(
+    ``,
+    `Do not replace one slop pattern with another. Keep everything not listed above — it already passes.`
+  );
+  return lines.join('\n');
+}
+
+// ── result-level styles ───────────────────────────────────────────────────────
+// Light-first; everything references BRAND_CSS tokens. Literal hexes appear only
+// for the flat chart fills (rgba tints — never a gradient) the design names.
+export const RESULT_CSS = `
+  .result{max-width:1040px;margin:0 auto;padding:36px var(--pad-x) 0}
+  .result-section{padding:34px 0}
+  .result-section + .result-section{border-top:1px solid var(--border-2)}
+  .rs-ledger{margin-bottom:16px}
+
+  /* domain header */
+  .rh{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+  .rh-id{display:flex;align-items:center;gap:12px;min-width:0}
+  .rh-dom{font-family:var(--mono);font-size:20px;color:var(--text);word-break:break-all}
+  .rh-scanned{font-family:var(--mono);font-size:12.5px;color:var(--text-4);margin-top:3px}
+  .rh-spacer{flex:1}
+
+  /* big score block */
+  .bs{display:grid;grid-template-columns:1fr auto;gap:28px 40px;align-items:start;margin-top:8px}
+  .bs-num{font-family:var(--serif);font-weight:500;font-size:var(--fs-score);line-height:0.8;letter-spacing:-0.03em;white-space:nowrap}
+  .bs-num small{font-family:var(--serif);font-weight:500;font-size:42px;color:var(--text-6);letter-spacing:-0.02em}
+  .bs-meta{margin-top:18px}
+  .bs-gt{font-family:var(--mono);font-size:13px;color:var(--text-3)}
+  .bs-grade{font-weight:700}
+  .bs-rank{font-family:var(--mono);font-size:13px;color:var(--text-4);margin-top:4px}
+  .bs-rank strong{color:var(--text-3);font-weight:700}
+  .bs-verdict{font-family:var(--serif);font-style:italic;font-size:22px;line-height:1.32;color:var(--text-2);margin-top:16px;max-width:34ch}
+  .bs-actions{display:flex;flex-direction:column;align-items:flex-end;gap:9px;font-family:var(--mono);font-size:13px}
+  .bs-action{color:var(--text-3)}
+  .bs-action:hover{color:var(--text)}
+
+  /* category overview bars */
+  .cbars{display:grid;grid-template-columns:repeat(5,1fr);gap:14px}
+  .cbar-track{height:8px;border-radius:4px;background:var(--track);overflow:hidden}
+  .cbar-fill{height:100%;border-radius:4px}
+  .cbar-name{font-family:var(--mono);font-size:12.5px;color:var(--text-2);margin-top:9px}
+  .cbar-sub{font-family:var(--mono);font-size:11.5px;color:var(--text-4);margin-top:2px}
+
+  /* expandable breakdown */
+  .bd-head{display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:14px}
+  .bd-count{font-family:var(--mono);font-size:13px;color:var(--text-4)}
+  .bd{border:1px solid var(--border);border-radius:8px;overflow:hidden;background:var(--panel)}
+  .bd-row + .bd-row{border-top:1px solid var(--border-2)}
+  .bd-toggle{display:flex;align-items:center;gap:12px;width:100%;text-align:left;background:transparent;border:0;cursor:pointer;padding:15px 18px;font:inherit;color:inherit}
+  .bd-caret{font-family:var(--mono);font-size:12px;color:var(--text-4);width:12px;flex:none}
+  .bd-cat{font-family:var(--serif);font-size:var(--fs-serif-row);color:var(--text);font-weight:500}
+  .bd-pill{font-family:var(--mono);font-size:11px;font-weight:700;padding:2px 9px;border-radius:4px;letter-spacing:0.02em}
+  .bd-n{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-left:auto;white-space:nowrap}
+  .bd-body{padding:2px 18px 14px 42px;display:none}
+  .bd-row[data-open="1"] .bd-body{display:block}
+  .bd-pat{display:grid;grid-template-columns:20px 1fr 44px;gap:8px;padding:11px 0;border-top:1px solid var(--row-inner)}
+  .bd-pat:first-child{border-top:0}
+  .bd-x{color:var(--heavy);font-family:var(--mono)}
+  .bd-pl{font-size:15px;font-weight:600;color:var(--text)}
+  .bd-ev{font-family:var(--mono);font-size:12px;color:var(--text-5);margin-top:3px}
+  .bd-why{font-size:13px;color:var(--text-3);margin-top:4px;line-height:1.5}
+  .bd-w{font-family:var(--mono);font-size:13px;font-weight:700;color:var(--heavy-text);text-align:right;white-space:nowrap}
+  .bd-clean{padding:13px 18px 15px 42px;font-family:var(--mono);font-size:13px;color:var(--clean-text)}
+
+  /* four-axis strip */
+  .axis-note{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-bottom:12px}
+  .axes{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+  .axis{border:1px solid var(--border);border-radius:6px;background:var(--panel);padding:15px 16px}
+  .axis-k{font-family:var(--mono);font-size:11.5px;color:var(--text-4)}
+  .axis-v{font-family:var(--mono);font-size:17px;font-weight:700;margin-top:8px}
+  .axis-t{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-top:3px}
+
+  /* system + AEO detail cards */
+  .sa{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  .sa-card{border:1px solid var(--border);border-radius:6px;background:var(--panel);padding:18px 20px}
+  .sa-head{display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:12px}
+  .sa-title{font-family:var(--mono);font-size:12.5px;color:var(--text-3)}
+  .sa-tier{font-family:var(--mono);font-size:13px;font-weight:700}
+  .sa-ok{font-family:var(--mono);font-size:13px;color:var(--clean-text)}
+  .sa-absent{font-family:var(--mono);font-size:13px;color:var(--text-4);line-height:1.6}
+  .sa-drift{display:flex;gap:9px;padding:7px 0;border-top:1px solid var(--row-inner);font-size:13px;color:var(--text-2);line-height:1.5}
+  .sa-drift:first-of-type{border-top:0}
+  .sa-tag{font-family:var(--mono);font-size:11px;color:var(--mild-text);flex:none;margin-top:2px}
+  .aeo-row{display:grid;grid-template-columns:16px 1fr 30px;gap:8px;align-items:baseline;padding:6px 0;border-top:1px solid var(--row-inner)}
+  .aeo-row:first-of-type{border-top:0}
+  .aeo-mark{font-family:var(--mono);font-size:13px}
+  .aeo-label{font-family:var(--mono);font-size:12.5px;color:var(--text-2);line-height:1.4}
+  .aeo-w{font-family:var(--mono);font-size:12px;color:var(--text-6);text-align:right}
+  .aeo-foot{font-family:var(--mono);font-size:11.5px;color:var(--text-4);margin-top:11px;line-height:1.5}
+
+  /* competitive analytics */
+  .analytics{display:grid;grid-template-columns:1fr 1fr;gap:28px}
+  .chart-card{border:1px solid var(--border);border-radius:6px;background:var(--panel);padding:16px 18px}
+  .chart-h{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-bottom:10px}
+  .chart svg{display:block;width:100%;height:auto}
+  .chart-delta{font-family:var(--mono);font-size:12px;margin-top:8px}
+  .chart-cap{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-top:8px}
+  .chart-cap strong{color:var(--text-2)}
+
+  /* fixes panel */
+  .fixes{border:1px solid var(--border);border-radius:10px;background:var(--panel);padding:38px 36px}
+  .fixes-h{font-family:var(--serif);font-weight:500;font-size:var(--fs-h3);line-height:1.05;letter-spacing:-0.02em;text-align:center;color:var(--text)}
+  .fixes-sub{font-family:var(--mono);font-size:13px;color:var(--text-4);text-align:center;margin-top:8px}
+  .fix{border:1px solid var(--border-2);border-radius:8px;background:var(--bg);padding:20px 22px;margin-top:18px}
+  .fix-head{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:12px}
+  .fix-label{font-family:var(--mono);font-size:14px;font-weight:600;color:var(--text)}
+  .fix-x{color:var(--heavy)}
+  .fix-w{font-family:var(--mono);font-size:13px;font-weight:700;color:var(--heavy-text);white-space:nowrap}
+  .fix-grid{display:grid;grid-template-columns:46px 1fr;gap:6px 12px}
+  .fix-k{font-family:var(--mono);font-size:12px}
+  .fix-k.why{color:var(--mild-text)}
+  .fix-k.fix{color:var(--clean-text)}
+  .fix-k.rule{color:var(--text-4)}
+  .fix-v{font-size:13.5px;color:var(--text-2);line-height:1.55}
+  .fix-foot{display:flex;flex-direction:column;align-items:center;gap:12px;margin-top:24px}
+  .fix-cli{font-family:var(--mono);font-size:12.5px;color:var(--text-4)}
+  .fixes-clean{text-align:center;font-family:var(--serif);font-style:italic;font-size:18px;color:var(--clean-text);padding:6px 0}
+
+  /* share + embed */
+  .se{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+  .se-card{border:1px solid var(--border);border-radius:10px;background:var(--panel);padding:24px 26px}
+  .se-title{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-bottom:14px}
+  .se-row{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+  .se-badge{margin:0 0 14px}
+  .se-md{margin-top:14px;display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+
+  /* claim / listed */
+  .claim{border:1px solid var(--border);border-radius:10px;background:var(--panel);padding:24px 26px}
+  .claim-h{font-family:var(--serif);font-weight:500;font-size:21px;letter-spacing:-0.01em;color:var(--text);margin-bottom:8px}
+  .claim p{font-size:14px;color:var(--text-2);line-height:1.6;max-width:62ch}
+  .claim a{color:var(--clean-text);text-decoration:underline}
+  .claim-form{display:flex;gap:10px;flex-wrap:wrap;margin-top:16px}
+  .claim-form input{flex:1;min-width:220px;background:var(--bg);border:1px solid var(--border-btn);border-radius:3px;color:var(--text);font-family:var(--mono);font-size:14px;padding:11px 14px}
+  .claim-msg{margin-top:12px;font-family:var(--mono);font-size:13px;color:var(--text-3);min-height:1.2em}
+
+  /* loading skeleton + error/retry (GAP-FILL states) */
+  .rl-dom{display:flex;align-items:center;gap:12px;font-family:var(--mono);font-size:20px;color:var(--text-3)}
+  .rl-dot{width:10px;height:10px;border-radius:var(--r-round);background:var(--neutral);flex:none}
+  .rl-num{font-family:var(--serif);font-weight:500;font-size:var(--fs-score);line-height:0.8;color:var(--text-6);margin-top:8px}
+  .rl-verdict{font-family:var(--serif);font-style:italic;font-size:20px;color:var(--text-4);margin-top:12px}
+  .rl-slot{height:8px;border-radius:4px;background:var(--bg-2);margin-top:14px}
+  .re{max-width:560px}
+  .re-h{font-family:var(--serif);font-weight:500;font-size:var(--fs-h3);letter-spacing:-0.02em;color:var(--text)}
+  .re-body{font-size:15px;color:var(--text-2);line-height:1.6;margin:12px 0 22px;max-width:60ch}
+  .re-row{display:flex;gap:12px;flex-wrap:wrap}
+
+  /* flash toast (copy/share confirmation) */
+  .flash{position:fixed;bottom:26px;left:50%;transform:translateX(-50%);background:var(--text);color:var(--d-text);font-family:var(--mono);font-size:13px;padding:10px 18px;border-radius:4px;opacity:0;transition:opacity var(--t);pointer-events:none;z-index:60}
+  .flash.show{opacity:1}
+
+  /* chart draw: only when motion is welcome (GAP-FILL: reduced-motion, design Gaps 7) */
+  @media (prefers-reduced-motion: no-preference){
+    .chart-draw{stroke-dasharray:1200;stroke-dashoffset:1200;animation:resultDraw 900ms ease forwards}
+    @keyframes resultDraw{to{stroke-dashoffset:0}}
+  }
+
+  @media (max-width:900px){
+    .analytics{grid-template-columns:1fr}
+    .axes{grid-template-columns:1fr 1fr}
+    .sa{grid-template-columns:1fr}
+    .se{grid-template-columns:1fr}
+    .bs{grid-template-columns:1fr}
+    .bs-actions{align-items:flex-start}
+  }
+  @media (max-width:640px){
+    .result{padding-left:20px;padding-right:20px}
+    .cbars{grid-template-columns:repeat(2,1fr)}
+    .fixes{padding:26px 20px}
+  }
+`;
+
+// ── inline progressive-enhancement script ──────────────────────────────────────
+// One script for the whole Result: a flash toast, clipboard copy (badge markdown +
+// the full fix prompt), share-to-X, the keyboard-operable breakdown toggles
+// (aria-expanded), and the claim form POST. Hostile field values reach the script
+// only through jsonForScript, so a value containing </script> comes out <-
+// escaped and cannot break out of the element (see inline-scripts.test.js).
+export function resultScript(opts: {
+  shareText: string;
+  shareUrl: string;
+  fixPrompt?: string;
+  badgeMd?: string;
+  domain?: string;
+  claim?: boolean;
+}) {
+  const j = jsonForScript;
+  return `(function(){
+  var flashEl=document.getElementById('flash');
+  function flash(m){if(!flashEl)return;flashEl.textContent=m;flashEl.classList.add('show');setTimeout(function(){flashEl.classList.remove('show')},1700);}
+  function copy(text,label,el,done){if(!navigator.clipboard){return;}navigator.clipboard.writeText(text).then(function(){flash('✓ '+label);if(el&&done){var o=el.textContent;el.textContent=done;setTimeout(function(){el.textContent=o},1700);}}).catch(function(){});}
+
+  var SHARE_TEXT=${j(opts.shareText)};
+  var SHARE_URL=${j(opts.shareUrl)};
+  var sx=document.getElementById('shareX');
+  if(sx)sx.addEventListener('click',function(){window.open('https://twitter.com/intent/tweet?text='+encodeURIComponent(SHARE_TEXT)+'&url='+encodeURIComponent(SHARE_URL),'_blank','noopener');});
+  var sc=document.getElementById('copyLink');
+  if(sc)sc.addEventListener('click',function(){copy(SHARE_URL,'link copied',sc,'link copied ✓');});
+
+  var BADGE_MD=${j(opts.badgeMd || '')};
+  var bm=document.getElementById('badgeMd');
+  if(bm)bm.addEventListener('click',function(){copy(BADGE_MD,'copied',null);});
+  var cb=document.getElementById('copyMd');
+  if(cb)cb.addEventListener('click',function(){copy(BADGE_MD,'copied',cb,'copied ✓');});
+
+  var FIX_PROMPT=${j(opts.fixPrompt || '')};
+  var cf=document.getElementById('copyFix');
+  if(cf)cf.addEventListener('click',function(){copy(FIX_PROMPT,'copied the fix prompt',cf,'copied the fix prompt ✓');});
+
+  document.querySelectorAll('[data-toggle]').forEach(function(btn){
+    btn.addEventListener('click',function(){
+      var row=btn.closest('.bd-row');var open=row.getAttribute('data-open')==='1';
+      row.setAttribute('data-open',open?'0':'1');
+      btn.setAttribute('aria-expanded',open?'false':'true');
+      var caret=btn.querySelector('.bd-caret');if(caret)caret.textContent=open?'▸':'▾';
+    });
+  });
+
+  var clf=document.getElementById('claimForm');
+  if(clf)clf.addEventListener('submit',function(e){
+    e.preventDefault();
+    var email=(document.getElementById('claimEmail')||{}).value;
+    var msg=document.getElementById('claimMsg');
+    if(msg)msg.textContent='Submitting…';
+    fetch('/api/watch',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({domain:${j(opts.domain || '')},email:(email||'').trim(),list:true})})
+      .then(function(r){return r.json().catch(function(){return {};}).then(function(jb){return {ok:r.ok,b:jb};});})
+      .then(function(res){if(msg)msg.textContent=res.ok?(res.b.note||'Check your email to confirm ownership and switch on the backlink.'):(res.b.error||'Could not submit. Try again.');})
+      .catch(function(){if(msg)msg.textContent='Network error. Try again.';});
+  });
+})();`;
+}
+
+// ── components ──────────────────────────────────────────────────────────────
+
+// 2. Domain header: letter-avatar + mono domain + scanned-line + tier badge pill.
+export function DomainHeader({ slim, monitored = false }: { slim: any; monitored?: boolean }) {
+  const scanned = (slim.createdAt || '').replace('T', ' ').slice(0, 16);
+  const ms = slim.scanMs ? ` · ${(slim.scanMs / 1000).toFixed(1)}s` : '';
+  return (
+    <div class="rh">
+      <div class="rh-id">
+        <LetterAvatar name={slim.domain} size={30} />
+        <div>
+          <div class="rh-dom">{slim.domain}</div>
+          <div class="rh-scanned">
+            {scanned ? `scanned ${scanned} UTC` : 'scan on record'}
+            {ms}
+            {slim.definitionsVersion ? ` · defs ${slim.definitionsVersion}` : ''}
+            {monitored ? ' · monitored' : ''}
+          </div>
+        </div>
+      </div>
+      <span class="rh-spacer" />
+      <ScoreTierBadge tier={slim.tier} score={slim.score} grade={slim.grade} />
+    </div>
+  );
+}
+
+// 3. Big score block: the 120px serif numeral, grade·tier, rank, verdict, actions.
+export function BigScore({
+  slim,
+  rank,
+  origin = '',
+}: {
+  slim: any;
+  rank?: { n: number; of: number; cleanerThanPct: number } | null;
+  origin?: string;
+}) {
+  const fg = tierText(slim.tier);
+  const actions = [
+    { label: 'Fix with AI →', href: '#fixes' },
+    { label: 'Get the badge →', href: '#embed' },
+    { label: 'Rescan →', href: `${origin}/?url=${encodeURIComponent(slim.domain)}` },
+    { label: 'Printable report →', href: `${origin}/report/${slim.domain}` },
+    { label: 'This scan →', href: `${origin}/r/${slim.id}` },
+  ];
+  return (
+    <div class="bs">
+      <div>
+        <div class="bs-num" style={`color:${fg}`}>
+          {slim.score}
+          <small>/100</small>
+        </div>
+        <div class="bs-meta">
+          <div class="bs-gt">
+            <span class="bs-grade" style={`color:${fg}`}>
+              {slim.grade}
+            </span>{' '}
+            · {slim.tier} · {slim.patternsFlagged}/{slim.patternsTotal} patterns flagged
+          </div>
+          {rank ? (
+            <div class="bs-rank">
+              Cleaner than <strong>{rank.cleanerThanPct}%</strong> · rank <strong>#{rank.n}</strong>{' '}
+              of {rank.of.toLocaleString('en-US')} scans
+            </div>
+          ) : null}
+          {slim.verdict ? <p class="bs-verdict">{slim.verdict}</p> : null}
+        </div>
+      </div>
+      <div class="bs-actions">
+        <button class="bs-action" id="shareX" type="button">
+          Share →
+        </button>
+        {actions.map((a) => (
+          <a class="bs-action" href={a.href}>
+            {a.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// 4. Category overview: five status bars (fill width = clean %, color = tier).
+export function CategoryBars({ categories }: { categories: any[] }) {
+  return (
+    <div class="cbars">
+      {categories.map((c) => (
+        <div>
+          <div
+            class="cbar-track"
+            role="img"
+            aria-label={`${c.label}: ${c.cleanPct}% clean${c.flagged ? `, ${c.flagged} flagged` : ''}`}
+          >
+            <div class="cbar-fill" style={`width:${c.cleanPct}%;background:${tierFill(c.tier)}`} />
+          </div>
+          <div class="cbar-name">{c.label}</div>
+          <div class="cbar-sub">{c.flagged ? `+${c.weight} · ${c.flagged} flagged` : 'clean'}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// 5. Expandable breakdown: one row per category; the first dirty category is open
+// by default. Toggles are real <button>s with aria-expanded (keyboard-operable).
+export function Breakdown({
+  categories,
+  flaggedTotal,
+  patternsTotal,
+}: {
+  categories: any[];
+  flaggedTotal: number;
+  patternsTotal: number;
+}) {
+  let firstDirtyDone = false;
+  return (
+    <>
+      <div class="bd-head">
+        <SectionLedger tag="" label="the breakdown" />
+        <span class="bd-count">
+          {flaggedTotal} of {patternsTotal} patterns flagged
+        </span>
+      </div>
+      <div class="bd">
+        {categories.map((c) => {
+          const open = c.flagged > 0 && !firstDirtyDone;
+          if (open) firstDirtyDone = true;
+          const id = `bd-${c.key}`;
+          return (
+            <div class="bd-row" data-open={open ? '1' : '0'}>
+              <button
+                class="bd-toggle"
+                type="button"
+                data-toggle
+                aria-expanded={open ? 'true' : 'false'}
+                aria-controls={id}
+              >
+                <span class="bd-caret" aria-hidden="true">
+                  {open ? '▾' : '▸'}
+                </span>
+                <span class="bd-cat">{c.label}</span>
+                <span
+                  class="bd-pill"
+                  style={`background:${tierPillBg(c.tier)};color:${tierText(c.tier)}`}
+                >
+                  {c.tier}
+                </span>
+                <span class="bd-n">{c.flagged ? `${c.flagged} flagged` : 'clean'}</span>
+              </button>
+              <div class="bd-body" id={id}>
+                {c.patterns.length ? (
+                  c.patterns.map((p: any) => (
+                    <div class="bd-pat">
+                      <span class="bd-x" aria-hidden="true">
+                        ✗
+                      </span>
+                      <div>
+                        <div class="bd-pl">{p.label}</div>
+                        {p.short ? <div class="bd-ev">{p.short}</div> : null}
+                        {p.why ? <div class="bd-why">{p.why}</div> : null}
+                      </div>
+                      <span class="bd-w">+{p.weight}</span>
+                    </div>
+                  ))
+                ) : (
+                  <div class="bd-clean">✓ clean, no tells in this category.</div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+// 6. Four-axis strip: design slop, copy slop, system, AEO + the polarity note.
+export function AxisStrip({ slim }: { slim: any }) {
+  const copy = slim.axes?.copy || null;
+  const sys = slim.system || null;
+  const cells = [
+    {
+      k: 'design slop',
+      v: `${slim.score}/100`,
+      t: slim.tier,
+      color: tierText(slim.tier),
+    },
+    copy
+      ? { k: 'copy slop', v: `${copy.score}/100`, t: copy.tier, color: tierText(copy.tier) }
+      : { k: 'copy slop', v: 'not run', t: '', color: 'var(--text-4)' },
+    sys
+      ? {
+          k: 'system · DESIGN.md',
+          v: `${sys.score}/100`,
+          t: sys.tier,
+          color: systemAxisColor(sys.score),
+        }
+      : { k: 'system · DESIGN.md', v: 'none', t: 'no DESIGN.md', color: 'var(--text-4)' },
+    { k: 'AEO · agent-readable', v: 'not run', t: 'scan to evaluate', color: 'var(--text-4)' },
+  ];
+  return (
+    <>
+      <div class="axis-note">slop: lower is better · system & AEO: higher is better</div>
+      <div class="axes">
+        {cells.map((c) => (
+          <div class="axis">
+            <div class="axis-k">{c.k}</div>
+            <div class="axis-v" style={`color:${c.color}`}>
+              {c.v}
+            </div>
+            {c.t ? <div class="axis-t">{c.t}</div> : null}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+// 7. System drift card + AEO eight-check card. The system axis is persisted; AEO
+// pass/fail is not, so the AEO card lists the eight checks (what AEO measures) and
+// says it is evaluated on a fresh scan rather than faking ✓/✗.
+export function SystemAeoCards({ slim }: { slim: any }) {
+  const sys = slim.system || null;
+  const sysTierColor = sys ? systemAxisColor(sys.score) : 'var(--text-4)';
+  return (
+    <div class="sa">
+      <div class="sa-card">
+        <div class="sa-head">
+          <span class="sa-title">system · DESIGN.md drift</span>
+          {sys ? (
+            <span class="sa-tier" style={`color:${sysTierColor}`}>
+              {sys.tier} · {sys.score}
+            </span>
+          ) : null}
+        </div>
+        {!sys ? (
+          <p class="sa-absent">
+            No DESIGN.md declared. Add a design system file to track drift between redesigns.
+          </p>
+        ) : (sys.drift || []).length === 0 ? (
+          <p class="sa-ok">✓ aligned with its declared DESIGN.md, no drift.</p>
+        ) : (
+          (sys.drift || []).map((d: any) => (
+            <div class="sa-drift">
+              <span class="sa-tag">drift</span>
+              <span>{d.message || d.id}</span>
+            </div>
+          ))
+        )}
+      </div>
+      <div class="sa-card">
+        <div class="sa-head">
+          <span class="sa-title">AEO · agent-readable</span>
+        </div>
+        {(AEO_CHECKS as any[]).map((chk) => (
+          <div class="aeo-row">
+            <span class="aeo-mark" style="color:var(--text-6)" aria-hidden="true">
+              ·
+            </span>
+            <span class="aeo-label">{chk.label}</span>
+            <span class="aeo-w">+{chk.weight}</span>
+          </div>
+        ))}
+        <p class="aeo-foot">
+          Eight checks, weighted to 100. Evaluated live per scan. Run a fresh scan to see pass/fail.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ── charts (inline SVG, no chart library) ──────────────────────────────────────
+
+// Score over time: a flat tier-fill area + a 2px line; a delta label vs the first
+// recorded scan. The line draws in only when motion is welcome.
+function ScoreOverTime({ points }: { points: any[] }) {
+  const W = 320,
+    H = 110,
+    padX = 6,
+    padTop = 8,
+    padBot = 16;
+  const innerW = W - padX * 2,
+    innerH = H - padTop - padBot;
+  const n = points.length;
+  const x = (i: number) => padX + (innerW * i) / (n - 1);
+  const y = (s: number) => padTop + (innerH * Math.max(0, Math.min(100, s))) / 100;
+  const line = points
+    .map((p, i) => `${i ? 'L' : 'M'}${x(i).toFixed(1)},${y(p.score).toFixed(1)}`)
+    .join(' ');
+  const area = `${line} L${x(n - 1).toFixed(1)},${(H - padBot).toFixed(1)} L${padX},${(H - padBot).toFixed(1)} Z`;
+  const last = points[n - 1];
+  const first = points[0];
+  const stroke = tierText(last.tier);
+  const fill =
+    last.tier === 'Heavy'
+      ? 'rgba(201,64,46,0.10)'
+      : last.tier === 'Mild'
+        ? 'rgba(216,154,46,0.10)'
+        : 'rgba(31,168,94,0.10)';
+  const cleanY = y(10).toFixed(1);
+  const delta = last.score - first.score;
+  const deltaColor =
+    delta < 0 ? 'var(--clean-text)' : delta > 0 ? 'var(--heavy-text)' : 'var(--text-4)';
+  const deltaTxt =
+    delta === 0
+      ? 'no change since first scan'
+      : `${delta < 0 ? '−' : '+'}${Math.abs(delta)} pts since first scan`;
+  return (
+    <div class="chart-card">
+      <div class="chart-h">score over time</div>
+      <div class="chart">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          role="img"
+          aria-label="slop score over time"
+          preserveAspectRatio="none"
+        >
+          <line
+            x1={padX}
+            y1={cleanY}
+            x2={W - padX}
+            y2={cleanY}
+            stroke="#D7D9D2"
+            stroke-width="1"
+            stroke-dasharray="3 4"
+          />
+          <path d={area} fill={fill} stroke="none" />
+          <path
+            class="chart-draw"
+            d={line}
+            fill="none"
+            stroke={stroke}
+            stroke-width="2"
+            stroke-linejoin="round"
+            stroke-linecap="round"
+          />
+        </svg>
+      </div>
+      <div class="chart-delta" style={`color:${deltaColor}`}>
+        {deltaTxt}
+      </div>
+    </div>
+  );
+}
+
+// Cleanliness radar: a pentagon over the five categories. The "you" polygon is the
+// per-category clean fraction; two guide rings frame it. No rank-average polygon —
+// per-category corpus averages are not persisted, so it is omitted rather than faked.
+function Radar({ categories, tier }: { categories: any[]; tier: string }) {
+  const W = 220,
+    H = 150,
+    cx = W / 2,
+    cy = H / 2 + 6,
+    R = 56;
+  const n = categories.length;
+  const ptAt = (i: number, r: number) => {
+    const a = -Math.PI / 2 + (i * 2 * Math.PI) / n;
+    return [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+  };
+  const ring = (r: number) =>
+    categories
+      .map((_, i) =>
+        ptAt(i, r)
+          .map((v) => v.toFixed(1))
+          .join(',')
+      )
+      .join(' ');
+  const you = categories
+    .map((c, i) =>
+      ptAt(i, R * clamp01(c.cleanFraction))
+        .map((v) => v.toFixed(1))
+        .join(',')
+    )
+    .join(' ');
+  const stroke = tierText(tier);
+  return (
+    <div class="chart-card">
+      <div class="chart-h">cleanliness radar</div>
+      <div class="chart">
+        <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="per-category cleanliness radar">
+          <polygon points={ring(R)} fill="none" stroke="#D7D9D2" stroke-width="1" />
+          <polygon points={ring(R * 0.5)} fill="none" stroke="#E2E4DD" stroke-width="1" />
+          <polygon
+            class="chart-draw"
+            points={you}
+            fill="rgba(31,168,94,0.14)"
+            stroke={stroke}
+            stroke-width="2"
+          />
+          {categories.map((c, i) => {
+            const [lx, ly] = ptAt(i, R + 12);
+            return (
+              <text
+                x={lx.toFixed(1)}
+                y={ly.toFixed(1)}
+                fill="#9A9B8E"
+                font-size="8"
+                font-family="var(--mono)"
+                text-anchor={lx < cx - 4 ? 'end' : lx > cx + 4 ? 'start' : 'middle'}
+              >
+                {c.label}
+              </text>
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// Slop distribution: a 10-bucket histogram with the domain's own bucket highlighted.
+function Distribution({ dist, score, tier }: { dist: number[]; score: number; tier: string }) {
+  const buckets = new Array(10).fill(0);
+  let total = 0;
+  for (let i = 0; i <= 100; i++) {
+    const n = dist[i] || 0;
+    buckets[Math.min(9, Math.floor(i / 10))] += n;
+    total += n;
+  }
+  const max = Math.max(1, ...buckets);
+  const mine = Math.min(9, Math.floor(score / 10));
+  let worse = 0;
+  for (let i = Math.round(score) + 1; i <= 100; i++) worse += dist[i] || 0;
+  const cleanerThan = total ? Math.round((worse / total) * 100) : 0;
+  const W = 320,
+    H = 110,
+    gap = 4,
+    bw = (W - gap * 9) / 10;
+  return (
+    <div class="chart-card">
+      <div class="chart-h">slop distribution</div>
+      <div class="chart">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          role="img"
+          aria-label="distribution of slop scores across all scans"
+        >
+          {buckets.map((b, i) => {
+            const h = Math.round((b / max) * (H - 10));
+            return (
+              <rect
+                x={(i * (bw + gap)).toFixed(1)}
+                y={(H - h).toFixed(1)}
+                width={bw.toFixed(1)}
+                height={h}
+                rx="1"
+                fill={i === mine ? tierFill(tier) : '#CDCFC8'}
+              />
+            );
+          })}
+        </svg>
+      </div>
+      <div class="chart-cap">
+        cleaner than <strong>{cleanerThan}%</strong> of {total.toLocaleString('en-US')} scans
+      </div>
+    </div>
+  );
+}
+
+// 8. Competitive analytics: the charts we can draw from persisted data. Each is
+// conditional on having enough data; the section is omitted entirely when none are.
+export function Analytics({
+  history = [],
+  dist,
+  slim,
+  categories,
+}: {
+  history?: any[];
+  dist?: number[] | null;
+  slim: any;
+  categories: any[];
+}) {
+  const points = (history || []).filter((h) => typeof h.score === 'number').slice(-30);
+  const totalScans = dist ? dist.reduce((s, n) => s + (n || 0), 0) : 0;
+  const showTime = points.length >= 2;
+  const showDist = !!dist && totalScans >= 5;
+  return (
+    <div class="analytics">
+      {showTime ? <ScoreOverTime points={points} /> : null}
+      <Radar categories={categories} tier={slim.tier} />
+      {showDist ? (
+        <Distribution dist={dist as number[]} score={slim.score} tier={slim.tier} />
+      ) : null}
+    </div>
+  );
+}
+
+// 9. Fixes panel: a fix card (why/fix/rule) per heaviest tell, a copy-prompt button
+// and the CLI hint; the clean empty state when nothing triggered.
+export function FixesPanel({ fixes, domain }: { fixes: any[]; domain: string }) {
+  return (
+    <div class="fixes" id="fixes">
+      <h2 class="fixes-h">You've seen the score. Now fix it.</h2>
+      {fixes.length ? (
+        <>
+          <p class="fixes-sub">{fixes.length} tells, heaviest first.</p>
+          {fixes.map((f) => (
+            <div class="fix">
+              <div class="fix-head">
+                <span class="fix-label">
+                  <span class="fix-x" aria-hidden="true">
+                    ✗
+                  </span>{' '}
+                  {f.label}
+                </span>
+                <span class="fix-w">+{f.weight}</span>
+              </div>
+              <div class="fix-grid">
+                <span class="fix-k why">why</span>
+                <span class="fix-v">{f.why}</span>
+                <span class="fix-k fix">fix</span>
+                <span class="fix-v">{f.fix}</span>
+                <span class="fix-k rule">rule</span>
+                <span class="fix-v">{f.rule}</span>
+              </div>
+            </div>
+          ))}
+          <div class="fix-foot">
+            <Button variant="primary" id="copyFix" label="Copy the full fix prompt" />
+            <span class="fix-cli">npx slop-detect {domain} --fix</span>
+          </div>
+        </>
+      ) : (
+        <p class="fixes-clean">Nothing to fix, this page is already Clean. Keep it that way.</p>
+      )}
+    </div>
+  );
+}
+
+// 10. Share + embed card: share buttons + the live badge preview, markdown snippet,
+// and a copy button. The badge markdown is the clickable code block.
+export function ShareEmbed({
+  slim,
+  origin,
+  pageUrl,
+}: {
+  slim: any;
+  origin: string;
+  pageUrl: string;
+}) {
+  const badgeMd = `[![slop](${origin}/badge/${slim.domain}.svg)](${pageUrl})`;
+  return (
+    <div class="se" id="embed">
+      <div class="se-card">
+        <div class="se-title">share</div>
+        <div class="se-row">
+          <Button variant="outline" id="copyLink" label="Copy link" />
+          <Button
+            variant="outline"
+            id="shareX2"
+            label="Post on X"
+            href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(pageUrl)}`}
+            target="_blank"
+          />
+          <Button
+            variant="outline"
+            label="LinkedIn"
+            href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(pageUrl)}`}
+            target="_blank"
+          />
+        </div>
+      </div>
+      <div class="se-card">
+        <div class="se-title">embed the live badge</div>
+        <div class="se-badge">
+          <LiveBadge tier={slim.tier} grade={slim.grade} score={slim.score} />
+        </div>
+        <pre class="cb cb-wrap" id="badgeMd" title="click to copy">
+          <code>{badgeMd}</code>
+        </pre>
+        <div class="se-md">
+          <Button variant="outline" id="copyMd" label="Copy markdown" />
+          <span class="se-title" style="margin:0">
+            live · re-scans periodically
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Claim / backlink model (MNR-12): a listed domain gets a dofollow backlink; an
+// unclaimed one gets the claim form and NO backlink. The claim form posts list:true
+// to /api/watch (verify-by-email), the same contract the old page used.
+export function ClaimPanel({
+  slim,
+  origin,
+  claimed,
+}: {
+  slim: any;
+  origin: string;
+  claimed: boolean;
+}) {
+  if (claimed) {
+    return (
+      <div class="claim">
+        <div class="claim-h">Listed in the directory</div>
+        <p>
+          This domain is claimed. It carries a dofollow backlink:{' '}
+          <a href={`https://${slim.domain}`} rel="dofollow">
+            {slim.domain}
+          </a>
+          . See it in the <a href={`${origin}/directory`}>directory</a>.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div class="claim">
+      <div class="claim-h">Claim this page</div>
+      <p>
+        Own {slim.domain}? Verify by email to list it in the directory with a real dofollow backlink
+        and get an alert if it ever drifts back into slop.
+      </p>
+      <form id="claimForm" class="claim-form" novalidate>
+        <label class="sr-only" for="claimEmail">
+          Email to verify ownership
+        </label>
+        <input
+          id="claimEmail"
+          type="email"
+          inputmode="email"
+          placeholder={`you@${slim.domain}`}
+          required
+        />
+        <Button variant="primary" type="submit" label="Claim + list" />
+      </form>
+      <div id="claimMsg" class="claim-msg" role="status" aria-live="polite" />
+    </div>
+  );
+}
+
+// ── GAP-FILL states (design "Motion and interaction states") ──────────────────
+
+// Loading placeholder: domain "…", a neutral dot, empty metric slots, "scanning…".
+// Reusable by /r's design loading phase; reachable on /score via ?preview=loading.
+export function ResultLoading({ domain }: { domain: string }) {
+  return (
+    <div class="result" aria-busy="true">
+      <div class="result-section">
+        <div class="rl-dom">
+          <span class="rl-dot" aria-hidden="true" />
+          {domain || '…'}
+        </div>
+        <div class="rl-num">…</div>
+        <div class="rl-verdict">scanning…</div>
+        <div class="rl-slot" style="width:60%" />
+        <div class="rl-slot" style="width:42%" />
+      </div>
+    </div>
+  );
+}
+
+// Error / retry (GAP-FILL: design Gaps 4): a blocked / timed-out / unavailable
+// scoring path. Honest copy, a retry link, no fake Clean.
+export function ResultError({
+  domain,
+  origin = '',
+  message = 'We could not load this score right now.',
+}: {
+  domain: string;
+  origin?: string;
+  message?: string;
+}) {
+  return (
+    <div class="result">
+      <div class="result-section re">
+        <SectionLedger tag="" label="error" />
+        <h1 class="re-h" style="margin-top:14px">
+          Score unavailable
+        </h1>
+        <p class="re-body">
+          {message} The scoring engine is fine; this is a temporary read error. Retry, or run a
+          fresh scan.
+        </p>
+        <div class="re-row">
+          <Button variant="primary" href={`${origin}/score/${domain}`} label="Retry →" />
+          <Button
+            variant="outline"
+            href={`${origin}/?url=${encodeURIComponent(domain)}`}
+            label={`Rescan ${domain} →`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/functions/score/[domain].tsx
+++ b/apps/web/functions/score/[domain].tsx
@@ -1,20 +1,21 @@
 /** @jsxRuntime automatic @jsxImportSource hono/jsx */
-// GET /score/:domain — the canonical per-domain score hub.
+// GET /score/:domain — the canonical per-domain score hub (the spine).
 //
-// One public, crawlable page per scanned domain: the latest slop grade, the axes
-// that ran, a score-over-time chart, where the domain ranks among all scanned
-// sites, and the loop controls (re-scan, claim + monitor, share). Every scan now
-// records a timeline point and bumps the global distribution (see recordScan in
-// _shared.js), so this page works for ANY scanned domain, not only monitored ones.
+// One public, crawlable Result per scanned domain: the latest grade, the axes that
+// ran, the breakdown, the competitive analytics, the fixes, and the loop controls
+// (re-scan, claim + monitor, share, embed). Every scan records a timeline point and
+// bumps the global distribution (recordScan in _data.ts), so this page works for
+// ANY scanned domain, not only monitored ones.
 //
-// Visibility model: the page is public for everyone (it is just the score, which
-// /r and /report already expose). The dofollow backlink to the site is the
-// incentive to CLAIM: it appears only once the owner verifies via the monitor
-// form (POST /api/watch { list:true }). Unclaimed domains show a claim CTA and no
-// dofollow link, so we never hand SEO juice to an arbitrary URL.
+// The visible shell + composites come from the shared foundation: _brand.ts tokens,
+// _ui.tsx shell (Nav / Footer / MonitorCard), and _result.tsx (the Result body,
+// reused by /r and /report). This page only fetches the persisted record, derives
+// the rank, and composes — it does not re-implement components or re-style tokens.
 //
-// Anti-slop by construction: the shared brand system (flat panels, cold-blue
-// accent, no gradients/glows), so the page passes the detector it represents.
+// Claim model (MNR-12): the dofollow backlink to the site is the incentive to CLAIM.
+// It appears only once the owner verifies via the claim form (POST /api/watch
+// { list:true }). Unclaimed domains show the claim form and no backlink, so we never
+// hand SEO juice to an arbitrary URL. Anti-slop by construction (flat light system).
 
 import { raw } from 'hono/html';
 import {
@@ -24,104 +25,87 @@ import {
   getHistory,
   getListing,
   publicWatch,
-  percentileForScore,
-  tierColors,
+  getScoreDistribution,
+  percentileFromDistribution,
   jsonForScript,
 } from '../_shared.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from '../_brand.js';
+import { Nav, Footer, MonitorCard, SectionLedger, UI_CSS } from '../_ui.js';
+import {
+  RESULT_CSS,
+  buildResultView,
+  assembleFixPrompt,
+  resultScript,
+  DomainHeader,
+  BigScore,
+  CategoryBars,
+  Breakdown,
+  AxisStrip,
+  SystemAeoCards,
+  Analytics,
+  FixesPanel,
+  ShareEmbed,
+  ClaimPanel,
+  ResultLoading,
+  ResultError,
+} from '../_result.js';
 
 const ORIGIN = 'https://slop-detect.com';
+const CSS = BRAND_CSS + UI_CSS + RESULT_CSS;
 
-// ── score-over-time chart (inline SVG, no deps, no gradients) ─────────────────
-// score 0 at top (cleaner), 100 at bottom (sloppier). The dashed guide marks the
-// Clean/Mild boundary (10). Drawn only when there are at least two points.
-function chartPoints(history) {
-  return (history || []).filter((h) => typeof h.score === 'number').slice(-30);
-}
-
-function ChartSvg({ pts }) {
-  const W = 640,
-    H = 140,
-    padX = 8,
-    padTop = 10,
-    padBot = 22;
-  const innerW = W - padX * 2,
-    innerH = H - padTop - padBot;
-  const x = (i) => padX + (innerW * i) / (pts.length - 1);
-  const y = (s) => padTop + (innerH * Math.max(0, Math.min(100, s))) / 100;
-  const line = pts
-    .map((p, i) => `${i ? 'L' : 'M'}${x(i).toFixed(1)},${y(p.score).toFixed(1)}`)
-    .join(' ');
-  const cleanY = y(10).toFixed(1);
+// Shared document shell. `head` is the per-state <head> content; `script` is the
+// optional inline progressive-enhancement JS.
+function Doc({
+  head,
+  noindex = false,
+  origin = '',
+  domain = '',
+  rescan = false,
+  children,
+  script = null,
+}: {
+  head?: any;
+  noindex?: boolean;
+  origin?: string;
+  domain?: string;
+  rescan?: boolean;
+  children?: any;
+  script?: any;
+}) {
   return (
-    <svg
-      class="chart"
-      viewBox={`0 0 ${W} ${H}`}
-      role="img"
-      aria-label="slop score over time"
-      preserveAspectRatio="none"
-    >
-      <line
-        x1={padX}
-        y1={cleanY}
-        x2={W - padX}
-        y2={cleanY}
-        stroke="var(--border-2)"
-        stroke-width="1"
-        stroke-dasharray="3 4"
-      ></line>
-      <text
-        x={padX}
-        y={(Number(cleanY) - 4).toFixed(1)}
-        fill="var(--dim)"
-        font-size="9"
-        font-family="var(--mono)"
-      >
-        clean ≤10
-      </text>
-      <path
-        d={line}
-        fill="none"
-        stroke="var(--accent)"
-        stroke-width="1.5"
-        stroke-linejoin="round"
-        stroke-linecap="round"
-      ></path>
-      {pts.map((p, i) => {
-        const c = tierColors(p.tier);
-        const last = i === pts.length - 1;
-        return (
-          <circle
-            cx={x(i).toFixed(1)}
-            cy={y(p.score).toFixed(1)}
-            r={last ? 3.6 : 2.2}
-            fill={c.fg}
-          ></circle>
-        );
-      })}
-    </svg>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        {head}
+        {noindex ? <meta name="robots" content="noindex" /> : null}
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        {raw(BRAND_FONTS_HEAD)}
+        <style>{raw(CSS)}</style>
+      </head>
+      <body>
+        <Nav origin={origin} current="" rescan={rescan} />
+        <main>{children}</main>
+        <Footer origin={origin} domain={domain} meta="a fingerprint, not a verdict · MIT" />
+        <div class="flash" id="flash" role="status" aria-live="polite" />
+        {script ? <script>{raw(script)}</script> : null}
+      </body>
+    </html>
   );
 }
 
-function AxisChip({ label, score, tier, suffix = '/100' }) {
-  const c = tierColors(tier);
-  return (
-    <div class="axis">
-      <div class="axis-k">{label}</div>
-      <div class="axis-v" style={`color:${c.fg}`}>
-        {score}
-        <small>{suffix}</small>
-      </div>
-      <div class="axis-t" style={`color:${c.fg}`}>
-        {tier || ''}
-      </div>
-    </div>
-  );
+function htmlResponse(node: any, { status = 200, cache = 'public, max-age=120' } = {}) {
+  return new Response('<!doctype html>' + node.toString(), {
+    status,
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': cache },
+  });
 }
 
 export async function onRequestGet({ params, request, env }) {
   const origin = new URL(request.url).origin;
+  const preview = new URL(request.url).searchParams.get('preview');
   const domain = normalizeDomain(String(params.domain || ''));
+
   if (!domain) {
     return new Response('Invalid domain', {
       status: 400,
@@ -129,92 +113,127 @@ export async function onRequestGet({ params, request, env }) {
     });
   }
 
-  let latest = null,
-    watch = null,
-    history = [],
-    listing = null,
-    pct = null;
-  if (env.RESULTS) {
-    [latest, watch, history, listing] = await Promise.all([
-      getLatestForDomain(env.RESULTS, domain).catch(() => null),
-      getWatch(env.RESULTS, domain).catch(() => null),
-      getHistory(env.RESULTS, domain).catch(() => []),
-      getListing(env.RESULTS, domain).catch(() => null),
-    ]);
-    if (latest) pct = await percentileForScore(env.RESULTS, latest.score).catch(() => null);
+  // ── GAP-FILL preview states (design "Motion and interaction states") ─────────
+  // /score is server-rendered from KV, so these never appear for resolved data;
+  // they are reachable via ?preview= for QA / screenshot capture and are the same
+  // components /r's design loading phase and the scan-failure path reuse.
+  if (preview === 'loading') {
+    const node = (
+      <Doc
+        head={<title>{`${domain} · scanning · slop-detect`}</title>}
+        noindex
+        origin={origin}
+        domain={domain}
+      >
+        <ResultLoading domain={domain} />
+      </Doc>
+    );
+    return htmlResponse(node, { status: 200, cache: 'no-store' });
   }
+  if (preview === 'error') {
+    const node = (
+      <Doc
+        head={<title>{`${domain} · score unavailable · slop-detect`}</title>}
+        noindex
+        origin={origin}
+        domain={domain}
+      >
+        <ResultError domain={domain} origin={origin} />
+      </Doc>
+    );
+    return htmlResponse(node, { status: 200, cache: 'no-store' });
+  }
+
+  // ── error / retry state (GAP-FILL): scoring store unavailable ────────────────
+  // RESULTS binding missing is a misconfiguration, not "never scanned" — surface an
+  // honest retry state rather than a misleading "no scan recorded" 404.
+  if (!env.RESULTS) {
+    const node = (
+      <Doc
+        head={<title>{`${domain} · score unavailable · slop-detect`}</title>}
+        noindex
+        origin={origin}
+        domain={domain}
+      >
+        <ResultError
+          domain={domain}
+          origin={origin}
+          message="Scoring is temporarily unavailable."
+        />
+      </Doc>
+    );
+    return htmlResponse(node, { status: 503, cache: 'no-store' });
+  }
+
+  const [latest, watch, history, listing, dist] = await Promise.all([
+    getLatestForDomain(env.RESULTS, domain).catch(() => null),
+    getWatch(env.RESULTS, domain).catch(() => null),
+    getHistory(env.RESULTS, domain).catch(() => []),
+    getListing(env.RESULTS, domain).catch(() => null),
+    getScoreDistribution(env.RESULTS).catch(() => null),
+  ]);
   const pub = watch ? publicWatch(watch, history) : null;
   const claimed = !!listing;
 
-  // ── empty state ────────────────────────────────────────────────────────────
+  // ── empty state: never-scanned domain (404 + scan CTA) ───────────────────────
   if (!latest) {
-    const emptyCss = `
-  body{padding:48px 20px}.wrap{max-width:680px;margin:0 auto}
-  h1{font-size:26px;font-weight:700;letter-spacing:-0.02em;margin:6px 0}
-  .empty{color:var(--muted);margin:18px 0 26px}
-  .btn{display:inline-block;background:var(--text);color:#000;border-radius:8px;padding:11px 20px;font-weight:600;text-decoration:none}
-`;
-    const emptyDoc = (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta name="viewport" content="width=device-width,initial-scale=1" />
-          <title>{`${domain} · slop score · slop-detect`}</title>
-          <meta
-            name="description"
-            content={`No slop scan recorded for ${domain} yet. Scan it to score how AI-generated its landing page looks.`}
-          />
-          <link rel="canonical" href={`${ORIGIN}/score/${domain}`} />
-          <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-          {raw(BRAND_FONTS_HEAD)}
-          <style>{raw(BRAND_CSS + emptyCss)}</style>
-        </head>
-        <body>
-          <div class="wrap">
-            <div class="eyebrow">
-              <span class="reg">§score</span>
-              <span class="reg-label">domain record</span>
+    const node = (
+      <Doc
+        head={
+          <>
+            <title>{`${domain} · slop score · slop-detect`}</title>
+            <meta
+              name="description"
+              content={`No slop scan recorded for ${domain} yet. Scan it to score how AI-generated its landing page looks.`}
+            />
+            <link rel="canonical" href={`${ORIGIN}/score/${domain}`} />
+          </>
+        }
+        origin={origin}
+        domain={domain}
+      >
+        <div class="result">
+          <div class="result-section re">
+            <SectionLedger tag="" label="domain record" />
+            <h1 class="re-h" style="margin-top:14px">
+              {domain}
+            </h1>
+            <p class="re-body">No scan recorded for this domain yet.</p>
+            <div class="re-row">
+              <a class="btn btn-primary" href={`${origin}/?url=${encodeURIComponent(domain)}`}>
+                Scan {domain} →
+              </a>
             </div>
-            <h1>{domain}</h1>
-            <p class="empty">No scan recorded for this domain yet.</p>
-            <a class="btn" href={`${origin}/?url=${encodeURIComponent(domain)}`}>
-              Scan {domain} →
-            </a>
           </div>
-        </body>
-      </html>
+        </div>
+      </Doc>
     );
-    return new Response('<!doctype html>' + emptyDoc.toString(), {
-      status: 404,
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-        'Cache-Control': 'public, max-age=60',
-      },
-    });
+    return htmlResponse(node, { status: 404, cache: 'public, max-age=60' });
   }
 
-  const c = tierColors(latest.tier);
-  const ogImg = `${origin}/og/${latest.id}.png`;
+  // ── full result ──────────────────────────────────────────────────────────────
+  const view = buildResultView(latest);
   const pageUrl = `${ORIGIN}/score/${domain}`;
+  const ogImg = `${origin}/og/${latest.id}.png`;
   const title = `${domain} scored ${latest.grade} (${latest.score}/100) on the AI-slop detector`;
   const desc =
     latest.verdict ||
     `${latest.patternsFlagged}/${latest.patternsTotal} AI-design-slop patterns triggered.`;
 
-  const showPeer = !!(pct && pct.count >= 5 && pct.cleanerThanPct != null);
-
-  // axes that actually ran
-  const axes = [<AxisChip label="design" score={latest.score} tier={latest.tier} />];
-  if (latest.axes && latest.axes.copy) {
-    const cp = latest.axes.copy;
-    axes.push(<AxisChip label="copy" score={cp.score} tier={cp.tier} />);
+  // Peer rank, derived from the same distribution that backs the percentile. Shown
+  // only once the corpus is large enough to be meaningful (>= 5 scans).
+  const pct = dist
+    ? percentileFromDistribution(dist, latest.score)
+    : { count: 0, cleanerThanPct: null };
+  let rank: { n: number; of: number; cleanerThanPct: number } | null = null;
+  if (pct.count >= 5 && pct.cleanerThanPct != null) {
+    const worse = Math.round((pct.count * pct.cleanerThanPct) / 100);
+    rank = {
+      n: Math.max(1, Math.min(pct.count, pct.count - worse)),
+      of: pct.count,
+      cleanerThanPct: pct.cleanerThanPct,
+    };
   }
-  if (latest.system) {
-    axes.push(<AxisChip label="system" score={latest.system.score} tier={latest.system.tier} />);
-  }
-
-  const pts = chartPoints(history);
-  const tells = (latest.triggered || []).slice(0, 10);
 
   const jsonLd = jsonForScript({
     '@context': 'https://schema.org',
@@ -229,256 +248,98 @@ export async function onRequestGet({ params, request, env }) {
   });
 
   const shareText = `${domain} scored ${latest.grade} (${latest.score}/100) on the AI-design-slop detector. ${latest.verdict || ''}`;
-  const SCRIPT = `
-  const flash=(m)=>{const f=document.getElementById('flash');f.textContent='✓ '+m;f.classList.add('show');setTimeout(()=>f.classList.remove('show'),1600)};
-  const copy=async(t,m)=>{try{await navigator.clipboard.writeText(t);flash(m)}catch(e){}};
-  const bm=document.getElementById('badgeMd');
-  if(bm)bm.addEventListener('click',()=>copy(bm.textContent,'Badge copied'));
-  const sx=document.getElementById('shareX');
-  if(sx)sx.addEventListener('click',()=>{
-    const text=${jsonForScript(shareText)};
-    window.open('https://twitter.com/intent/tweet?text='+encodeURIComponent(text)+'&url='+encodeURIComponent(${jsonForScript(pageUrl)}),'_blank','noopener');
+  const badgeMd = `[![slop](${origin}/badge/${domain}.svg)](${pageUrl})`;
+  const script = resultScript({
+    shareText,
+    shareUrl: pageUrl,
+    fixPrompt: assembleFixPrompt(latest, view),
+    badgeMd,
+    domain,
+    claim: !claimed,
   });
-  const cf=document.getElementById('claimForm');
-  if(cf)cf.addEventListener('submit',async(e)=>{
-    e.preventDefault();
-    const email=document.getElementById('claimEmail').value.trim();
-    const msg=document.getElementById('claimMsg');
-    msg.textContent='Submitting…';
-    try{
-      const r=await fetch('/api/watch',{method:'POST',headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({domain:${jsonForScript(domain)},email,list:true})});
-      const j=await r.json().catch(()=>({}));
-      msg.textContent=r.ok?(j.note||'Check your email to confirm and switch on alerts.'):(j.error||'Could not submit. Try again.');
-    }catch(_){msg.textContent='Network error. Try again.';}
-  });
-`;
 
-  const PAGE_CSS = `
-  body{padding:40px 20px 80px}
-  .wrap{max-width:680px;margin:0 auto}
-  .brand{font-size:14px;font-weight:600;margin-bottom:22px}
-  .brand .slash{color:var(--dim);font-weight:400}
-  h1{font-size:26px;font-weight:700;letter-spacing:-0.02em;margin:6px 0 2px;word-break:break-all}
-  h1 a{color:inherit;text-decoration:underline;text-decoration-color:var(--border-2)}
-  .meta{color:var(--dim);font-size:12.5px;font-family:var(--mono);margin-bottom:22px}
-  .hero{display:flex;align-items:center;gap:26px;background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:26px 28px}
-  .grade{font-size:92px;font-weight:800;line-height:.82;letter-spacing:-0.04em;font-family:var(--mono);color:${c.fg}}
-  .hmeta{display:flex;flex-direction:column;gap:7px}
-  .score{font-size:32px;font-weight:700;letter-spacing:-0.02em;font-family:var(--mono)}
-  .score small{font-size:17px;color:var(--muted);font-weight:500}
-  .tier{align-self:flex-start;font-size:13px;font-weight:700;padding:3px 13px;border-radius:999px;border:1.5px solid ${c.fg};color:${c.fg}}
-  .flagged{font-size:12.5px;color:var(--muted)}
-  .verdict{margin:20px 2px 0;font-size:17px;color:var(--text-2);line-height:1.45}
-  .peer{margin:14px 2px 0;font-size:14px;color:var(--muted)}.peer strong{color:var(--text)}
-  .axes{display:flex;gap:12px;flex-wrap:wrap;margin:24px 0 4px}
-  .axis{flex:1;min-width:120px;background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:14px 16px}
-  .axis-k{font-family:var(--mono);font-size:10.5px;color:var(--dim);text-transform:uppercase;letter-spacing:.05em}
-  .axis-v{font-size:26px;font-weight:700;font-family:var(--mono);margin-top:6px;letter-spacing:-0.02em}
-  .axis-v small{font-size:13px;color:var(--dim)}
-  .axis-t{font-size:12px;font-weight:600;margin-top:2px}
-  h2{font-size:13px;font-weight:700;font-family:var(--mono);text-transform:uppercase;letter-spacing:.05em;color:var(--dim);margin:30px 0 10px}
-  .chartwrap{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:14px}
-  .chart{width:100%;height:140px;display:block}
-  .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:24px}
-  .btn{display:inline-block;background:var(--text);color:#000;border:0;border-radius:8px;padding:10px 18px;font-size:14px;font-weight:600;cursor:pointer;font-family:inherit;text-decoration:none}
-  .btn.ghost{background:transparent;color:var(--text);border:1px solid var(--border-2)}
-  .btn:hover{opacity:.88}
-  .tells{list-style:none;margin-top:4px}
-  .tells li{padding:7px 0;border-bottom:1px solid var(--bg-2);font-size:14px;display:flex;align-items:center;gap:10px}
-  .tells .x{color:var(--red)}.tells .w{margin-left:auto;color:var(--red);font-size:12px;font-family:var(--mono)}
-  .claim{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:20px 22px;margin-top:30px}
-  .claim.claimed{border-color:var(--border-2)}
-  .claim-h{font-weight:700;font-size:15px;margin-bottom:6px}
-  .claim p{color:var(--muted);font-size:13.5px;line-height:1.5}
-  .claim a{color:var(--accent)}
-  .claimform{display:flex;gap:8px;margin-top:14px;flex-wrap:wrap}
-  .claimform input{flex:1;min-width:200px;background:var(--bg-2);border:1px solid var(--border-2);border-radius:8px;padding:10px 13px;color:var(--text);font-family:var(--mono);font-size:13px}
-  .claimform button{background:var(--accent);color:var(--accent-ink);border:0;border-radius:8px;padding:10px 18px;font-weight:700;font-size:13px;cursor:pointer;font-family:inherit}
-  .claim-msg{margin-top:10px;font-size:13px;color:var(--text-2)}
-  .embed{margin-top:30px}
-  .embed-row{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
-  .embed pre{margin:10px 0 0;background:var(--bg-2);border:1px solid var(--border);border-radius:8px;padding:12px 14px;font-family:var(--mono);font-size:12px;color:var(--muted);white-space:pre-wrap;overflow-wrap:anywhere;cursor:pointer}
-  footer{margin-top:36px;font-family:var(--mono);font-size:11.5px;color:var(--dim);line-height:1.7}
-  footer a{color:var(--muted)}
-  .flash{position:fixed;bottom:26px;left:50%;transform:translateX(-50%);background:var(--green);color:#003314;padding:9px 18px;border-radius:8px;font-weight:600;font-size:13px;opacity:0;transition:opacity .2s;pointer-events:none}
-  .flash.show{opacity:1}
-  @media(max-width:520px){.grade{font-size:68px}.hero{gap:16px;padding:20px}}
-`;
-
-  const doc = (
-    <html lang="en">
-      <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
-        <title>{title}</title>
-        <meta name="description" content={desc} />
-        <link rel="canonical" href={pageUrl} />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={desc} />
-        <meta property="og:image" content={ogImg} />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
-        <meta property="og:url" content={pageUrl} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={title} />
-        <meta name="twitter:description" content={desc} />
-        <meta name="twitter:image" content={ogImg} />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <script type="application/ld+json">{raw(jsonLd)}</script>
-        {raw(BRAND_FONTS_HEAD)}
-        <style>{raw(BRAND_CSS + PAGE_CSS)}</style>
-      </head>
-      <body>
-        <div class="wrap">
-          <div class="brand">
-            <a href="/" style="color:inherit">
-              {raw('slop&#8209;detect')}
-            </a>{' '}
-            <span class="slash">/ score</span>
-          </div>
-          <div class="eyebrow">
-            <span class="reg">§score</span>
-            <span class="reg-label">domain record</span>
-          </div>
-          <h1>
-            {claimed ? (
-              <a href={`https://${domain}`} rel="dofollow">
-                {domain}
-              </a>
-            ) : (
-              domain
-            )}
-          </h1>
-          <div class="meta">
-            last scan {(latest.createdAt || '').replace('T', ' ').slice(0, 16)} UTC · defs{' '}
-            {latest.definitionsVersion || 'n/a'}
-            {pub?.monitoring ? ' · monitored' : ''}
-          </div>
-
-          <section class="hero">
-            <div class="grade">{latest.grade}</div>
-            <div class="hmeta">
-              <div class="score">
-                {latest.score}
-                <small>/100</small>
-              </div>
-              <div class="tier">{latest.tier}</div>
-              <div class="flagged">
-                {latest.patternsFlagged}/{latest.patternsTotal} patterns triggered · lower is better
-              </div>
-            </div>
-          </section>
-          {latest.verdict ? <div class="verdict">{latest.verdict}</div> : null}
-          {showPeer ? (
-            <div class="peer">
-              Cleaner than <strong>{pct.cleanerThanPct}%</strong> of{' '}
-              {pct.count.toLocaleString('en-US')} scans on record
-            </div>
-          ) : null}
-
-          <div class="axes">{axes}</div>
-
-          {pts.length >= 2 ? (
-            <>
-              <h2>Score over time</h2>
-              <div class="chartwrap">
-                <ChartSvg pts={pts} />
-              </div>
-            </>
-          ) : null}
-
-          <div class="actions">
-            <a class="btn" href={`${origin}/?url=${encodeURIComponent(domain)}`}>
-              Re-scan
-            </a>
-            <a class="btn ghost" href={`${origin}/r/${latest.id}`}>
-              This scan
-            </a>
-            <a class="btn ghost" href={`${origin}/report/${domain}`}>
-              Printable report
-            </a>
-            <button class="btn ghost" id="shareX">
-              Share
-            </button>
-          </div>
-
-          {tells.length ? (
-            <>
-              <h2>Triggered patterns</h2>
-              <ul class="tells">
-                {tells.map((t) => (
-                  <li>
-                    <span class="x">✗</span> {t.label || t.short || t.id}{' '}
-                    <span class="w">+{t.weight}</span>
-                  </li>
-                ))}
-              </ul>
-            </>
-          ) : null}
-
-          {claimed ? (
-            <div class="claim claimed">
-              <div class="claim-h">
-                Listed in the <a href={`${origin}/directory`}>directory</a>
-              </div>
-              <p>
-                This domain is claimed and monitored. It carries a dofollow backlink:{' '}
-                <a href={`https://${domain}`} rel="dofollow">
-                  {domain}
-                </a>
-                .
-              </p>
-            </div>
-          ) : (
-            <div class="claim">
-              <div class="claim-h">Claim this page</div>
-              <p>
-                Own {domain}? Verify by email to list it in the directory (a real dofollow backlink)
-                and get an alert if it ever drifts back into slop.
-              </p>
-              <form id="claimForm" class="claimform" novalidate>
-                <input
-                  id="claimEmail"
-                  type="email"
-                  inputmode="email"
-                  placeholder={`you@${domain}`}
-                  required
-                />
-                <button type="submit">Claim + monitor</button>
-              </form>
-              <div id="claimMsg" class="claim-msg"></div>
-            </div>
-          )}
-
-          <div class="embed">
-            <h2>Embed the live badge</h2>
-            <div class="embed-row">
-              <img
-                src={`${origin}/badge/${domain}.svg`}
-                alt={`slop badge for ${domain}`}
-                height="20"
-              />
-              <span style="font-size:13px;color:var(--muted)">live · re-scans periodically</span>
-            </div>
-            <pre id="badgeMd">{`[![slop](${origin}/badge/${domain}.svg)](${pageUrl})`}</pre>
-          </div>
-
-          <footer>
-            Scores are deterministic, named checks: a fingerprint, not a verdict. Reproduce: npx
-            slop-detect {domain} · <a href={`${origin}/`}>slop-detect.com</a>
-          </footer>
-        </div>
-        <div class="flash" id="flash">
-          ✓ Copied
-        </div>
-        <script>{raw(SCRIPT)}</script>
-      </body>
-    </html>
+  const head = (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={desc} />
+      <link rel="canonical" href={pageUrl} />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={desc} />
+      <meta property="og:image" content={ogImg} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:url" content={pageUrl} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={desc} />
+      <meta name="twitter:image" content={ogImg} />
+      <script type="application/ld+json">{raw(jsonLd)}</script>
+    </>
   );
 
-  return new Response('<!doctype html>' + doc.toString(), {
-    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=120' },
-  });
+  const node = (
+    <Doc head={head} origin={origin} domain={domain} rescan script={script}>
+      <div class="result">
+        <section class="result-section">
+          <DomainHeader slim={latest} monitored={!!pub?.monitoring} />
+          <BigScore slim={latest} rank={rank} origin={origin} />
+        </section>
+
+        <section class="result-section">
+          <div class="rs-ledger">
+            <SectionLedger tag="" label="category overview" />
+          </div>
+          <CategoryBars categories={view.categories} />
+        </section>
+
+        <section class="result-section">
+          <Breakdown
+            categories={view.categories}
+            flaggedTotal={view.flaggedTotal}
+            patternsTotal={view.patternsTotal}
+          />
+        </section>
+
+        <section class="result-section">
+          <div class="rs-ledger">
+            <SectionLedger tag="" label="the four axes" />
+          </div>
+          <AxisStrip slim={latest} />
+        </section>
+
+        <section class="result-section">
+          <div class="rs-ledger">
+            <SectionLedger tag="" label="system & aeo detail" />
+          </div>
+          <SystemAeoCards slim={latest} />
+        </section>
+
+        <section class="result-section">
+          <div class="rs-ledger">
+            <SectionLedger tag="" label="competitive analytics" />
+          </div>
+          <Analytics history={history} dist={dist} slim={latest} categories={view.categories} />
+        </section>
+
+        <section class="result-section">
+          <FixesPanel fixes={view.fixes} domain={domain} />
+        </section>
+
+        <section class="result-section">
+          <ShareEmbed slim={latest} origin={origin} pageUrl={pageUrl} />
+        </section>
+
+        <section class="result-section">
+          <ClaimPanel slim={latest} origin={origin} claimed={claimed} />
+        </section>
+
+        <section class="result-section">
+          <MonitorCard domain={domain} />
+        </section>
+      </div>
+    </Doc>
+  );
+
+  return htmlResponse(node, { status: 200, cache: 'public, max-age=120' });
 }

--- a/apps/web/test/score.test.js
+++ b/apps/web/test/score.test.js
@@ -43,13 +43,24 @@ function slim(over = {}) {
   };
 }
 
-async function render(kv, domainParam) {
+async function render(kv, domainParam, opts = {}) {
+  const query = opts.query || '';
+  const env = 'env' in opts ? opts.env : { RESULTS: kv };
   const res = await onRequestGet({
     params: { domain: domainParam },
-    request: { url: `https://slop-detect.com/score/${domainParam}` },
-    env: { RESULTS: kv },
+    request: { url: `https://slop-detect.com/score/${domainParam}${query}` },
+    env,
   });
   return { status: res.status, html: await res.text(), res };
+}
+
+// The page's OWN CSS must stay dogfood-clean, but the Fixes panel legitimately
+// QUOTES slop tells in its remediation copy ("replace Inter…", "no background-clip:
+// text on H1"). So the anti-slop guardrail is checked against the <style> block, not
+// the body prose.
+function styleOf(html) {
+  const m = html.match(/<style>([\s\S]*?)<\/style>/);
+  return m ? m[1] : '';
 }
 
 test('invalid domain returns 400', async () => {
@@ -126,4 +137,68 @@ test('the page links to this scan, the printable report, and a re-scan', async (
   expect(html).toMatch(/href="https:\/\/slop-detect\.com\/r\/sc0re001"/);
   expect(html).toMatch(/href="https:\/\/slop-detect\.com\/report\/ex\.com"/);
   expect(html).toMatch(/\/\?url=ex\.com/);
+});
+
+test('the densest sections render: 120px numeral, category bars, breakdown, axes', async () => {
+  const kv = makeKv();
+  const s = slim();
+  await saveResult(kv, s);
+  await recordScan(kv, s);
+  const { html } = await render(kv, 'ex.com');
+  // the big serif numeral (120px token) and the score/100 readout
+  expect(styleOf(html)).toMatch(/--fs-score:\s*120px/);
+  expect(html).toMatch(/class="bs-num"/);
+  // five-up category bars, the expandable breakdown (keyboard-operable), the strip
+  expect(html).toMatch(/class="cbar-fill"/);
+  expect(html).toMatch(/data-toggle/);
+  expect(html).toMatch(/aria-expanded/);
+  expect(html).toMatch(/lower is better/); // four-axis polarity note
+  expect(html).toMatch(/competitive analytics/);
+  expect(html).toMatch(/Copy the full fix prompt/);
+});
+
+test('the first dirty breakdown category is open by default', async () => {
+  const kv = makeKv();
+  const s = slim(); // slop_fonts triggered → the Type category is dirty
+  await saveResult(kv, s);
+  await recordScan(kv, s);
+  const { html } = await render(kv, 'ex.com');
+  expect(html).toMatch(/data-open="1"/); // at least one category opens
+  expect(html).toMatch(/aria-expanded="true"/);
+});
+
+test('loading placeholder renders a scanning skeleton (?preview=loading)', async () => {
+  const { status, html } = await render(makeKv(), 'ex.com', { query: '?preview=loading' });
+  expect(status).toBe(200);
+  expect(html).toMatch(/scanning…/);
+  expect(html).toMatch(/aria-busy="true"/);
+  expect(html).toMatch(/name="robots" content="noindex"/);
+});
+
+test('error/retry state renders when the scoring store is unavailable', async () => {
+  // No RESULTS binding is a misconfiguration, not "never scanned": surface an
+  // honest 503 retry state, never a misleading clean/empty page.
+  const { status, html } = await render(makeKv(), 'ex.com', { env: {} });
+  expect(status).toBe(503);
+  expect(html).toMatch(/Score unavailable/);
+  expect(html).toMatch(/Retry/);
+  expect(html).toMatch(/\/\?url=ex\.com/); // a rescan escape hatch
+  expect(html).toMatch(/name="robots" content="noindex"/);
+});
+
+test('the page is dogfood-clean: its own CSS uses no slop fonts, gradients, or clip-text', async () => {
+  const kv = makeKv();
+  const s = slim(); // slop_fonts triggered → fix copy QUOTES "Inter" in the body
+  await saveResult(kv, s);
+  await recordScan(kv, s);
+  const { html } = await render(kv, 'ex.com');
+  const css = styleOf(html);
+  expect(css, 'no slop font-family').not.toMatch(/font-family:[^;}]*(Inter|Geist|Space Grotesk)/i);
+  expect(css, 'no gradient text').not.toMatch(/background-clip:\s*text/i);
+  expect(css, 'no gradient surfaces').not.toMatch(/(linear|radial)-gradient/i);
+  // the light editorial-instrument families are the ones actually loaded
+  expect(css).toMatch(/Newsreader/);
+  expect(css).toMatch(/JetBrains Mono/);
+  // the remediation copy legitimately names the banned font — proof we scoped right
+  expect(html).toMatch(/Inter/);
 });


### PR DESCRIPTION
Phase C build task 03 (`score-hub`) per docs/parity-spec.md. Rebased onto current main. Acceptance = parity-spec "### Build task 03" (design fidelity + functional parity / MNR floor + real green tests + dogfood/responsive/a11y). Full web suite + typecheck green per the build worker; clean commit (Ravindra Kumar, no trailers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of a public, SEO-facing page and claim flow wiring, though behavior stays data-driven with no new backend contracts beyond existing distribution helpers.
> 
> **Overview**
> Introduces **`_result.tsx`**, a shared Result screen used by `/score/:domain` (and intended for `/r` and `/report`). Slim KV records are joined to engine metadata (`PATTERNS` / `FIXES` / `AEO_CHECKS`) to rebuild category bars, breakdown, fixes, and charts without inventing unpersisted data (e.g. AEO pass/fail checklist only, no fake corpus radar averages).
> 
> **`/score/:domain`** drops its bespoke layout and inline chart/CSS in favor of the shared shell (`Nav` / `Footer` / `MonitorCard`) plus the new sections: big score block with peer rank from **`getScoreDistribution`** / **`percentileFromDistribution`**, category overview, expandable breakdown, four-axis strip, system/AEO cards, analytics (time series, radar, distribution histogram), fixes panel with copyable prompt, share/embed, and claim panel. Adds **`?preview=loading|error`**, a **503** when `RESULTS` is missing, and consolidated **`resultScript`** for copy, share, toggles, and claim POST.
> 
> **`score.test.js`** gains coverage for the denser UI, preview/error paths, and dogfood CSS checks scoped to `<style>` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36326b005eac1ab209025a543df49b72b974d405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->