### PR TITLE
Production readiness: CI, security hardening, v0.8.0 alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
       - name: Scan a known-clean page (HN)
+        env:
+          # Chromium was installed above — skip the CLI's lazy installer so its
+          # download progress can't pollute stdout (which is redirected to JSON).
+          SKIP_PLAYWRIGHT_DOWNLOAD: 1
         run: |
           cd packages/cli
           node dist/bin/slop.js https://news.ycombinator.com --json > result.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,8 @@
 # Generated / vendored — never reformat
 node_modules
 package-lock.json
+# Astro content-collections codegen (regenerated on build)
+examples/astro-blog/.astro
 **/dist
 **/build
 apps/web/public/**

--- a/apps/web/functions/_ssrf.ts
+++ b/apps/web/functions/_ssrf.ts
@@ -109,3 +109,35 @@ export function validateScanUrl(raw) {
 export function isAllowedUrl(raw) {
   return !validateScanUrl(raw).error;
 }
+
+// Worker-side fetch with manual redirect following and per-hop SSRF re-checks.
+// Mirrors packages/core/src/aeo.ts fetchWithTimeout so a public DESIGN.md URL
+// cannot 302 to cloud metadata or RFC-1918. Returns null when blocked, timed
+// out, or too many hops — callers treat that as "unreachable".
+export async function fetchAllowedUrl(url, init = {}, { timeoutMs = 8000, maxHops = 6 } = {}) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    let current = String(url);
+    for (let hop = 0; hop < maxHops; hop++) {
+      if (!isAllowedUrl(current)) return null;
+      const res = await fetch(current, {
+        ...init,
+        signal: controller.signal,
+        redirect: 'manual',
+      });
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get('location');
+        if (!loc) return res;
+        current = new URL(loc, current).toString();
+        continue;
+      }
+      return res;
+    }
+    return null;
+  } catch (_) {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}

--- a/apps/web/functions/api/_middleware.ts
+++ b/apps/web/functions/api/_middleware.ts
@@ -427,10 +427,23 @@ export async function onRequest(context) {
       const day = new Date().toISOString().slice(0, 10);
       const gkey = `rl:global:scan:${day}`;
       let used = 0;
+      let kvReadOk = false;
       try {
         used = parseInt(await env.RATE_LIMIT.get(gkey), 10) || 0;
+        kvReadOk = true;
       } catch (_) {
-        /* fail open on read */
+        /* handled below */
+      }
+      if (!kvReadOk) {
+        return jsonResponse(
+          {
+            error: 'scanning_paused',
+            message:
+              'Scanning is temporarily unavailable while capacity limits are checked. Try again shortly or self-host.',
+          },
+          503,
+          origin
+        );
       }
       if (used >= cap) {
         return jsonResponse(

--- a/apps/web/functions/api/dashboard/link.ts
+++ b/apps/web/functions/api/dashboard/link.ts
@@ -17,6 +17,25 @@ function json(data, status = 200) {
   });
 }
 
+// Per-email send cap — stops address bombing while keeping the anti-enumeration
+// response identical (we skip the send silently when over limit).
+const DASHLINK_LIMIT = 3;
+const DASHLINK_WINDOW_SEC = 3600;
+
+async function dashLinkAllowed(kv, email) {
+  if (!kv) return true;
+  const key = `rl:dashlink:${email}`;
+  try {
+    const n = parseInt(await kv.get(key), 10) || 0;
+    if (n >= DASHLINK_LIMIT) return false;
+    await kv.put(key, String(n + 1), { expirationTtl: DASHLINK_WINDOW_SEC });
+    return true;
+  } catch {
+    // Fail closed on the send path when KV is unavailable.
+    return false;
+  }
+}
+
 export async function onRequestPost({ request, env, waitUntil }) {
   if (!env.RESULTS)
     return json({ error: 'dashboard_unavailable', message: 'Storage is offline.' }, 503);
@@ -50,7 +69,7 @@ export async function onRequestPost({ request, env, waitUntil }) {
 
   try {
     const watches = await listWatchesByEmail(env.RESULTS, email);
-    if (watches.length) {
+    if (watches.length && (await dashLinkAllowed(env.RATE_LIMIT, email))) {
       // Issue + send out-of-band so the response latency is IDENTICAL whether or
       // not the address owns watches. Doing the KV write + email round-trip inline
       // would make existence measurable (a timing oracle) despite the generic

--- a/apps/web/functions/api/scan.ts
+++ b/apps/web/functions/api/scan.ts
@@ -30,6 +30,7 @@ import {
   recordScan,
   validateScanUrl,
   isAllowedUrl,
+  fetchAllowedUrl,
   recordScanForWatch,
 } from '../_shared.js';
 import { report } from '../_report.js';
@@ -210,18 +211,12 @@ export async function onRequestPost({ request, env }) {
           : new URL('/DESIGN.md', data.url || url).toString();
       let mdText = null;
       if (isAllowedUrl(mdUrl)) {
-        try {
-          const ctl = new AbortController();
-          const t = setTimeout(() => ctl.abort(), 8000);
-          const res = await fetch(mdUrl, {
-            signal: ctl.signal,
-            headers: { Accept: 'text/markdown,text/plain,*/*' },
-          });
-          clearTimeout(t);
-          if (res.ok) mdText = (await res.text()).slice(0, 200_000);
-        } catch (_) {
-          /* unreachable DESIGN.md → reported as "no system" below */
-        }
+        const res = await fetchAllowedUrl(
+          mdUrl,
+          { headers: { Accept: 'text/markdown,text/plain,*/*' } },
+          { timeoutMs: 8000 }
+        );
+        if (res?.ok) mdText = (await res.text()).slice(0, 200_000);
       }
       result.system = scoreSystemCompliance(
         mdText ? parseDesignMd(mdText) : null,

--- a/apps/web/functions/index.ts
+++ b/apps/web/functions/index.ts
@@ -19,7 +19,7 @@ function agentView() {
     url: ORIGIN,
     license: 'MIT',
     repository: 'https://github.com/ravidsrk/slop-detect',
-    version: '0.7.0',
+    version: '0.8.0',
     catalogue: {
       definitionsVersion: DEFINITIONS_VERSION,
       patternCount: PATTERNS.length,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slop-detect-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Cloudflare Pages app for slop-detect.com — web UI + /api/scan + /api/fix-prompt.",
   "type": "module",

--- a/apps/web/public/.well-known/agent-card.json
+++ b/apps/web/public/.well-known/agent-card.json
@@ -4,7 +4,7 @@
   "description": "Score any landing page against the AI-design-slop fingerprint. Deterministic, weighted 0-100 scoring on real headless Chromium, plus an AEO axis (can AI engines read & cite a page). Open source, MIT.",
   "url": "https://slop-detect.com",
   "preferredTransport": "JSONRPC",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "documentationUrl": "https://slop-detect.com/llms.txt",
   "provider": {
     "organization": "Slop Detector",

--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -3,7 +3,7 @@
   "name": "slop-detect-mcp",
   "displayName": "Slop Detector",
   "description": "MCP server that scores any landing page against the AI-design-slop fingerprint (deterministic 0-100, real Chromium) and an AEO axis, and builds fix prompts.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "vendor": {
     "name": "Slop Detector",
     "url": "https://slop-detect.com"

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -88,7 +88,7 @@
       "operatingSystem": "Web, Node.js (CLI), MCP",
       "url": "https://slop-detect.com",
       "downloadUrl": "https://www.npmjs.com/package/slop-detect",
-      "softwareVersion": "0.7.0",
+      "softwareVersion": "0.8.0",
       "license": "https://opensource.org/licenses/MIT",
       "isAccessibleForFree": true,
       "publisher": { "@id": "https://slop-detect.com/#org" },

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Slop Detector API",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "summary": "Deterministic AI-design-slop scoring for landing pages, plus an AEO axis.",
     "description": "Score any landing page against the AI-design fingerprint. The API runs the same deterministic, weighted 0-100 engine as the web app and CLI, on real headless Chromium (Cloudflare Browser Rendering). No API key is required for normal use; requests are rate-limited per IP and the browser-driving routes (/api/scan, /api/aeo) are protected by a Turnstile challenge for browser origins. Foreign browser origins must present an API key. CLI / server-to-server callers (no Origin header) are allowed but rate-limited harder.",
     "license": {

--- a/apps/web/test/dashboard.test.js
+++ b/apps/web/test/dashboard.test.js
@@ -144,6 +144,23 @@ test('link endpoint never reveals whether an email has watches (anti-enumeration
   expect(sent[0].text).toMatch(/\/dashboard\?token=/);
 });
 
+test('link endpoint rate-limits magic-link sends per email (anti-bombing)', async () => {
+  const sent = [];
+  globalThis.fetch = async (_url, opts) => {
+    sent.push(JSON.parse(opts.body));
+    return new Response('{}', { status: 200 });
+  };
+  const kv = makeKv({ 'w:a.com': watch('a.com', 'known@x.io') });
+  const env = { RESULTS: kv, RATE_LIMIT: kv, ...LIVE_ENV };
+
+  for (let i = 0; i < 4; i++) {
+    const res = await linkPost({ request: postReq({ email: 'known@x.io' }), env });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  }
+  expect(sent.length).toBe(3);
+});
+
 test('dashboard link email copy: single-use, 15 minutes, privacy', () => {
   const m = buildDashboardLinkEmail('https://slop-detect.com/dashboard?token=abc', 3);
   expect(m.text).toMatch(/token=abc/);

--- a/apps/web/test/middleware.test.js
+++ b/apps/web/test/middleware.test.js
@@ -151,9 +151,7 @@ test('global daily cap fails closed when KV read errors', async () => {
     headers: { 'CF-Connecting-IP': '203.0.113.55' },
     body: { url: 'https://x.com' },
   });
-  const res = await onRequest(
-    makeContext(req, { RATE_LIMIT: flakyKv, SCAN_DAILY_CAP: '10000' })
-  );
+  const res = await onRequest(makeContext(req, { RATE_LIMIT: flakyKv, SCAN_DAILY_CAP: '10000' }));
   expect(res.status).toBe(503);
   expect((await res.json()).error).toBe('scanning_paused');
 });

--- a/apps/web/test/middleware.test.js
+++ b/apps/web/test/middleware.test.js
@@ -139,6 +139,25 @@ test('global daily cap returns 503 daily_capacity_reached for scans', async () =
   expect((await res.json()).error).toBe('daily_capacity_reached');
 });
 
+test('global daily cap fails closed when KV read errors', async () => {
+  const flakyKv = {
+    get: async (k) => {
+      if (k.startsWith('rl:global:scan:')) throw new Error('KV down');
+      return '0';
+    },
+    put: async () => {},
+  };
+  const req = makeRequest({
+    headers: { 'CF-Connecting-IP': '203.0.113.55' },
+    body: { url: 'https://x.com' },
+  });
+  const res = await onRequest(
+    makeContext(req, { RATE_LIMIT: flakyKv, SCAN_DAILY_CAP: '10000' })
+  );
+  expect(res.status).toBe(503);
+  expect((await res.json()).error).toBe('scanning_paused');
+});
+
 test('SCAN_DISABLED kill switch returns 503 scanning_paused', async () => {
   const okKv = { get: async () => '0', put: async () => {} };
   const req = makeRequest({

--- a/apps/web/test/ssrf.test.js
+++ b/apps/web/test/ssrf.test.js
@@ -3,8 +3,13 @@
 // page content — these tests lock in that private/loopback/metadata hosts and
 // non-http(s) schemes are rejected, while legitimate public URLs pass.
 
-import { test, expect } from 'vitest';
-import { validateScanUrl } from '../functions/_shared.ts';
+import { test, expect, afterEach } from 'vitest';
+import { validateScanUrl, fetchAllowedUrl } from '../functions/_shared.ts';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
 
 const BLOCKED = [
   'http://169.254.169.254/latest/meta-data/', // AWS/GCP metadata
@@ -74,4 +79,15 @@ test('SSRF guard rejects empty / non-string input', () => {
     expect(r.error).toBeTruthy();
     expect(r.status).toBe(400);
   }
+});
+
+test('fetchAllowedUrl blocks redirect chains to private hosts', async () => {
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('public.example.com')) {
+      return new Response('', { status: 302, headers: { location: 'http://127.0.0.1/secret' } });
+    }
+    return new Response('leaked', { status: 200 });
+  };
+  const res = await fetchAllowedUrl('https://public.example.com/DESIGN.md');
+  expect(res).toBeNull();
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slop-detect-monorepo",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Score any landing page against the multi-axis (design + copy) AI-slop fingerprint. Detect Cursor/v0/Lovable templates and GPT-default copy in the wild.",
   "type": "module",
   "packageManager": "bun@1.3.5",

--- a/packages/cli/src/detector.ts
+++ b/packages/cli/src/detector.ts
@@ -88,7 +88,8 @@ async function ensureChromium() {
     }
     process.stderr.write('slop-detect: first run — downloading Chromium (~150 MB, one-time)…\n');
     const r = spawnSync('npx', ['--yes', 'playwright', 'install', 'chromium'], {
-      stdio: 'inherit',
+      // Pipe stdout so a `--json` redirect never captures download progress.
+      stdio: ['ignore', 'pipe', 'inherit'],
       shell: process.platform === 'win32',
     });
     if (r.status !== 0) {

--- a/packages/cli/test/golden.test.js
+++ b/packages/cli/test/golden.test.js
@@ -16,14 +16,18 @@ const fixture = (name) => new URL(`./fixtures/${name}`, import.meta.url).href;
 const triggered = (r, id) => r.patterns.find((p) => p.id === id)?.triggered === true;
 const fixtureText = (name) => readFile(new URL(`./fixtures/${name}`, import.meta.url), 'utf8');
 
-test('clean artisan page scores Clean and trips no font/purple tells', { skip: !RUN }, async () => {
-  const r = await scanUrl(fixture('clean-artisan.html'), { axes: ['design'] });
-  expect(r.tier).toBe('Clean');
-  expect(r.score).toBeLessThan(10);
-  expect(triggered(r, 'slop_fonts')).toBe(false);
-  expect(triggered(r, 'purple_accent')).toBe(false);
-  expect(triggered(r, 'gradient_text')).toBe(false);
-});
+test(
+  'clean artisan page scores Clean and trips no font/purple tells',
+  { skip: !RUN, timeout: 60_000 },
+  async () => {
+    const r = await scanUrl(fixture('clean-artisan.html'), { axes: ['design'] });
+    expect(r.tier).toBe('Clean');
+    expect(r.score).toBeLessThan(10);
+    expect(triggered(r, 'slop_fonts')).toBe(false);
+    expect(triggered(r, 'purple_accent')).toBe(false);
+    expect(triggered(r, 'gradient_text')).toBe(false);
+  }
+);
 
 test(
   'maximal VibeCode page scores out of Clean with the canonical tells',

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
   test: {
     include: ['test/**/*.test.{ts,js}'],
     environment: 'node',
+    // Golden fixtures cold-start Chromium on first run; 5s default flakes locally.
+    testTimeout: 60_000,
   },
 });


### PR DESCRIPTION
## Summary

Closes the actionable gaps from the production-readiness adversarial review. Seven atomic commits, each fixing one issue.

## Commits

1. **fix(ci):** Stop Playwright lazy-install from corrupting smoke-cli JSON (`SKIP_PLAYWRIGHT_DOWNLOAD` + pipe installer stdout)
2. **chore:** Align web/root/discovery surfaces to `0.8.0` so `publish.yml` tag verification passes
3. **fix(web):** `fetchAllowedUrl` — per-hop SSRF checks on `designMd` worker fetch (matches AEO path)
4. **fix(web):** Dashboard magic-link capped at 3 emails/address/hour (anti-bombing, anti-enumeration preserved)
5. **fix(web):** Global daily scan cap fails closed when KV read errors
6. **chore:** Prettier ignores Astro-generated `.astro/` types
7. **test(cli):** 60s vitest timeout for golden Chromium cold starts

## Verification

- `bun run build` — pass
- `bun run test` — 256 web + 56 core + 9 mcp + 5 cli (7 golden skipped) — pass
- `bun run format:check` — pass

## Post-merge (human)

- [ ] Merge → tag `v0.8.0` → `deploy.yml` + `publish.yml`
- [ ] Verify live: Newsreader fonts, `definitions@2026.09`, CSP/HSTS headers
- [ ] Enable branch protection requiring CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF fetch paths, scan availability during KV outages, and auth email rate limits—security- and availability-sensitive, but changes are narrow with matching tests.
> 
> **Overview**
> **Production readiness** closes gaps from the adversarial review: security hardening, reliable CI, and version alignment for **v0.8.0**.
> 
> **Web / SSRF & abuse:** `DESIGN.md` fetches on scan now use **`fetchAllowedUrl`** — manual redirects with **per-hop SSRF checks** (same idea as the AEO path), so a public URL cannot 302 to metadata or private hosts. The **global daily scan cap** **fails closed** when KV cannot be read (`scanning_paused` 503 instead of fail-open). Dashboard magic links are capped at **3 sends per email per hour** while keeping the same generic response (anti-bombing, anti-enumeration preserved).
> 
> **CLI & CI:** Smoke test sets **`SKIP_PLAYWRIGHT_DOWNLOAD=1`** after installing Chromium; lazy-install **pipes installer stdout** so `--json` redirects stay valid. Golden Vitest runs get a **60s** default timeout for Chromium cold starts.
> 
> **Release & hygiene:** Public version strings move **0.7.0 → 0.8.0** (root, web, OpenAPI, agent/MCP cards, JSON-LD). Prettier ignores **Astro-generated** `examples/astro-blog/.astro`. New tests cover redirect SSRF, KV fail-closed cap, and dash-link rate limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d09596f48128aa9413cde58884519709e3234eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->