### PR TITLE
feat(web): seo-version-consistency (parity-spec build task 16)

### DIFF
--- a/apps/web/public/api/patterns.md
+++ b/apps/web/public/api/patterns.md
@@ -1,6 +1,6 @@
 # Slop Detector — Pattern Catalogue
 
-> The deterministic patterns the engine checks. Version 2026.08, 27 patterns. Live JSON: https://slop-detect.com/api/patterns
+> The deterministic patterns the engine checks. Version 2026.09, 27 patterns. Live JSON: https://slop-detect.com/api/patterns
 
 ## fonts
 

--- a/apps/web/public/developers/llms.txt
+++ b/apps/web/public/developers/llms.txt
@@ -20,8 +20,8 @@ npm: `slop-detect`. Source: https://github.com/ravidsrk/slop-detect
 npx -y slop-detect-mcp
 ```
 
-Exposes three tools to any MCP client (Claude Code, Cursor, Windsurf):
-`scan_page`, `check_aeo`, `fix_prompt`. Server card:
+Exposes four tools to any MCP client (Claude Code, Cursor, Windsurf):
+`scan_page`, `check_aeo`, `check_design_system`, `fix_prompt`. Server card:
 https://slop-detect.com/.well-known/mcp/server-card.json
 
 ## HTTP API

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -133,8 +133,8 @@ npm package: `slop-detect`.
 npx -y slop-detect-mcp
 ```
 
-Exposes `scan_page`, `check_aeo`, `fix_prompt` to any MCP client (Claude Code,
-Cursor, Windsurf). Server card:
+Exposes `scan_page`, `check_aeo`, `check_design_system`, `fix_prompt` to any MCP
+client (Claude Code, Cursor, Windsurf). Server card:
 https://slop-detect.com/.well-known/mcp/server-card.json
 
 ## Monitoring, system axis & dashboard
@@ -180,6 +180,8 @@ Free and open source (MIT). No paid tiers. See https://slop-detect.com/pricing.m
 ## Discovery & links
 
 - llms.txt: https://slop-detect.com/llms.txt
+- Methodology: https://slop-detect.com/docs
+- Brand & identity: https://slop-detect.com/brand
 - OpenAPI: https://slop-detect.com/openapi.json
 - Auth: https://slop-detect.com/auth.md
 - Pricing: https://slop-detect.com/pricing.md

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -14,6 +14,10 @@ page looks machine-generated, not that it is bad.
 
 - [Homepage (markdown twin)](https://slop-detect.com/index.md): What Slop
   Detector measures and how the scan works.
+- [Methodology](https://slop-detect.com/docs): How each axis is scored, the
+  DESIGN.md system axis, and the REST/CLI/MCP surface in one reference.
+- [Brand & identity](https://slop-detect.com/brand): The design system, and the
+  dogfood proof that this site passes its own detector.
 - [Pattern catalogue (JSON)](https://slop-detect.com/api/patterns): Every design
   and copy pattern, with weights and the current definitions version.
 - [Blog](https://slop-detect.com/blog): how the score works and why a fixed

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -779,7 +779,7 @@
         "properties": {
           "version": {
             "type": "string",
-            "example": "2026.08",
+            "example": "2026.09",
             "description": "DEFINITIONS_VERSION of the catalogue."
           },
           "count": {

--- a/apps/web/public/pricing.md
+++ b/apps/web/public/pricing.md
@@ -20,7 +20,7 @@
 ## Monitored domains: the continuity layer
 
 A one-off scan tells you the score today. **Monitoring remembers it.** Register a
-domain (`POST /api/watch`) and slop-detect keeps a score history and flags a
+domain (`POST /api/watch`) and Slop Detector keeps a score history and flags a
 **regression** (the score gets meaningfully worse, or the tier drops a band:
 Clean → Mild → Heavy) so a redesign or an agent-written page can't quietly
 drag your site back into slop without anyone noticing. Add `system: true` and the

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -11,6 +11,26 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://slop-detect.com/docs</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/brand</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/leaderboard</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/directory</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://slop-detect.com/compare</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -30,16 +50,132 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+
+  <!-- Per-domain score hubs (/score/:domain) — the canonical, crawlable Result
+       for each scanned domain. A representative set drawn from the leaderboard
+       corpus (the well-known landing pages we score live); the full, growing set
+       is discoverable via /leaderboard and the opt-in /directory. -->
   <url>
-    <loc>https://slop-detect.com/directory</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://slop-detect.com/leaderboard</loc>
+    <loc>https://slop-detect.com/score/v0.dev</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://slop-detect.com/score/lovable.dev</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/bolt.new</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/framer.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/replit.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/aura.build</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/stripe.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/linear.app</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/vercel.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/supabase.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/resend.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/posthog.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/railway.app</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/cal.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/clerk.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/notion.so</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/figma.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/openai.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/anthropic.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/news.ycombinator.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/berkshirehathaway.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/gnu.org</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/motherfuckingwebsite.com</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://slop-detect.com/score/craigslist.org</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
   <url>
     <loc>https://slop-detect.com/api/patterns</loc>
     <changefreq>monthly</changefreq>

--- a/apps/web/test/seo-version.test.js
+++ b/apps/web/test/seo-version.test.js
@@ -1,0 +1,89 @@
+// Build task 16: seo-version-consistency.
+// Closes the discovery gap (the new /docs + /brand routes and the per-domain
+// /score hubs must be in the sitemap) and the version-drift gap (every static
+// copy of the product version and the catalogue version is pinned to its ONE
+// source — root package.json and core's DEFINITIONS_VERSION — so the labels can
+// never silently lag a release again).
+
+import { test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const read = (rel) => readFileSync(new URL(rel, import.meta.url), 'utf8');
+
+const sitemap = read('../public/sitemap.xml');
+const openapi = JSON.parse(read('../public/openapi.json'));
+const agentCard = JSON.parse(read('../public/.well-known/agent-card.json'));
+const serverCard = JSON.parse(read('../public/.well-known/mcp/server-card.json'));
+const patternsMd = read('../public/api/patterns.md');
+
+// The single sources of truth.
+const pkg = JSON.parse(read('../../../package.json'));
+const coreSrc = read('../../../packages/core/src/index.ts');
+const DEFINITIONS_VERSION = coreSrc.match(/DEFINITIONS_VERSION\s*=\s*'([^']+)'/)?.[1];
+
+// ── discovery: the sitemap lists the new routes (floor "discovery gap") ───────
+test('sitemap includes the new /docs and /brand routes', () => {
+  expect(sitemap, '/docs must be discoverable').toContain(
+    '<loc>https://slop-detect.com/docs</loc>'
+  );
+  expect(sitemap, '/brand must be discoverable').toContain(
+    '<loc>https://slop-detect.com/brand</loc>'
+  );
+});
+
+test('sitemap lists a representative set of per-domain /score hubs', () => {
+  const scoreHubs = (sitemap.match(/<loc>https:\/\/slop-detect\.com\/score\//g) || []).length;
+  expect(scoreHubs, 'the canonical score hubs are the spine and must be crawlable').toBeGreaterThan(
+    5
+  );
+  // Marquee corpus domains the leaderboard headlines.
+  for (const d of ['stripe.com', 'vercel.com', 'v0.dev', 'linear.app']) {
+    expect(sitemap).toContain(`<loc>https://slop-detect.com/score/${d}</loc>`);
+  }
+});
+
+test('sitemap is well-formed: every <loc> sits inside a <url> and uses the canonical origin', () => {
+  const locs = sitemap.match(/<loc>([^<]+)<\/loc>/g) || [];
+  expect(locs.length).toBeGreaterThan(15);
+  for (const loc of locs) {
+    expect(loc).toMatch(/<loc>https:\/\/slop-detect\.com\//);
+  }
+  expect((sitemap.match(/<url>/g) || []).length).toBe((sitemap.match(/<\/url>/g) || []).length);
+});
+
+// ── version drift: product version pinned to ONE source (root package.json) ───
+test('openapi + agent surface advertise the released package version (no drift)', () => {
+  const v = pkg.version;
+  expect(openapi.info.version, 'openapi.json must track package.json').toBe(v);
+  expect(agentCard.version, 'agent-card.json must track package.json').toBe(v);
+  expect(serverCard.version, 'mcp server-card.json must track package.json').toBe(v);
+});
+
+// ── defs drift: catalogue label pinned to ONE source (DEFINITIONS_VERSION) ────
+test('catalogue version labels track DEFINITIONS_VERSION (no defs drift)', () => {
+  expect(DEFINITIONS_VERSION, 'parsed DEFINITIONS_VERSION from core').toMatch(/^\d{4}\.\d{2}$/);
+  expect(
+    patterns_md_version(patternsMd),
+    'api/patterns.md catalogue label must match the engine'
+  ).toBe(DEFINITIONS_VERSION);
+  expect(
+    openapi.components.schemas.PatternCatalogue.properties.version.example,
+    'openapi PatternCatalogue example must match the engine'
+  ).toBe(DEFINITIONS_VERSION);
+  // The stale label must not reappear anywhere in the catalogue doc.
+  expect(patternsMd.includes('Version 2026.08,'), 'no stale catalogue label').toBeFalsy();
+});
+
+function patterns_md_version(md) {
+  return md.match(/Version (\d{4}\.\d{2}),/)?.[1];
+}
+
+// ── parity: the full agent tool surface is advertised everywhere (MNR-24) ─────
+test('the llms developer surfaces advertise the full MCP tool list', () => {
+  for (const rel of ['../public/llms-full.txt', '../public/developers/llms.txt']) {
+    const txt = read(rel);
+    for (const tool of ['scan_page', 'check_aeo', 'check_design_system', 'fix_prompt']) {
+      expect(txt.includes(tool), `${rel}: must advertise ${tool}`).toBeTruthy();
+    }
+  }
+});


### PR DESCRIPTION
Phase C build task 16 (`seo-version-consistency`) per docs/parity-spec.md. Rebased onto current main. Acceptance = parity-spec "### Build task 16" (design fidelity + functional parity / MNR floor + real green tests + dogfood/responsive/a11y). Full web suite + typecheck green per the build worker; clean commit (Ravindra Kumar, no trailers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static public assets and Vitest guards only; no runtime scan, auth, or API behavior changes.
> 
> **Overview**
> **SEO and agent-discovery parity** for parity-spec build task 16: static docs, sitemap, and version labels stay aligned with the engine and release metadata.
> 
> The **sitemap** now lists `/docs`, `/brand`, and a representative set of per-domain **`/score/:domain`** hubs (leaderboard corpus), with a short comment explaining how the full set is discovered elsewhere.
> 
> **Catalogue version** labels move from **2026.08** to **2026.09** in `api/patterns.md` and the OpenAPI `PatternCatalogue` example so they match **`DEFINITIONS_VERSION`** in core.
> 
> **LLM-facing docs** add links to **Methodology** (`/docs`) and **Brand** (`/brand`), and MCP copy now advertises all **four** tools—including **`check_design_system`**—in `llms-full.txt` and `developers/llms.txt` (aligned with `llms.txt`).
> 
> Minor copy tweak in **`pricing.md`** (“Slop Detector” branding).
> 
> New **`apps/web/test/seo-version.test.js`** guards sitemap routes, sitemap shape, `package.json` version parity across OpenAPI/agent/MCP cards, catalogue version parity, and the full MCP tool list in the llms files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf10d6f52f876cd8979251309deac569258f60c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->