### PR TITLE
feat(web): directory (parity-spec build task 07)

### DIFF
--- a/apps/web/functions/directory.tsx
+++ b/apps/web/functions/directory.tsx
@@ -6,89 +6,122 @@
 // Each row links OUT to the original site with a real (dofollow) backlink — the
 // catalogue ranks for "is <site> AI slop", sends link equity to listed sites,
 // and the backlink is the incentive that pulls owners into the claim + monitor
-// funnel (see VALIDATION.md).
+// funnel (see VALIDATION.md). Opt-in only: the directory never publishes an
+// unrequested verdict on a company (MNR-27).
 //
-// Anti-slop by construction: no Inter/Geist, no gradient text, no VibeCode
-// purple, no glows — this page should itself score Clean on slop-detect.
+// Rebuilt as a full page in the design's "3. Leaderboard > 6. Directory (opt-in
+// only)" language: the shared nav/footer shell, the 1.5px ink section-ledger,
+// then owner-listed rows on the directory grid `26px 22px 1fr auto auto`
+// (rank, letter-avatar chip, name + domain, "listed <date>", score/grade).
+//
+// Anti-slop by construction: it composes the shared _ui components and the light
+// BRAND_CSS tokens — no Inter/Geist, no gradient text, no VibeCode purple, flat
+// 1px surfaces — so this page itself scores Clean on slop-detect.
 
 import { raw } from 'hono/html';
 import { listAllSites, tierColors, jsonForScript } from './_shared.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
+import { Nav, Footer, LetterAvatar, ScanInput, SectionLedger, UI_CSS } from './_ui.js';
 
 const ORIGIN = 'https://slop-detect.com';
 
 const PAGE_CSS = `
-  body{padding:48px 20px 80px}
-  .wrap{max-width:820px;margin:0 auto}
-  header{border-bottom:1px solid var(--border);padding-bottom:20px;margin-bottom:8px}
-  h1{font-size:30px;font-weight:700;letter-spacing:-0.02em;margin:2px 0 8px}
-  .sub{color:var(--muted);font-size:15px;max-width:60ch}
-  .sub a{color:var(--text);text-decoration:underline;text-underline-offset:2px}
-  .bar{display:flex;justify-content:space-between;align-items:center;
-       font-family:var(--mono);font-size:12px;color:var(--dim);
-       padding:14px 2px 8px}
-  .bar a{color:var(--text-2);text-decoration:none;border-bottom:1px solid var(--border-2);padding-bottom:1px}
-  .bar a:hover{color:var(--text)}
-  ol{list-style:none}
-  .r{display:grid;grid-template-columns:34px 78px 64px 1fr auto;gap:12px;align-items:baseline;
-     padding:13px 2px;border-bottom:1px solid var(--bg-2);font-size:15px}
-  .g{font-family:var(--mono);font-weight:700;font-size:14px;
-     border:1px solid;border-radius:5px;text-align:center;padding:1px 0}
-  .sc{font-family:var(--mono);color:var(--text-2);font-size:13px}
-  .sc small{color:var(--dim);font-size:11px}
-  .t{font-family:var(--mono);font-size:12px}
-  .d{min-width:0;overflow:hidden}
-  .dom{font-weight:600;text-decoration:none;border-bottom:1px solid var(--border-2);padding-bottom:1px}
-  .dom:hover{border-color:var(--text)}
-  .ti{display:block;color:var(--dim);font-size:12.5px;margin-top:2px;
-      white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .scan{font-family:var(--mono);font-size:11.5px;color:var(--dim);text-decoration:none;white-space:nowrap}
-  .scan:hover{color:var(--text)}
-  .empty{padding:28px 2px;color:var(--muted)}
-  .empty a{color:var(--text)}
-  footer{margin-top:28px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
-  footer a{color:var(--muted)}
-  @media(max-width:560px){
-    .r{grid-template-columns:30px 1fr auto;gap:8px}
-    .t,.scan{display:none}
+  .wrap{max-width:760px;margin:0 auto;padding:52px var(--pad-x) 0}
+  h1{font-family:var(--serif);font-weight:500;font-size:var(--fs-h2-a);line-height:1.02;
+     letter-spacing:-0.02em;color:var(--text);margin:14px 0 0}
+  .dir-count{font-family:var(--mono);font-size:13px;color:var(--text-4);margin-top:16px}
+  .dir-count strong{color:var(--text);font-weight:700}
+  .dir-explain{max-width:60ch;margin-top:10px}
+
+  .dir-bar{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+     font-family:var(--mono);font-size:12px;color:var(--text-4);margin:30px 0 2px}
+  .dir-bar a{color:var(--text-3);border-bottom:1px solid var(--border)}
+  .dir-bar a:hover{color:var(--text);border-color:var(--text)}
+
+  ol.dir{list-style:none}
+  .dir-row{display:grid;grid-template-columns:26px 22px 1fr auto auto;gap:14px;
+     align-items:center;padding:11px 4px;border-bottom:1px solid var(--row)}
+  .dir-row:hover{background:var(--bg-2)}
+  .dir-rank{font-family:var(--mono);font-size:12px;color:var(--text-6);text-align:right}
+  .dir-name{min-width:0;display:flex;flex-direction:column;gap:1px}
+  .dir-link{font-weight:600;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .dir-link:hover{text-decoration:underline;text-underline-offset:2px}
+  .dir-dom{font-family:var(--mono);font-size:12px;color:var(--text-5);
+     overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .dir-listed{font-family:var(--mono);font-size:11.5px;color:var(--text-6);white-space:nowrap;text-align:right}
+  .dir-score{font-family:var(--mono);font-size:13px;color:var(--text-3);white-space:nowrap}
+  .dir-score:hover .dir-sc{color:var(--text)}
+  .dir-grade{font-weight:700}
+  .dir-pending{font-family:var(--mono);font-size:12px;color:var(--text-6);white-space:nowrap}
+
+  .dir-empty{padding:30px 4px;color:var(--text-4);font-size:var(--fs-body);border-bottom:1px solid var(--row)}
+  .dir-empty a{color:var(--text);border-bottom:1px solid var(--border)}
+  .dir-empty a:hover{border-color:var(--text)}
+
+  .dir-add{margin:48px 0 80px;border-top:1.5px solid var(--text);padding-top:22px}
+  .dir-add-h{font-family:var(--serif);font-weight:500;font-size:var(--fs-h2-c);
+     line-height:1.05;letter-spacing:-0.02em;color:var(--text)}
+  .dir-add-body{color:var(--text-2);margin:8px 0 18px;max-width:54ch}
+  .dir-add .scan{max-width:440px}
+
+  @media (max-width:560px){
+    .wrap{padding-top:36px}
+    .dir-row{grid-template-columns:22px 1fr auto;gap:10px}
+    .dir-rank,.dir-listed{display:none}
   }
 `;
 
-function Row({ site, origin }) {
+// Listing dates arrive as ISO strings from KV metadata (listedAt). Format them by
+// slicing the date part — no Date object, so it's deterministic and TZ-free.
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+function formatListed(iso) {
+  if (typeof iso !== 'string' || iso.length < 10) return null;
+  const mon = MONTHS[parseInt(iso.slice(5, 7), 10) - 1];
+  const day = parseInt(iso.slice(8, 10), 10);
+  const year = iso.slice(0, 4);
+  if (!mon || !day || !/^\d{4}$/.test(year)) return null;
+  return `${mon} ${day}, ${year}`;
+}
+
+// One directory row on the `26px 22px 1fr auto auto` grid. The domain link is the
+// dofollow backlink (a plain <a href> with no rel — the gift). The score/grade
+// readout links to the per-domain score hub, closing the re-scan loop. A listed-
+// but-not-yet-scored domain shows "Pending", never "Unlisted" — it IS listed.
+function Row({ site, rank, origin }) {
   const c = tierColors(site.tier);
-  const grade = site.grade || '—';
-  const score = site.score == null ? 'pending' : `${site.score}`;
-  // A listed-but-not-yet-scored domain has tier null — it IS listed, only the
-  // score is pending, so don't mislabel it "Unlisted".
-  const tier = site.tier || 'Pending';
+  const name = site.title || site.domain;
+  const listed = formatListed(site.listedAt);
+  const scored = site.score != null;
   return (
-    <li class="r">
-      <span class="g" style={`color:${c.fg};border-color:${c.fg}`}>
-        {grade}
-      </span>
-      <span class="sc">
-        {score}
-        <small>{site.score == null ? '' : '/100'}</small>
-      </span>
-      <span class="t" style={`color:${c.fg}`}>
-        {tier}
-      </span>
-      <span class="d">
-        {/* The dofollow backlink — a plain <a href> with no rel. This is the gift. */}
-        <a class="dom" href={`https://${site.domain}`}>
-          {site.domain}
+    <li class="dir-row">
+      <span class="dir-rank">{rank}</span>
+      <LetterAvatar name={site.domain} size={20} />
+      <span class="dir-name">
+        <a class="dir-link" href={`https://${site.domain}`}>
+          {name}
         </a>
-        {site.title ? <span class="ti">{site.title}</span> : null}
+        {site.title ? <span class="dir-dom">{site.domain}</span> : null}
       </span>
-      {site.id ? (
-        <a class="scan" href={`${origin}/r/${site.id}`}>
-          {raw('scan&nbsp;&rarr;')}
+      <span class="dir-listed">{listed ? `listed ${listed}` : ''}</span>
+      {scored ? (
+        <a
+          class="dir-score"
+          href={`${origin}/score/${site.domain}`}
+          aria-label={`${site.domain}: slop score ${site.score}, grade ${site.grade || '—'}`}
+        >
+          <span class="dir-sc">{site.score}</span>{' '}
+          <span class="dir-grade" style={`color:${c.fg}`}>
+            {site.grade || '—'}
+          </span>
         </a>
-      ) : null}
+      ) : (
+        <span class="dir-pending">Pending</span>
+      )}
     </li>
   );
 }
 
+// ItemList JSON-LD so the catalogue is machine-readable for search/AEO crawlers.
 function jsonLd(sites) {
   return jsonForScript({
     '@context': 'https://schema.org',
@@ -106,11 +139,14 @@ function jsonLd(sites) {
 }
 
 export async function onRequestGet({ request, env }) {
-  const origin = new URL(request.url).origin;
-  const sort = new URL(request.url).searchParams.get('sort') === 'slop' ? 'slop' : 'clean';
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const sort = url.searchParams.get('sort') === 'slop' ? 'slop' : 'clean';
 
+  // Works with no RESULTS binding: an unconfigured environment renders the empty
+  // state rather than erroring.
   let sites = [];
-  if (env.RESULTS) {
+  if (env?.RESULTS) {
     sites = await listAllSites(env.RESULTS).catch(() => []);
   }
   sites.sort((a, b) => {
@@ -121,8 +157,10 @@ export async function onRequestGet({ request, env }) {
     return sort === 'slop' ? b.score - a.score : a.score - b.score;
   });
 
+  const n = sites.length;
   const other = sort === 'slop' ? 'clean' : 'slop';
   const otherLabel = sort === 'slop' ? 'cleanest first' : 'sloppiest first';
+  const sortLabel = sort === 'slop' ? 'sloppiest first' : 'cleanest first';
 
   const doc = (
     <html lang="en">
@@ -132,7 +170,7 @@ export async function onRequestGet({ request, env }) {
         <title>Directory — sites scored for AI design slop · slop-detect</title>
         <meta
           name="description"
-          content="An opt-in catalogue of websites scored against the AI-design-slop fingerprint. Each listed site links out, ranked by how generic its design reads."
+          content="An opt-in catalogue of websites scored against the AI-design-slop fingerprint. Each listed site links out with a dofollow backlink, ranked by how generic its design reads."
         />
         <link rel="canonical" href={`${ORIGIN}/directory`} />
         <meta property="og:title" content="Directory of sites scored for AI design slop" />
@@ -144,43 +182,51 @@ export async function onRequestGet({ request, env }) {
         <meta property="og:image" content={`${ORIGIN}/og.png`} />
         <script type="application/ld+json">{raw(jsonLd(sites))}</script>
         {raw(BRAND_FONTS_HEAD)}
-        <style>{raw(BRAND_CSS + PAGE_CSS)}</style>
+        <style>{raw(BRAND_CSS + UI_CSS + PAGE_CSS)}</style>
       </head>
       <body>
-        <div class="wrap">
-          <header>
-            <div class="eyebrow">
-              <span class="reg">{raw('&sect;dir')}</span>
-              <span class="reg-label">the directory</span>
+        <Nav origin={origin} />
+        <main class="wrap">
+          <SectionLedger tag="/directory" label="opt-in only" />
+          <h1>The directory</h1>
+          <p class="dir-count">
+            <strong>{n}</strong> site{n === 1 ? '' : 's'} listed {raw('&middot;')} dofollow
+            backlinks
+          </p>
+          <p class="lead dir-explain">
+            Owners opt in to appear here. Scanning is free; listing is a choice. Each row links to
+            the live site and to its score over time.
+          </p>
+
+          {n > 0 ? (
+            <div class="dir-bar">
+              <span>{sortLabel}</span>
+              <a href={`${origin}/directory?sort=${other}`}>sort: {otherLabel}</a>
             </div>
-            <h1>Sites scored for AI design slop</h1>
-            <p class="sub">
-              An opt-in catalogue. Owners <a href={`${origin}/`}>claim their domain</a> to appear
-              here {raw('&mdash;')} with a live badge and a link back to their site. Detection is
-              free; listing is a choice.
-            </p>
-          </header>
-          <div class="bar">
-            <span>
-              {sites.length} site{sites.length === 1 ? '' : 's'} {raw('&middot;')} {sort} first
-            </span>
-            <a href={`${origin}/directory?sort=${other}`}>sort: {otherLabel}</a>
-          </div>
-          <ol>
-            {sites.length ? (
-              sites.map((s) => <Row site={s} origin={origin} />)
+          ) : null}
+
+          <ol class="dir">
+            {n > 0 ? (
+              sites.map((s, i) => <Row site={s} rank={i + 1} origin={origin} />)
             ) : (
-              <li class="empty">
-                No sites listed yet. Scan your site, then <a href={`${origin}/`}>claim it</a> to
-                appear here with a backlink.
+              <li class="dir-empty">
+                No sites listed yet. <a href={`${origin}/`}>Scan a site</a>, then claim it to appear
+                here with a backlink.
               </li>
             )}
           </ol>
-          <footer>
-            Listed by opt-in only. <a href={`${origin}/`}>Scan a site</a> {raw('&middot;')}{' '}
-            <a href="https://github.com/ravidsrk/slop-detect">source</a>
-          </footer>
-        </div>
+
+          <section class="dir-add" aria-labelledby="dir-add-h">
+            <h2 class="dir-add-h" id="dir-add-h">
+              Don't see your site?
+            </h2>
+            <p class="dir-add-body">
+              Scan it, then opt in from the result to list it here with a backlink.
+            </p>
+            <ScanInput variant="leaderboard" id="dir-scan" label="Scan" />
+          </section>
+        </main>
+        <Footer origin={origin} />
       </body>
     </html>
   );

--- a/apps/web/test/sites.test.js
+++ b/apps/web/test/sites.test.js
@@ -162,7 +162,10 @@ test('/directory renders a DOFOLLOW backlink to each listed site', async () => {
   expect(html, 'the backlink must be dofollow').not.toMatch(/rel=["']?nofollow/i);
   expect(html, 'emits ItemList JSON-LD for SEO').toMatch(/application\/ld\+json/);
   // Anti-slop self-check: the directory must not wear the tells it detects.
-  expect(html, 'no slop fonts').not.toMatch(/Inter|Geist|Space Grotesk/i);
+  // Case-sensitive on the font names (matching ui.test.js): the page embeds the
+  // shared UI_CSS, whose `cursor:pointer` contains a lowercase "inter" substring
+  // that an /i match would false-flag. The real slop faces are always capitalized.
+  expect(html, 'no slop fonts').not.toMatch(/Inter|Geist|Space Grotesk/);
   expect(html, 'no gradient text').not.toMatch(/background-clip:\s*text/i);
 });
 


### PR DESCRIPTION
Phase C build task 07 (`directory`) per docs/parity-spec.md. Rebased onto current main. Acceptance = parity-spec "### Build task 07" (design fidelity + functional parity / MNR floor + real green tests + dogfood/responsive/a11y). Full web suite + typecheck green per the build worker; clean commit (Ravindra Kumar, no trailers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public HTML/CSS and link-target changes only; listing data and dofollow/JSON-LD behavior stay aligned with existing tests.
> 
> **Overview**
> **Rebuilds the public `/directory` page** to match the parity-spec “Directory (opt-in only)” design: shared **`Nav`**, **`Footer`**, **`SectionLedger`**, and **`UI_CSS`**, replacing the previous standalone layout.
> 
> **Row model changes:** each listing is a ranked grid row with **`LetterAvatar`**, title (or domain) as the **dofollow** outbound link, optional domain subline, **“listed &lt;date&gt;”** from `listedAt` (string-sliced formatting), and score/grade linking to **`/score/{domain}`** instead of **`/r/{id}`**; unscored listings still show **Pending**. Copy and meta descriptions emphasize opt-in (MNR-27) and dofollow backlinks. A **“Don’t see your site?”** section adds **`ScanInput`**. **`env?.RESULTS`** avoids errors when storage is missing.
> 
> **Test:** the directory anti-slop font assertion is **case-sensitive** so embedded `cursor:pointer` in shared CSS does not false-match “Inter”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0815c8395fccd45fd52b0c32f1d4871ae4b9c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->