### PR TITLE
feat(web): blog (parity-spec build task 09)

### DIFF
--- a/apps/web/functions/blog.tsx
+++ b/apps/web/functions/blog.tsx
@@ -1,34 +1,79 @@
 /** @jsxRuntime automatic @jsxImportSource hono/jsx */
-// GET /blog — the index of posts. Crawlable, server-rendered on the shared brand
-// system (anti-slop), with a Blog JSON-LD for AEO. Content lives in _posts.js.
+// GET /blog — the index of posts. Crawlable, server-rendered on the shared light
+// editorial system (anti-slop), with a Blog JSON-LD for AEO. Content lives in
+// _posts.ts (unchanged); this file only re-skins the presentation.
+//
+// Design (GAP-FILL): the export ships no blog screen, so the index borrows the
+// "Research / article cards" vocabulary — a large feature card for the newest
+// post (Newsreader title + a mono date·read-time footer) beside a stack of plain
+// article links (Newsreader 19px + a mono reference tag). Shell, ledger rule, and
+// footer come from the shared _ui library so it reads as the same product.
 
 import { raw } from 'hono/html';
 import { jsonForScript } from './_render.js';
 import { POSTS } from './_posts.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
+import { Nav, Footer, SectionLedger, UI_CSS } from './_ui.js';
 
 const ORIGIN = 'https://slop-detect.com';
 
+// Reading time from the markdown body, ~200 wpm, floor of one minute.
+function readingMinutes(body: string) {
+  const words = String(body || '')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+  return Math.max(1, Math.round(words / 200));
+}
+
 const PAGE_CSS = `
-  body{padding:48px 20px 80px}
-  .wrap{max-width:680px;margin:0 auto}
-  .brand{font-size:14px;font-weight:600;margin-bottom:22px}
-  .brand .slash{color:var(--dim);font-weight:400}
-  h1{font-size:30px;font-weight:700;letter-spacing:-0.02em;margin:6px 0 6px}
-  .lead{color:var(--muted);margin-bottom:26px;max-width:60ch}
-  .posts{list-style:none}
-  .post{padding:20px 0;border-bottom:1px solid var(--bg-2)}
-  .post-title{font-size:19px;font-weight:700;letter-spacing:-0.01em;text-decoration:none}
-  .post-title:hover{text-decoration:underline}
-  .post-meta{font-family:var(--mono);font-size:11.5px;color:var(--dim);margin-top:4px}
-  .post-sum{color:var(--text-2);font-size:14.5px;margin-top:8px;max-width:62ch}
-  footer{margin-top:36px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
-  footer a{color:var(--muted)}
+  .bl-main{max-width:1080px;margin:0 auto;padding:56px var(--pad-x) 16px}
+  .bl-hd{max-width:60ch;margin:22px 0 40px}
+  .bl-h1{font-family:var(--serif);font-weight:500;font-size:clamp(34px,4.6vw,52px);line-height:1.02;letter-spacing:-0.02em;color:var(--text);margin:0 0 12px}
+  .bl-lead{font-size:var(--fs-lead);line-height:1.55;color:var(--text-2);max-width:58ch}
+
+  /* Research / article cards: a 1.3fr 1fr grid (feature card + a link stack). */
+  .bl-research{display:grid;grid-template-columns:1.3fr 1fr;gap:28px;align-items:start}
+
+  .bl-feature{display:block;border:1px solid var(--border);border-radius:var(--r-6);background:var(--panel);padding:30px 30px 26px;transition:border-color var(--t)}
+  .bl-feature:hover{border-color:var(--text)}
+  .bl-feature-title{font-family:var(--serif);font-weight:500;font-size:var(--fs-h3);line-height:1.08;letter-spacing:-0.01em;color:var(--text)}
+  .bl-feature-sum{font-size:var(--fs-body-sm);line-height:1.55;color:var(--text-3);margin-top:12px;max-width:46ch}
+  .bl-feature-foot{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-top:18px}
+
+  .bl-links{display:flex;flex-direction:column}
+  .bl-link{display:block;padding:18px 0;border-bottom:1px solid var(--border);transition:opacity var(--t)}
+  .bl-link:first-child{padding-top:0}
+  .bl-link:hover{opacity:0.7}
+  .bl-link-title{font-family:var(--serif);font-weight:500;font-size:19px;line-height:1.15;letter-spacing:-0.01em;color:var(--text)}
+  .bl-link-sum{font-size:var(--fs-body-sm);line-height:1.5;color:var(--text-4);margin-top:6px;max-width:44ch}
+  .bl-link-tag{display:block;font-family:var(--mono);font-size:11.5px;color:var(--text-5);margin-top:8px}
+
+  .bl-empty{border:1px solid var(--border);border-radius:var(--r-6);background:var(--panel);padding:30px;color:var(--text-3);font-size:var(--fs-body)}
+  .bl-empty a{color:var(--clean-text);text-decoration:underline;text-underline-offset:2px}
+
+  @media(max-width:900px){.bl-research{grid-template-columns:1fr}}
+  @media(max-width:640px){.bl-main{padding-left:20px;padding-right:20px}}
 `;
+
+// One plain article link in the right-hand stack: serif title, an optional
+// summary, and a mono date·read-time reference tag.
+function ArticleLink({ post, origin }) {
+  return (
+    <a class="bl-link" href={`${origin}/blog/${post.slug}`}>
+      <span class="bl-link-title">{post.title}</span>
+      <span class="bl-link-sum">{post.summary}</span>
+      <span class="bl-link-tag">
+        {post.date} · {readingMinutes(post.body)} min read
+      </span>
+    </a>
+  );
+}
 
 export async function onRequestGet({ request }) {
   const origin = new URL(request.url).origin;
   const posts = POSTS.slice().sort((a, b) => (a.date < b.date ? 1 : -1));
+  const [feature, ...rest] = posts;
 
   const jsonLd = jsonForScript({
     '@context': 'https://schema.org',
@@ -65,42 +110,42 @@ export async function onRequestGet({ request }) {
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <script type="application/ld+json">{raw(jsonLd)}</script>
         {raw(BRAND_FONTS_HEAD)}
-        <style>{raw(BRAND_CSS + PAGE_CSS)}</style>
+        <style>{raw(BRAND_CSS + UI_CSS + PAGE_CSS)}</style>
       </head>
       <body>
-        <div class="wrap">
-          <div class="brand">
-            <a href="/" style="color:inherit">
-              {raw('slop&#8209;detect')}
-            </a>{' '}
-            <span class="slash">/ blog</span>
-          </div>
-          <div class="eyebrow">
-            <span class="reg">{raw('&sect;log')}</span>
-            <span class="reg-label">notes</span>
-          </div>
-          <h1>Blog</h1>
-          <p class="lead">
-            Notes on the AI-design-slop fingerprint: how the score works, why detectors decay, and
-            the durable per-site signal.
-          </p>
-          <ul class="posts">
-            {posts.map((p) => (
-              <li class="post">
-                <a class="post-title" href={`${origin}/blog/${p.slug}`}>
-                  {p.title}
-                </a>
-                <div class="post-meta">{p.date}</div>
-                <p class="post-sum">{p.summary}</p>
-              </li>
-            ))}
-          </ul>
-          <footer>
-            <a href={`${origin}/`}>slop-detect.com</a> {raw('&middot;')}{' '}
-            <a href={`${origin}/leaderboard`}>the report</a> {raw('&middot;')}{' '}
-            <a href="https://github.com/ravidsrk/slop-detect">source</a>
-          </footer>
-        </div>
+        <Nav origin={origin} current="" />
+        <main class="bl-main">
+          <SectionLedger tag="§" label="notes" />
+          <header class="bl-hd">
+            <h1 class="bl-h1">Blog</h1>
+            <p class="bl-lead">
+              Notes on the AI-design-slop fingerprint: how the score works, why detectors decay, and
+              the durable per-site signal.
+            </p>
+          </header>
+
+          {feature ? (
+            <div class="bl-research">
+              <a class="bl-feature" href={`${origin}/blog/${feature.slug}`}>
+                <h2 class="bl-feature-title">{feature.title}</h2>
+                <p class="bl-feature-sum">{feature.summary}</p>
+                <div class="bl-feature-foot">
+                  {feature.date} · {readingMinutes(feature.body)} min read
+                </div>
+              </a>
+              <div class="bl-links">
+                {rest.map((p) => (
+                  <ArticleLink post={p} origin={origin} />
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div class="bl-empty">
+              No notes yet. In the meantime, <a href={`${origin}/`}>scan a page</a>.
+            </div>
+          )}
+        </main>
+        <Footer origin={origin} />
       </body>
     </html>
   );

--- a/apps/web/functions/blog/[slug].tsx
+++ b/apps/web/functions/blog/[slug].tsx
@@ -133,7 +133,7 @@ export async function onRequestGet({ params, request }) {
             Machine-readable twin: <a href={`${url}.md`}>{`${post.slug}.md`}</a>
           </div>
         </main>
-        <Footer origin={origin} domain={post.slug} />
+        <Footer origin={origin} />
       </body>
     </html>
   );

--- a/apps/web/functions/blog/[slug].tsx
+++ b/apps/web/functions/blog/[slug].tsx
@@ -2,36 +2,58 @@
 // GET /blog/<slug>      → the post, server-rendered (anti-slop, BlogPosting JSON-LD).
 // GET /blog/<slug>.md    → the raw markdown twin, the AEO convention we preach.
 //
-// Single source: both come from _posts.js, so the HTML and the twin never drift.
+// Single source: both come from _posts.ts, so the HTML and the twin never drift.
+//
+// Design (GAP-FILL): a reading column — Newsreader title + headings, Libre Franklin
+// prose, and the design dark "Code block" for any fenced code. Because _posts.ts /
+// mdToHtml stay frozen, the prose <pre>/<code> they emit are styled here to match
+// the shared .cb code block rather than swapping in the component.
 
 import { raw as rawHtml } from 'hono/html';
 import { jsonForScript } from '../_render.js';
 import { getPost, mdToHtml } from '../_posts.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from '../_brand.js';
+import { Nav, Footer, SectionLedger, UI_CSS } from '../_ui.js';
 
 const ORIGIN = 'https://slop-detect.com';
 
+// Reading time from the markdown body, ~200 wpm, floor of one minute.
+function readingMinutes(body: string) {
+  const words = String(body || '')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+  return Math.max(1, Math.round(words / 200));
+}
+
 const PAGE_CSS = `
-  body{padding:48px 20px 90px}
-  .wrap{max-width:660px;margin:0 auto}
-  .brand{font-size:14px;font-weight:600;margin-bottom:22px}
-  .brand .slash{color:var(--dim);font-weight:400}
-  h1{font-size:30px;font-weight:700;letter-spacing:-0.02em;line-height:1.15;margin:6px 0 6px}
-  .meta{font-family:var(--mono);font-size:12px;color:var(--dim);margin-bottom:26px}
-  .body{font-size:16px;color:var(--text-2);line-height:1.7}
-  .body h2{font-size:20px;font-weight:700;color:var(--text);letter-spacing:-0.01em;margin:30px 0 8px}
-  .body h3{font-size:16px;font-weight:700;color:var(--text);margin:22px 0 6px}
-  .body p{margin:0 0 16px}
-  .body ul{margin:0 0 16px;padding-left:20px}
-  .body li{margin:4px 0}
-  .body a{color:var(--accent)}
-  .body code{font-family:var(--mono);font-size:13.5px;color:var(--text);background:var(--bg-2);border:1px solid var(--border);border-radius:5px;padding:1px 5px}
-  .body pre{background:var(--bg-2);border:1px solid var(--border);border-radius:8px;padding:14px;overflow:auto;margin:0 0 16px}
-  .body pre code{border:0;padding:0;background:none}
-  .twin{margin-top:30px;font-family:var(--mono);font-size:12px;color:var(--dim)}
-  .twin a{color:var(--muted)}
-  footer{margin-top:36px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
-  footer a{color:var(--muted)}
+  .bp-main{max-width:680px;margin:0 auto;padding:48px var(--pad-x) 24px}
+  .bp-back{display:inline-block;font-family:var(--mono);font-size:12.5px;color:var(--text-4);margin-bottom:22px}
+  .bp-back:hover{color:var(--text)}
+  .bp-title{font-family:var(--serif);font-weight:500;font-size:clamp(30px,4.4vw,44px);line-height:1.1;letter-spacing:-0.02em;color:var(--text);margin:0 0 8px}
+  .bp-meta{font-family:var(--mono);font-size:12.5px;color:var(--text-4);margin-bottom:30px}
+
+  /* prose — Libre Franklin body, Newsreader headings, the design code block */
+  .prose{font-family:var(--sans);font-size:var(--fs-body);line-height:1.7;color:var(--text-2)}
+  .prose h2{font-family:var(--serif);font-weight:600;font-size:var(--fs-h3);line-height:1.1;letter-spacing:-0.01em;color:var(--text);margin:34px 0 10px}
+  .prose h3{font-family:var(--serif);font-weight:600;font-size:var(--fs-serif-row);line-height:1.15;color:var(--text);margin:26px 0 6px}
+  .prose h4{font-family:var(--serif);font-weight:600;font-size:18px;color:var(--text);margin:22px 0 6px}
+  .prose p{margin:0 0 16px}
+  .prose ul{margin:0 0 16px;padding-left:22px}
+  .prose li{margin:6px 0}
+  .prose a{color:var(--clean-text);text-decoration:underline;text-underline-offset:2px}
+  .prose a:hover{color:var(--text)}
+  /* inline mono: same family, slightly smaller, no background (design "Code block") */
+  .prose code{font-family:var(--mono);font-size:0.92em;color:var(--text)}
+  /* fenced code: the design dark code block */
+  .prose pre{background:#16170F;border-radius:var(--r-5);padding:18px 20px;overflow:auto;margin:0 0 18px}
+  .prose pre code{font-family:var(--mono);font-size:var(--fs-code);line-height:1.85;color:#C9CABF;background:none;white-space:pre}
+
+  .bp-twin{margin-top:34px;padding-top:18px;border-top:1px solid var(--border);font-family:var(--mono);font-size:12.5px;color:var(--text-4)}
+  .bp-twin a{color:var(--clean-text);text-decoration:underline;text-underline-offset:2px}
+  .bp-twin a:hover{color:var(--text)}
+
+  @media(max-width:640px){.bp-main{padding-left:20px;padding-right:20px}}
 `;
 
 export async function onRequestGet({ params, request }) {
@@ -91,32 +113,27 @@ export async function onRequestGet({ params, request }) {
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <script type="application/ld+json">{rawHtml(jsonLd)}</script>
         {rawHtml(BRAND_FONTS_HEAD)}
-        <style>{rawHtml(BRAND_CSS + PAGE_CSS)}</style>
+        <style>{rawHtml(BRAND_CSS + UI_CSS + PAGE_CSS)}</style>
       </head>
       <body>
-        <div class="wrap">
-          <div class="brand">
-            <a href="/" style="color:inherit">
-              {rawHtml('slop&#8209;detect')}
-            </a>{' '}
-            <span class="slash">
-              /{' '}
-              <a href={`${origin}/blog`} style="color:inherit">
-                blog
-              </a>
-            </span>
-          </div>
-          <h1>{post.title}</h1>
-          <div class="meta">{post.date}</div>
-          <div class="body">{rawHtml(mdToHtml(post.body))}</div>
-          <div class="twin">
+        <Nav origin={origin} current="" />
+        <main class="bp-main">
+          <SectionLedger tag="§" label="notes" />
+          <a class="bp-back" href={`${origin}/blog`}>
+            {rawHtml('&larr; all posts')}
+          </a>
+          <article>
+            <h1 class="bp-title">{post.title}</h1>
+            <div class="bp-meta">
+              {post.date} · {readingMinutes(post.body)} min read
+            </div>
+            <div class="prose">{rawHtml(mdToHtml(post.body))}</div>
+          </article>
+          <div class="bp-twin">
             Machine-readable twin: <a href={`${url}.md`}>{`${post.slug}.md`}</a>
           </div>
-          <footer>
-            <a href={`${origin}/blog`}>{rawHtml('&larr; all posts')}</a> {rawHtml('&middot;')}{' '}
-            <a href={`${origin}/`}>scan a page</a>
-          </footer>
-        </div>
+        </main>
+        <Footer origin={origin} domain={post.slug} />
       </body>
     </html>
   );

--- a/apps/web/test/blog.test.js
+++ b/apps/web/test/blog.test.js
@@ -60,3 +60,59 @@ test('mdToHtml renders blocks and escapes HTML in inline code', () => {
   expect(html).toMatch(/<strong>bold<\/strong>/);
   expect(html).toMatch(/<a href="https:\/\/x\.com">link<\/a>/);
 });
+
+// ── re-skin: design fidelity (Research / article-card vocabulary) ────────────
+test('/blog uses the article-card vocabulary on the shared shell, newest-first', async () => {
+  const res = await indexGet({ request: req('/blog') });
+  const html = await res.text();
+  // shared shell from _ui (Nav + Footer), not a one-off header
+  expect(html, 'shared nav').toMatch(/class="nav"/);
+  expect(html, 'shared footer').toMatch(/class="ft"/);
+  // a feature card beside a stack of article links
+  expect(html).toMatch(/bl-research/);
+  expect(html).toMatch(/bl-feature/);
+  expect(html).toMatch(/bl-link/);
+  // Newsreader (serif) titles + a mono date·read-time reference tag
+  expect(html).toMatch(/bl-feature-title\{font-family:var\(--serif\)/);
+  expect(html).toMatch(/\d+ min read/);
+  // newest-first: posts render in non-increasing date order (first occurrence)
+  const firstSeen = [];
+  for (const m of html.matchAll(/\/blog\/([a-z0-9-]+)(?=["<.])/g))
+    if (!firstSeen.includes(m[1])) firstSeen.push(m[1]);
+  expect(firstSeen.length).toBe(POSTS.length);
+  const dates = firstSeen.map((slug) => POSTS.find((p) => p.slug === slug).date);
+  for (let i = 1; i < dates.length; i++) expect(dates[i] <= dates[i - 1]).toBe(true);
+});
+
+test('/blog/<slug> renders Libre Franklin prose, Newsreader headings, and the design code block', async () => {
+  const res = await postGet({
+    params: { slug: 'how-the-slop-score-works' },
+    request: req('/blog/how-the-slop-score-works'),
+  });
+  const html = await res.text();
+  expect(html, 'shared shell').toMatch(/class="nav"/);
+  expect(html, 'prose column').toMatch(/class="prose"/);
+  expect(html, 'Libre Franklin body (--sans)').toMatch(/\.prose\{font-family:var\(--sans\)/);
+  expect(html, 'Newsreader headings (--serif)').toMatch(/\.prose h2\{font-family:var\(--serif\)/);
+  expect(html, 'dark design code block for fenced code').toMatch(/\.prose pre\{background:#16170F/);
+});
+
+// ── dogfood: both surfaces must score Clean ──────────────────────────────────
+test('the blog dogfoods its own detector (no slop fonts, no gradient text, no purple CTA)', async () => {
+  const index = await (await indexGet({ request: req('/blog') })).text();
+  const post = await (
+    await postGet({
+      params: { slug: 'why-detectors-decay' },
+      request: req('/blog/why-detectors-decay'),
+    })
+  ).text();
+  for (const [label, html] of [
+    ['index', index],
+    ['post', post],
+  ]) {
+    expect(html, `${label}: no AI-default faces`).not.toMatch(/Inter,|Geist|Space Grotesk/i);
+    expect(html, `${label}: no gradient text`).not.toMatch(/background-clip:\s*text/i);
+    // the lone purple lives only in the data-avatar palette (_theme); never on the blog
+    expect(html, `${label}: no purple accent`).not.toMatch(/#7A4D9A/i);
+  }
+});


### PR DESCRIPTION
Phase C build task 09 (`blog`) per docs/parity-spec.md. Rebased onto current main. Acceptance = parity-spec "### Build task 09" (design fidelity + functional parity / MNR floor + real green tests + dogfood/responsive/a11y). Full web suite + typecheck green per the build worker; clean commit (Ravindra Kumar, no trailers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only HTML/CSS changes on static blog routes; no auth, data, or post-pipeline logic changes.
> 
> **Overview**
> Re-skins **`/blog`** and **`/blog/<slug>`** presentation to match the parity-spec editorial system while keeping post content and JSON-LD / `.md` twin behavior unchanged.
> 
> The index drops the narrow list layout for a **research-style grid**: newest post as a feature card, remaining posts in a link stack, with **estimated read time** on each entry. Both routes now use **`Nav`**, **`Footer`**, **`SectionLedger`**, and **`UI_CSS`** from `_ui` instead of bespoke headers/footers.
> 
> Post pages get a reading-column layout (Newsreader titles/headings, sans prose, dark fenced-code styling) plus back link and read-time in meta. **`blog.test.js`** adds assertions for shell classes, typography/CSS hooks, newest-first ordering, and dogfood rules (no slop fonts, gradients, or purple accent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f451a5456da24edb4079a6225ff4beee033dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->