### PR TITLE
feat(web): printable-report (parity-spec build task 05)

### DIFF
--- a/apps/web/functions/report/[domain].tsx
+++ b/apps/web/functions/report/[domain].tsx
@@ -1,14 +1,24 @@
 /** @jsxRuntime automatic @jsxImportSource hono/jsx */
-// GET /report/:domain — a print-friendly client report (Roadmap v2 P2b-lite).
+// GET /report/:domain — the printable agency client report (a Result variant).
 //
-// The agency deliverable: one page summarizing a domain's slop score, its
-// design-system compliance (when monitored), score history, and drift items —
-// styled for screen AND for printing to PDF (@media print), which is the
-// indie-smart substitute for server-side PDF generation infrastructure.
+// The agency deliverable: one focused page summarizing a domain's slop fingerprint,
+// its design-system compliance (when monitored), what drifted, the triggered
+// patterns, and the score history — rendered in the SAME editorial-instrument
+// language as /score and /r (Newsreader / Libre Franklin / JetBrains Mono, the
+// verdict palette, the 1.5px ink ledger rule), and styled for screen AND for
+// printing to PDF (@media print), the indie-smart substitute for server-side PDF
+// generation infrastructure (MNR-16).
 //
-// Public data only: latest stored scan (d:/r: keys), the watch's PUBLIC view
-// (publicWatch — never the email), and history. A domain with no data renders
-// an honest empty state. Anti-slop by construction, like /directory.
+// Public data only: the latest stored scan (d:/r: keys), the watch's PUBLIC view
+// (publicWatch — never the subscriber email), and history. A domain with no data
+// renders an honest, email-free empty state. Anti-slop by construction: flat 1px
+// surfaces, no gradients, no slop fonts — it must pass its own detector.
+//
+// It composes the shared foundation rather than re-implementing it: _brand.ts
+// tokens, _ui.tsx shell (Footer / SectionLedger / LogoLockup), _theme.ts color
+// resolvers, and _result.tsx's buildResultView (the canonical engine-joined
+// view-model that turns a slim scan into its triggered-pattern list). This file
+// imports the foundation but does not edit it (foundation acceptance gate).
 
 import { raw } from 'hono/html';
 import {
@@ -17,84 +27,82 @@ import {
   getWatch,
   getHistory,
   publicWatch,
-  tierColors,
 } from '../_shared.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from '../_brand.js';
+import { Footer, SectionLedger, LogoLockup, UI_CSS } from '../_ui.js';
+import { tierText, systemAxisColor } from '../_theme.js';
+import { buildResultView } from '../_result.js';
 
 const ORIGIN = 'https://slop-detect.com';
 
-const PAGE_CSS = `
-  body{padding:48px 20px 80px}
-  .wrap{max-width:720px;margin:0 auto}
-  h1{font-size:28px;font-weight:700;letter-spacing:-0.02em;margin:2px 0 2px}
-  h2{font-size:17px;font-weight:700;margin:30px 0 8px}
-  .meta{color:var(--dim);font-size:12.5px;font-family:var(--mono);margin-bottom:24px}
-  .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-  .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:18px}
-  .k{font-family:var(--mono);font-size:11px;color:var(--dim);text-transform:uppercase;letter-spacing:.04em;margin-bottom:10px}
-  .big{font-size:44px;font-weight:800;line-height:1;font-family:var(--mono);letter-spacing:-0.03em}
-  .big small{font-size:18px;color:var(--dim)}
-  .sub{font-size:16px;font-weight:600;margin-top:6px}
-  .note{color:var(--muted);font-size:12.5px;margin-top:8px}
-  .dim{color:var(--dim)}
-  .drift{list-style:none}
-  .drift li{padding:7px 0;border-bottom:1px solid var(--bg-2);font-size:14.5px}
-  .x{color:var(--red);margin-right:6px}
-  table{border-collapse:collapse;width:100%;font-size:13px}
-  th,td{text-align:left;padding:7px 12px 7px 0;border-bottom:1px solid var(--bg-2)}
-  th{color:var(--dim);font-weight:500;font-family:var(--mono);font-size:11px}
-  td{font-family:var(--mono)}
-  .empty{color:var(--muted);padding:24px 0}
-  footer{margin-top:36px;font-family:var(--mono);font-size:11.5px;color:var(--dim)}
-  footer a{color:var(--muted)}
-  .printbtn{float:right;font-size:12px;font-family:var(--mono);color:var(--muted);background:none;border:1px solid var(--border-2);border-radius:6px;padding:5px 12px;cursor:pointer}
-  .printbtn:hover{color:var(--text);border-color:var(--muted)}
-  @media(max-width:560px){.grid{grid-template-columns:1fr}}
+// Report-only styles. Light-first; everything references BRAND_CSS tokens so there
+// is one source of truth. The @media print block is the PDF substitute: it flattens
+// the paper to white and drops the one dark section (the footer band) to ink-on-
+// white, since a printer should not flood a page with the dark register.
+const REPORT_CSS = `
+  .rpt-top{max-width:760px;margin:0 auto;padding:26px var(--pad-x) 0;display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap}
+  .rpt-print{font-family:var(--mono);font-size:12.5px;color:var(--text-3);background:var(--panel);border:1px solid var(--border-btn);border-radius:3px;padding:7px 14px;cursor:pointer;transition:var(--t)}
+  .rpt-print:hover{border-color:var(--text);color:var(--text)}
+
+  .rpt{max-width:760px;margin:0 auto;padding:6px var(--pad-x) 60px}
+  .rpt-sec{padding:30px 0}
+  .rpt-sec + .rpt-sec{border-top:1px solid var(--border-2)}
+  .rpt-led{margin-bottom:16px}
+  .rpt-h1{font-family:var(--serif);font-weight:500;font-size:clamp(32px,5vw,46px);line-height:1.0;letter-spacing:-0.02em;color:var(--text);margin:2px 0 8px;word-break:break-word}
+  .rpt-meta{font-family:var(--mono);font-size:12.5px;color:var(--text-4)}
+
+  /* the two summary cards: fingerprint + design-system compliance */
+  .rpt-cards{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  .rpt-cards.one{grid-template-columns:1fr}
+  .rcard{border:1px solid var(--border);border-radius:8px;background:var(--panel);padding:20px 22px}
+  .rcard-k{font-family:var(--mono);font-size:12px;color:var(--text-4);letter-spacing:0;margin-bottom:14px}
+  .rcard-big{font-family:var(--serif);font-weight:500;font-size:56px;line-height:0.82;letter-spacing:-0.03em}
+  .rcard-big small{font-family:var(--serif);font-size:22px;color:var(--text-6);letter-spacing:-0.01em}
+  .rcard-sub{font-family:var(--mono);font-size:14px;font-weight:700;margin-top:12px}
+  .rcard-note{font-family:var(--mono);font-size:12px;color:var(--text-4);line-height:1.6;margin-top:8px}
+  .rcard-note code{background:var(--bg-2);border-radius:3px;padding:1px 5px}
+
+  /* what drifted + triggered patterns — flat, print-legible lists */
+  .rlist{list-style:none}
+  .rlist li{display:flex;gap:10px;align-items:baseline;padding:9px 0;border-bottom:1px solid var(--row-inner);font-size:14.5px;color:var(--text-2);line-height:1.5}
+  .rlist li:last-child{border-bottom:0}
+  .rlist .rx{color:var(--heavy-text);font-family:var(--mono);flex:none}
+  .rlist .rid{color:var(--text-5);font-family:var(--mono);font-size:12px}
+  .rlist .rw{margin-left:auto;color:var(--heavy-text);font-family:var(--mono);font-size:13px;font-weight:700;flex:none;white-space:nowrap}
+
+  /* history table */
+  .rtable{border-collapse:collapse;width:100%;font-family:var(--mono);font-size:13px}
+  .rtable caption{text-align:left}
+  .rtable th{text-align:left;padding:9px 14px 9px 0;border-bottom:1.5px solid #181815;color:var(--text-4);font-weight:500;font-size:11.5px;white-space:nowrap}
+  .rtable td{text-align:left;padding:9px 14px 9px 0;border-bottom:1px solid var(--row-inner);color:var(--text-2);white-space:nowrap}
+  .rtable .rt-dim{color:var(--text-6)}
+
+  .rpt-empty{font-family:var(--serif);font-style:italic;font-size:20px;color:var(--text-3);line-height:1.5;padding:8px 0}
+  .rpt-empty a{color:var(--clean-text);text-decoration:underline}
+
+  @media (max-width:560px){
+    .rpt-cards{grid-template-columns:1fr}
+  }
+
+  /* the PDF substitute: paper prints white, the dark footer band drops to ink */
   @media print{
-    body{background:#fff;color:#111;padding:0}
-    .card{border-color:#ccc;background:#fff}
-    .printbtn{display:none}
-    th,td,.drift li{border-color:#ddd}
-    footer,a{color:#555}
+    body{background:#fff;color:#111}
+    .rpt-top{padding-top:12px}
+    .rpt-print{display:none}
+    .rcard{border-color:#ccc;background:#fff}
+    .rlist li,.rtable td{border-color:#ddd}
+    .rtable th,.section-ledger{border-color:#111}
+    a{color:#111}
+    .ft{background:#fff;color:#444;border-top:1px solid #ccc}
+    .ft-word,.ft-fp{color:#111}
+    .ft-meta,.ft-repro,.ft-links a{color:#555}
+    .ft .logo-mark svg path{stroke:#111}
   }
 `;
 
-function sysColors(tier) {
-  if (tier === 'Aligned') return { fg: '#4ade80' };
-  if (tier === 'Drifting') return { fg: '#fbbf24' };
-  if (tier === 'Off-system') return { fg: '#f87171' };
-  return { fg: '#8a8a92' };
-}
-
-function HistoryRows({ history }) {
-  return (
-    <>
-      {history
-        .slice(-20)
-        .reverse()
-        .map((h) => {
-          const c = tierColors(h.tier);
-          return (
-            <tr>
-              <td>{String(h.at || '').slice(0, 10)}</td>
-              <td>
-                <span style={`color:${c.fg}`}>{h.grade || '—'}</span>
-              </td>
-              <td>{h.score}/100</td>
-              <td style={`color:${c.fg}`}>{h.tier || ''}</td>
-              {h.system ? (
-                <td style={`color:${sysColors(h.system.tier).fg}`}>
-                  {h.system.score}/100 {h.system.tier}
-                </td>
-              ) : (
-                <td class="dim">—</td>
-              )}
-            </tr>
-          );
-        })}
-    </>
-  );
-}
+// Wire the print button without an inline onclick attribute. No interpolation, so
+// nothing hostile can reach it (and it stays under the page CSP).
+const PRINT_SCRIPT = `(function(){var b=document.getElementById('rptPrint');if(b)b.addEventListener('click',function(){window.print();});})();`;
 
 export async function onRequestGet({ params, request, env }) {
   const origin = new URL(request.url).origin;
@@ -102,13 +110,13 @@ export async function onRequestGet({ params, request, env }) {
   if (!domain) {
     return new Response('Invalid domain', {
       status: 400,
-      headers: { 'Content-Type': 'text/plain' },
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
     });
   }
 
-  let latest = null,
-    watch = null,
-    history = [];
+  let latest: any = null,
+    watch: any = null,
+    history: any[] = [];
   if (env.RESULTS) {
     [latest, watch, history] = await Promise.all([
       getLatestForDomain(env.RESULTS, domain).catch(() => null),
@@ -116,118 +124,163 @@ export async function onRequestGet({ params, request, env }) {
       getHistory(env.RESULTS, domain).catch(() => []),
     ]);
   }
-  const pub = watch ? publicWatch(watch, history) : null;
-  const hasData = !!(latest || (history && history.length));
 
-  const c = tierColors(latest?.tier);
+  const pub = watch ? publicWatch(watch, history) : null;
+  const monitored = !!pub?.monitoring;
   const sys = pub?.system || null;
-  const sc = sysColors(sys?.tier);
+  const hasData = !!(latest || (history && history.length));
   const today = new Date().toISOString().slice(0, 10);
-  const tells = latest?.triggered?.length ? latest.triggered.slice(0, 10) : [];
+
+  // The triggered-pattern list comes from the shared Result view-model so the
+  // report reads the same join (slim → engine metadata) the hub uses.
+  const view = latest ? buildResultView(latest) : null;
+  const tells = view
+    ? [...(view.triggered || [])].sort((a, b) => (b.weight || 0) - (a.weight || 0)).slice(0, 12)
+    : [];
+
+  const fg = latest ? tierText(latest.tier) : 'var(--text-6)';
+  const sysColor = sys ? systemAxisColor(sys.score) : 'var(--text-6)';
 
   const body = hasData ? (
     <>
-      {latest ? (
-        <section class="grid">
-          <div class="card">
-            <div class="k">design-slop fingerprint</div>
-            <div class="big" style={`color:${c.fg}`}>
-              {latest.grade || '—'}
+      <section class="rpt-sec">
+        <div class={`rpt-cards${monitored ? '' : ' one'}`}>
+          <div class="rcard">
+            <div class="rcard-k">design-slop fingerprint</div>
+            <div class="rcard-big" style={`color:${fg}`}>
+              {latest?.grade || '—'}
             </div>
-            <div class="sub">
-              {latest.score}/100 · <span style={`color:${c.fg}`}>{latest.tier || ''}</span>
+            <div class="rcard-sub">
+              {latest?.score}/100 · <span style={`color:${fg}`}>{latest?.tier || ''}</span>
             </div>
-            <div class="note">
-              {latest.patternsFlagged}/{latest.patternsTotal} patterns triggered · defs{' '}
-              {latest.definitionsVersion || ''}
+            <div class="rcard-note">
+              {latest?.patternsFlagged}/{latest?.patternsTotal} patterns triggered
+              {latest?.definitionsVersion ? ` · defs ${latest.definitionsVersion}` : ''}
             </div>
           </div>
-          <div class="card">
-            <div class="k">design-system compliance</div>
-            {sys ? (
-              <>
-                <div class="big" style={`color:${sc.fg}`}>
-                  {sys.score}
-                  <small>/100</small>
-                </div>
-                <div class="sub" style={`color:${sc.fg}`}>
-                  {sys.tier}
-                </div>
-                <div class="note">
-                  vs its own DESIGN.md · higher is better
-                  {sys.drifted ? (
-                    <>
-                      {' · '}
-                      <strong>drifted</strong>
-                    </>
-                  ) : null}
-                </div>
-              </>
-            ) : (
-              <>
-                <div class="big dim">—</div>
-                <div class="note">
-                  Not monitored against a DESIGN.md yet. Opt in via{' '}
-                  <code>{'POST /api/watch { system: true }'}</code>.
-                </div>
-              </>
-            )}
+          {monitored ? (
+            <div class="rcard">
+              <div class="rcard-k">design-system compliance</div>
+              {sys ? (
+                <>
+                  <div class="rcard-big" style={`color:${sysColor}`}>
+                    {sys.score}
+                    <small>/100</small>
+                  </div>
+                  <div class="rcard-sub" style={`color:${sysColor}`}>
+                    {sys.tier}
+                  </div>
+                  <div class="rcard-note">
+                    vs its own DESIGN.md · higher is better
+                    {sys.drifted ? ' · drifted' : ''}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div class="rcard-big" style="color:var(--text-6)">
+                    —
+                  </div>
+                  <div class="rcard-note">
+                    Monitored, but no DESIGN.md declared yet. Opt in with{' '}
+                    <code>{'POST /api/watch { system: true }'}</code>.
+                  </div>
+                </>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      {sys && sys.drift && sys.drift.length ? (
+        <section class="rpt-sec">
+          <div class="rpt-led">
+            <SectionLedger tag="" label="what drifted" />
           </div>
+          <ul class="rlist">
+            {sys.drift.map((d) => (
+              <li>
+                <span class="rx" aria-hidden="true">
+                  ✗
+                </span>
+                <span>
+                  {d.message || d.id} <span class="rid">({d.id})</span>
+                </span>
+              </li>
+            ))}
+          </ul>
         </section>
       ) : null}
 
-      {sys && sys.drift && sys.drift.length ? (
-        <>
-          <h2>What drifted</h2>
-          <ul class="drift">
-            {sys.drift.map((d) => (
-              <li>
-                <span class="x">✗</span> {d.message} <span class="dim">({d.id})</span>
-              </li>
-            ))}
-          </ul>
-        </>
-      ) : null}
-
       {tells.length ? (
-        <>
-          <h2>Triggered patterns</h2>
-          <ul class="drift">
+        <section class="rpt-sec">
+          <div class="rpt-led">
+            <SectionLedger tag="" label="triggered patterns" />
+          </div>
+          <ul class="rlist">
             {tells.map((t) => (
               <li>
-                <span class="x">✗</span> {t.label || t.short || t.id}{' '}
-                <span class="dim">(+{t.weight})</span>
+                <span class="rx" aria-hidden="true">
+                  ✗
+                </span>
+                <span>{t.label || t.short || t.id}</span>
+                <span class="rw">+{t.weight}</span>
               </li>
             ))}
           </ul>
-        </>
+        </section>
       ) : null}
 
-      {history.length ? (
-        <>
-          <h2>History</h2>
-          <table>
+      {history && history.length ? (
+        <section class="rpt-sec">
+          <div class="rpt-led">
+            <SectionLedger tag="" label="history" />
+          </div>
+          <table class="rtable">
+            <caption class="sr-only">History of slop scores for {domain}</caption>
             <thead>
               <tr>
-                <th>date</th>
-                <th>grade</th>
-                <th>slop score</th>
-                <th>tier</th>
-                <th>system</th>
+                <th scope="col">date</th>
+                <th scope="col">grade</th>
+                <th scope="col">slop score</th>
+                <th scope="col">tier</th>
+                <th scope="col">system</th>
               </tr>
             </thead>
             <tbody>
-              <HistoryRows history={history} />
+              {history
+                .slice(-20)
+                .reverse()
+                .map((h) => {
+                  const hc = tierText(h.tier);
+                  return (
+                    <tr>
+                      <td>{String(h.createdAt || h.at || '').slice(0, 10)}</td>
+                      <td style={`color:${hc}`}>{h.grade || '—'}</td>
+                      <td>{h.score}/100</td>
+                      <td style={`color:${hc}`}>{h.tier || ''}</td>
+                      {h.sys ? (
+                        <td style={`color:${systemAxisColor(h.sys.score)}`}>
+                          {h.sys.score}/100 {h.sys.tier}
+                        </td>
+                      ) : (
+                        <td class="rt-dim">—</td>
+                      )}
+                    </tr>
+                  );
+                })}
             </tbody>
           </table>
-        </>
+        </section>
       ) : null}
     </>
   ) : (
-    <p class="empty">
-      No scan data for <strong>{domain}</strong> yet. <a href={`${origin}/`}>Run a scan</a>, then
-      revisit this report.
-    </p>
+    <section class="rpt-sec">
+      <p class="rpt-empty">
+        No scan data for <strong>{domain}</strong> yet.{' '}
+        <a href={`${origin}/?url=${encodeURIComponent(domain)}`}>Run a scan</a>, then revisit this
+        report.
+      </p>
+    </section>
   );
 
   const doc = (
@@ -235,38 +288,43 @@ export async function onRequestGet({ params, request, env }) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>{`Report: ${domain} · slop-detect`}</title>
+        <title>{`Report: ${domain} · Slop Detector`}</title>
         <meta name="robots" content="noindex" />
         <link rel="canonical" href={`${ORIGIN}/report/${domain}`} />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         {raw(BRAND_FONTS_HEAD)}
-        <style>{raw(BRAND_CSS + PAGE_CSS)}</style>
+        <style>{raw(BRAND_CSS + UI_CSS + REPORT_CSS)}</style>
       </head>
-      <body>
-        <div class="wrap">
-          <button class="printbtn" onclick="window.print()">
+      <body class="report">
+        <header class="rpt-top">
+          <LogoLockup href={`${origin}/`} />
+          <button id="rptPrint" class="rpt-print" type="button">
             print / save PDF
           </button>
-          <div class="eyebrow">
-            <span class="reg">{raw('&sect;cli')}</span>
-            <span class="reg-label">client report</span>
-          </div>
-          <h1>{domain}</h1>
-          <div class="meta">
-            prepared {today} · slop-detect.com{pub?.monitoring ? ' · monitored' : ''}
-          </div>
+        </header>
+        <main class="rpt">
+          <section class="rpt-sec">
+            <div class="rpt-led">
+              <SectionLedger tag="" label="client report" />
+            </div>
+            <h1 class="rpt-h1">{domain}</h1>
+            <div class="rpt-meta">
+              prepared {today} · slop-detect.com{monitored ? ' · monitored' : ''}
+              {latest?.definitionsVersion ? ` · defs ${latest.definitionsVersion}` : ''}
+            </div>
+          </section>
           {body}
-          <footer>
-            Scores are deterministic, named checks — a fingerprint, not a verdict. Live score hub:{' '}
-            <a href={`${origin}/score/${domain}`}>{`slop-detect.com/score/${domain}`}</a>
-            <br />
-            Reproduce: <a href={`${origin}/`}>slop-detect.com</a> · npx slop-detect {domain}
-          </footer>
-        </div>
+        </main>
+        <Footer origin={origin} domain={domain} meta="a fingerprint, not a verdict · MIT" />
+        <script>{raw(PRINT_SCRIPT)}</script>
       </body>
     </html>
   );
 
   return new Response('<!doctype html>' + doc.toString(), {
-    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=120' },
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=120',
+    },
   });
 }


### PR DESCRIPTION
Phase C build task 05 (`printable-report`) per docs/parity-spec.md. Rebased onto current main. Acceptance = parity-spec "### Build task 05" (design fidelity + functional parity / MNR floor + real green tests + dogfood/responsive/a11y). Full web suite + typecheck green per the build worker; clean commit (Ravindra Kumar, no trailers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only HTML rendering on public scan/watch data with no API or auth changes; risk is mostly visual/regression coverage via existing drift/report tests.
> 
> **Overview**
> **`/report/:domain`** is rewritten as the parity-spec **printable-report** deliverable: same editorial stack as `/score` and `/r` via shared **`_brand`**, **`_ui`** (`LogoLockup`, `SectionLedger`, `Footer`), **`_theme`** (`tierText`, `systemAxisColor`), and **`buildResultView`** for triggered patterns (weight-sorted, up to 12).
> 
> The old bespoke **`PAGE_CSS`** and local tier color helpers are replaced with token-driven **`REPORT_CSS`** plus **`UI_CSS`**, sectioned layout, and a stronger **`@media print`** path (white paper, footer band flattened for PDF). Print uses a small **`PRINT_SCRIPT`** listener instead of inline **`onclick`** for CSP.
> 
> **Behavior tweaks:** the design-system summary card renders only when the watch is **monitored**; drift/patterns/history use ledger sections and accessible table markup; history rows read **`h.sys`** and **`createdAt`/`at`**; the no-data CTA deep-links **`/?url=`**; page chrome adds favicon and shared footer copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d55797b60ca17700fab98cf8166182b2b406ac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->