### PR TITLE
feat(web): residual-cleanup (parity-spec build task ??)

### DIFF
--- a/apps/web/functions/directory.tsx
+++ b/apps/web/functions/directory.tsx
@@ -126,7 +126,7 @@ function jsonLd(sites) {
   return jsonForScript({
     '@context': 'https://schema.org',
     '@type': 'ItemList',
-    name: 'slop-detect — directory of scanned sites',
+    name: 'Slop Detector — directory of scanned sites',
     description: 'Opt-in catalogue of sites scored against the AI-design-slop fingerprint.',
     numberOfItems: sites.length,
     itemListElement: sites.slice(0, 200).map((s, i) => ({

--- a/apps/web/functions/leaderboard.tsx
+++ b/apps/web/functions/leaderboard.tsx
@@ -17,6 +17,7 @@
 // surfaces. This page must itself score Clean on the detector it reports.
 
 import { raw } from 'hono/html';
+import { DEFINITIONS_VERSION } from '@slop-detect/core';
 import { getStats } from './_data.js';
 import { tierFor, tierFill, tierText } from './_theme.js';
 import { BRAND_FONTS_HEAD, BRAND_CSS } from './_brand.js';
@@ -277,7 +278,7 @@ export async function onRequestGet({ request, env }: { request: { url: string };
   const stats = data?.stats || {};
   const sites = (data?.sites || []).filter((s: any) => s.scored);
   const scored = data?.scored || sites.length;
-  const def = data?.definitionsVersion || '2026.08';
+  const def = data?.definitionsVersion || DEFINITIONS_VERSION;
   const when = data?.generatedAt ? new Date(data.generatedAt).toISOString().slice(0, 10) : '—';
 
   // The all-time live counter (every scan slop-detect has ever run, not just the

--- a/apps/web/leaderboard/build.mjs
+++ b/apps/web/leaderboard/build.mjs
@@ -12,6 +12,7 @@
 //                 byBuilder, byCategory, sites:[{domain,score,grade,tier,...}] }
 
 import { readFileSync, writeFileSync } from 'node:fs';
+import { DEFINITIONS_VERSION } from '@slop-detect/core';
 
 const API = process.env.SLOP_API || 'https://slop-detect.com';
 const KEY = process.env.SLOP_API_KEY || null;
@@ -114,7 +115,7 @@ function buildReport(sites, corpus) {
 
   return {
     generatedAt: new Date().toISOString(),
-    definitionsVersion: scored[0]?.score != null ? '2026.08' : '2026.08',
+    definitionsVersion: DEFINITIONS_VERSION,
     count: sites.length,
     scored: scored.length,
     stats: {

--- a/apps/web/test/leaderboard.test.js
+++ b/apps/web/test/leaderboard.test.js
@@ -7,7 +7,7 @@ import { onRequestGet } from '../functions/leaderboard.tsx';
 
 const SAMPLE = {
   generatedAt: '2026-06-05T00:00:00.000Z',
-  definitionsVersion: '2026.08',
+  definitionsVersion: '2026.09',
   count: 3,
   scored: 3,
   stats: { avgScore: 17, slopShare: 33, cleanCount: 2, mildCount: 1, heavyCount: 0 },


### PR DESCRIPTION
Phase C build task ?? (`residual-cleanup`) per docs/parity-spec.md. Rebased onto current main. Acceptance = parity-spec "### Build task ??" (design fidelity + functional parity / MNR floor + real green tests + dogfood/responsive/a11y). Full web suite + typecheck green per the build worker; clean commit (Ravindra Kumar, no trailers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and version-label consistency only; no scoring, auth, or API behavior changes beyond using the shared constant.
> 
> **Overview**
> **Residual cleanup** removes duplicated fingerprint version strings and aligns one structured-data label with product naming.
> 
> The directory page’s ItemList JSON-LD **`name`** now reads **“Slop Detector — directory of scanned sites”** instead of the lowercase **“slop-detect”** form, so crawlers see consistent branding.
> 
> Leaderboard rendering and the **`leaderboard/build.mjs`** dataset writer no longer hardcode **`2026.08`**; both import **`DEFINITIONS_VERSION`** from **`@slop-detect/core`** (fallback on the page when JSON is missing, and the field written into **`leaderboard.json`**). The leaderboard test fixture’s **`definitionsVersion`** is bumped to **`2026.09`** to match the current core export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419f9618eb62414616ec1e198fa0ae6b32bd2690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->