### PR TITLE
feat(web): result peer-analytics — rank-average radar overlay + category-neighbors tile

### DIFF
--- a/apps/web/functions/_data.ts
+++ b/apps/web/functions/_data.ts
@@ -7,7 +7,33 @@
 //
 // Framework-agnostic: this is the layer the route handlers (and a future Hono
 // app) call into, so it imports only the leaf utils, never anything presentational.
+import { PATTERNS } from '@slop-detect/core';
 import { domainOf, newId, tierRank } from './_util.js';
+
+// ── pattern-category clean fractions (shared record + render) ────────────────
+// The five overview bars / radar axes map engine pattern categories to display
+// names. Order is stable — bumpCategoryStats and buildResultView both key off it.
+export const PATTERN_CATEGORY_ORDER = ['fonts', 'colors', 'layout', 'css', 'images'] as const;
+
+const CAT_MAX: Record<string, number> = {};
+for (const p of PATTERNS as any[]) CAT_MAX[p.category] = (CAT_MAX[p.category] || 0) + p.weight;
+const PATTERN_BY_ID = new Map((PATTERNS as any[]).map((p) => [p.id, p]));
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
+
+// Per-category clean fraction (0..1) for a slim record. Same formula as
+// buildResultView's categories[].cleanFraction — one source of truth.
+export function categoryCleanFractions(slim: any): Record<string, number> {
+  const triggered = (slim?.triggered || []).filter(Boolean);
+  const out: Record<string, number> = {};
+  for (const key of PATTERN_CATEGORY_ORDER) {
+    const hits = triggered.filter((t: any) => PATTERN_BY_ID.get(t.id)?.category === key);
+    const weight = hits.reduce((s: number, t: any) => s + (t.weight || 0), 0);
+    const max = CAT_MAX[key] || 0;
+    const ratio = max > 0 ? clamp01(weight / max) : 0;
+    out[key] = 1 - ratio;
+  }
+  return out;
+}
 
 const RESULT_TTL = 60 * 60 * 24 * 90; // 90 days
 const DOMAIN_TTL = 60 * 60 * 24 * 90;
@@ -253,6 +279,46 @@ function historyPoint(slim) {
 // enumerating per-domain keys. Read-modify-write is not atomic in KV, so counts
 // are approximate under heavy concurrency, which is fine for a percentile.
 const STATS_DIST_KEY = 'stats:dist';
+const STATS_CATCLEAN_KEY = 'stats:catclean';
+
+type CatCleanStore = { cats: Record<string, { sum: number; n: number }>; count: number };
+
+async function getCategoryCleanStore(kv: any): Promise<CatCleanStore> {
+  if (!kv) return { cats: {}, count: 0 };
+  const raw = await kv.get(STATS_CATCLEAN_KEY);
+  if (!raw) return { cats: {}, count: 0 };
+  try {
+    const o = JSON.parse(raw);
+    return {
+      cats: o.cats && typeof o.cats === 'object' ? o.cats : {},
+      count: Number(o.count) || 0,
+    };
+  } catch {
+    return { cats: {}, count: 0 };
+  }
+}
+
+export async function getCategoryCleanAverages(kv: any) {
+  const store = await getCategoryCleanStore(kv);
+  const averages: Record<string, number> = {};
+  for (const [k, { sum, n }] of Object.entries(store.cats)) {
+    if (n > 0) averages[k] = sum / n;
+  }
+  return { averages, count: store.count };
+}
+
+async function bumpCategoryStats(kv: any, slim: any) {
+  if (!kv || !slim) return;
+  const fracs = categoryCleanFractions(slim);
+  const store = await getCategoryCleanStore(kv);
+  for (const key of PATTERN_CATEGORY_ORDER) {
+    if (!store.cats[key]) store.cats[key] = { sum: 0, n: 0 };
+    store.cats[key].sum += fracs[key];
+    store.cats[key].n += 1;
+  }
+  store.count += 1;
+  await kv.put(STATS_CATCLEAN_KEY, JSON.stringify(store)); // durable: no TTL
+}
 
 export async function getScoreDistribution(kv) {
   const empty = () => new Array(101).fill(0);
@@ -334,6 +400,7 @@ export async function recordScan(kv, slim) {
   await Promise.all([
     appendHistory(kv, slim.domain, historyPoint(slim)),
     bumpScoreStats(kv, slim.score),
+    bumpCategoryStats(kv, slim),
   ]);
 }
 

--- a/apps/web/functions/_result.tsx
+++ b/apps/web/functions/_result.tsx
@@ -18,6 +18,7 @@
 // not edit it (foundation acceptance gate).
 
 import { PATTERNS, FIXES, AEO_CHECKS } from '@slop-detect/core';
+import { categoryCleanFractions } from './_data.js';
 import { jsonForScript } from './_render.js';
 import { tierFill, tierText, tierPillBg, systemAxisColor } from './_theme.js';
 import { LetterAvatar, ScoreTierBadge, LiveBadge, Button, SectionLedger } from './_ui.js';
@@ -52,6 +53,7 @@ const firstSentence = (s: string) => {
 // permalink/report pages (and tests) can build the same model.
 export function buildResultView(slim: any) {
   const triggered = (slim?.triggered || []).filter(Boolean);
+  const cleanFracs = categoryCleanFractions(slim);
 
   // Per-category rollup, in the fixed display order.
   const categories = CATS.map((c) => {
@@ -65,8 +67,8 @@ export function buildResultView(slim: any) {
       label: c.label,
       flagged: hits.length,
       weight,
-      cleanPct: Math.round((1 - ratio) * 100),
-      cleanFraction: 1 - ratio,
+      cleanPct: Math.round(cleanFracs[c.key] * 100),
+      cleanFraction: cleanFracs[c.key],
       tier,
       patterns: hits
         .slice()
@@ -230,6 +232,20 @@ export const RESULT_CSS = `
   .chart-delta{font-family:var(--mono);font-size:12px;margin-top:8px}
   .chart-cap{font-family:var(--mono);font-size:12px;color:var(--text-4);margin-top:8px}
   .chart-cap strong{color:var(--text-2)}
+  .chart-legend{display:flex;gap:16px;margin-top:8px;font-family:var(--mono);font-size:11.5px;color:var(--text-4)}
+  .chart-legend-you{font-weight:600}
+  .chart-legend-avg{color:#9A9B8E}
+
+  /* category neighbors tile */
+  .nb-row{display:grid;grid-template-columns:28px 20px 1fr auto;align-items:center;gap:10px;padding:9px 4px;border-bottom:1px solid var(--row);text-decoration:none;color:inherit}
+  .nb-row:hover{background:var(--bg-2)}
+  .nb-row:last-child{border-bottom:0}
+  .nb-you{background:rgba(31,168,94,0.08)}
+  .nb-rank{font-family:var(--mono);font-size:12px;color:var(--text-6);text-align:right}
+  .nb-name{font-size:14px;font-weight:600;color:var(--text);line-height:1.2}
+  .nb-dom{font-family:var(--mono);font-size:11px;color:var(--text-5);margin-top:1px}
+  .nb-score{font-family:var(--mono);font-size:13px;color:var(--text-3);white-space:nowrap}
+  .nb-grade{font-weight:700}
 
   /* fixes panel */
   .fixes{border:1px solid var(--border);border-radius:10px;background:var(--panel);padding:38px 36px}
@@ -708,9 +724,20 @@ function ScoreOverTime({ points }: { points: any[] }) {
 }
 
 // Cleanliness radar: a pentagon over the five categories. The "you" polygon is the
-// per-category clean fraction; two guide rings frame it. No rank-average polygon —
-// per-category corpus averages are not persisted, so it is omitted rather than faked.
-function Radar({ categories, tier }: { categories: any[]; tier: string }) {
+// per-category clean fraction; two guide rings frame it. When corpus per-category
+// averages exist (stats:catclean, count >= 5), a dashed rank-average overlay draws
+// on top — otherwise omitted rather than faked.
+function Radar({
+  categories,
+  tier,
+  catAvg = null,
+  catAvgCount = 0,
+}: {
+  categories: any[];
+  tier: string;
+  catAvg?: number[] | null;
+  catAvgCount?: number;
+}) {
   const W = 220,
     H = 150,
     cx = W / 2,
@@ -736,6 +763,20 @@ function Radar({ categories, tier }: { categories: any[]; tier: string }) {
         .join(',')
     )
     .join(' ');
+  const showAvg =
+    !!catAvg &&
+    catAvg.length === categories.length &&
+    catAvgCount >= 5 &&
+    catAvg.every((v) => typeof v === 'number' && Number.isFinite(v));
+  const avg = showAvg
+    ? catAvg!
+        .map((v, i) =>
+          ptAt(i, R * clamp01(v))
+            .map((n) => n.toFixed(1))
+            .join(',')
+        )
+        .join(' ')
+    : '';
   const stroke = tierText(tier);
   return (
     <div class="chart-card">
@@ -744,6 +785,15 @@ function Radar({ categories, tier }: { categories: any[]; tier: string }) {
         <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="per-category cleanliness radar">
           <polygon points={ring(R)} fill="none" stroke="#D7D9D2" stroke-width="1" />
           <polygon points={ring(R * 0.5)} fill="none" stroke="#E2E4DD" stroke-width="1" />
+          {showAvg ? (
+            <polygon
+              points={avg}
+              fill="none"
+              stroke="#9A9B8E"
+              stroke-width="1"
+              stroke-dasharray="3 3"
+            />
+          ) : null}
           <polygon
             class="chart-draw"
             points={you}
@@ -768,6 +818,51 @@ function Radar({ categories, tier }: { categories: any[]; tier: string }) {
           })}
         </svg>
       </div>
+      {showAvg ? (
+        <div class="chart-legend">
+          <span class="chart-legend-you" style={`color:${stroke}`}>
+            — you
+          </span>
+          <span class="chart-legend-avg">--- rank avg</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// Same-category peers from the curated leaderboard corpus. Omitted when the domain
+// is not in the corpus or its business category has fewer than two members.
+function Neighbors({
+  categoryLabel,
+  rows,
+  origin,
+}: {
+  categoryLabel: string;
+  rows: any[];
+  origin: string;
+}) {
+  return (
+    <div class="chart-card">
+      <div class="chart-h">{categoryLabel} neighbors</div>
+      {rows.map((r) => (
+        <a
+          class={`nb-row${r.you ? ' nb-you' : ''}`}
+          href={`${origin}/score/${encodeURIComponent(r.domain)}`}
+        >
+          <span class="nb-rank">#{r.rank}</span>
+          <LetterAvatar name={r.domain} size={20} />
+          <span>
+            <div class="nb-name">{r.name}</div>
+            <div class="nb-dom">{r.domain}</div>
+          </span>
+          <span class="nb-score">
+            {r.score}{' '}
+            <span class="nb-grade" style={`color:${tierText(r.tier)}`}>
+              {r.grade}
+            </span>
+          </span>
+        </a>
+      ))}
     </div>
   );
 }
@@ -828,20 +923,42 @@ export function Analytics({
   dist,
   slim,
   categories,
+  catAvg = null,
+  catAvgCount = 0,
+  neighbors = null,
+  origin = '',
 }: {
   history?: any[];
   dist?: number[] | null;
   slim: any;
   categories: any[];
+  catAvg?: number[] | null;
+  catAvgCount?: number;
+  neighbors?: { categoryLabel: string; rows: any[] } | null;
+  origin?: string;
 }) {
   const points = (history || []).filter((h) => typeof h.score === 'number').slice(-30);
   const totalScans = dist ? dist.reduce((s, n) => s + (n || 0), 0) : 0;
   const showTime = points.length >= 2;
   const showDist = !!dist && totalScans >= 5;
+  const showNeighbors = !!neighbors?.rows?.length;
+  if (!showTime && !showDist && !showNeighbors && !categories.length) return null;
   return (
     <div class="analytics">
       {showTime ? <ScoreOverTime points={points} /> : null}
-      <Radar categories={categories} tier={slim.tier} />
+      <Radar
+        categories={categories}
+        tier={slim.tier}
+        catAvg={catAvg}
+        catAvgCount={catAvgCount}
+      />
+      {showNeighbors ? (
+        <Neighbors
+          categoryLabel={neighbors!.categoryLabel}
+          rows={neighbors!.rows}
+          origin={origin}
+        />
+      ) : null}
       {showDist ? (
         <Distribution dist={dist as number[]} score={slim.score} tier={slim.tier} />
       ) : null}

--- a/apps/web/functions/score/[domain].tsx
+++ b/apps/web/functions/score/[domain].tsx
@@ -26,6 +26,7 @@ import {
   getListing,
   publicWatch,
   getScoreDistribution,
+  getCategoryCleanAverages,
   percentileFromDistribution,
   jsonForScript,
 } from '../_shared.js';
@@ -52,6 +53,49 @@ import {
 
 const ORIGIN = 'https://slop-detect.com';
 const CSS = BRAND_CSS + UI_CSS + RESULT_CSS;
+
+const CATEGORY_NAMES: Record<string, string> = {
+  'ai-builder': 'AI builders',
+  saas: 'SaaS & dev tools',
+  bigtech: 'Big tech',
+  classic: 'Classic, deliberately plain',
+};
+
+async function loadLeaderboard(request: { url: string }) {
+  try {
+    const res = await fetch(new URL('/leaderboard.json', request.url), {
+      cf: { cacheTtl: 300 },
+    } as any);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+function buildNeighbors(lbData: any, domain: string) {
+  const sites = lbData?.sites;
+  if (!Array.isArray(sites)) return null;
+  const me = sites.find((s: any) => s.domain === domain && s.scored);
+  if (!me) return null;
+  const siblings = sites.filter((s: any) => s.category === me.category && s.scored);
+  if (siblings.length < 2) return null;
+  const sorted = siblings.slice().sort((a: any, b: any) => a.score - b.score);
+  const capped = sorted.slice(0, 6);
+  const categoryLabel = CATEGORY_NAMES[me.category] || me.category;
+  return {
+    categoryLabel,
+    rows: capped.map((s: any) => ({
+      rank: sorted.findIndex((x: any) => x.domain === s.domain) + 1,
+      name: s.title || s.domain,
+      domain: s.domain,
+      score: s.score,
+      grade: s.grade,
+      tier: s.tier,
+      you: s.domain === domain,
+    })),
+  };
+}
 
 // Shared document shell. `head` is the per-state <head> content; `script` is the
 // optional inline progressive-enhancement JS.
@@ -165,12 +209,14 @@ export async function onRequestGet({ params, request, env }) {
     return htmlResponse(node, { status: 503, cache: 'no-store' });
   }
 
-  const [latest, watch, history, listing, dist] = await Promise.all([
+  const [latest, watch, history, listing, dist, catClean, lbData] = await Promise.all([
     getLatestForDomain(env.RESULTS, domain).catch(() => null),
     getWatch(env.RESULTS, domain).catch(() => null),
     getHistory(env.RESULTS, domain).catch(() => []),
     getListing(env.RESULTS, domain).catch(() => null),
     getScoreDistribution(env.RESULTS).catch(() => null),
+    getCategoryCleanAverages(env.RESULTS).catch(() => ({ averages: {}, count: 0 })),
+    loadLeaderboard(request).catch(() => null),
   ]);
   const pub = watch ? publicWatch(watch, history) : null;
   const claimed = !!listing;
@@ -213,6 +259,12 @@ export async function onRequestGet({ params, request, env }) {
 
   // ── full result ──────────────────────────────────────────────────────────────
   const view = buildResultView(latest);
+  const neighbors = buildNeighbors(lbData, domain);
+  let catAvg: number[] | null = null;
+  if (catClean.count >= 5) {
+    const mapped = view.categories.map((c) => catClean.averages[c.key]);
+    if (mapped.every((v) => typeof v === 'number' && Number.isFinite(v))) catAvg = mapped;
+  }
   const pageUrl = `${ORIGIN}/score/${domain}`;
   const ogImg = `${origin}/og/${latest.id}.png`;
   const title = `${domain} scored ${latest.grade} (${latest.score}/100) on the AI-slop detector`;
@@ -319,7 +371,16 @@ export async function onRequestGet({ params, request, env }) {
           <div class="rs-ledger">
             <SectionLedger tag="" label="competitive analytics" />
           </div>
-          <Analytics history={history} dist={dist} slim={latest} categories={view.categories} />
+          <Analytics
+            history={history}
+            dist={dist}
+            slim={latest}
+            categories={view.categories}
+            catAvg={catAvg}
+            catAvgCount={catClean.count}
+            neighbors={neighbors}
+            origin={origin}
+          />
         </section>
 
         <section class="result-section">

--- a/apps/web/functions/score/[domain].tsx
+++ b/apps/web/functions/score/[domain].tsx
@@ -81,11 +81,17 @@ function buildNeighbors(lbData: any, domain: string) {
   const siblings = sites.filter((s: any) => s.category === me.category && s.scored);
   if (siblings.length < 2) return null;
   const sorted = siblings.slice().sort((a: any, b: any) => a.score - b.score);
-  const capped = sorted.slice(0, 6);
+  const myIdx = sorted.findIndex((s: any) => s.domain === domain);
+  const myRank = myIdx + 1;
+  const WINDOW = 6;
+  // Always include the current domain. Top 6 when it ranks there; otherwise the
+  // five cleanest peers plus you at your true category rank.
+  const window =
+    myRank <= WINDOW ? sorted.slice(0, WINDOW) : [...sorted.slice(0, WINDOW - 1), sorted[myIdx]];
   const categoryLabel = CATEGORY_NAMES[me.category] || me.category;
   return {
     categoryLabel,
-    rows: capped.map((s: any) => ({
+    rows: window.map((s: any) => ({
       rank: sorted.findIndex((x: any) => x.domain === s.domain) + 1,
       name: s.title || s.domain,
       domain: s.domain,

--- a/apps/web/test/result-analytics.test.js
+++ b/apps/web/test/result-analytics.test.js
@@ -1,0 +1,84 @@
+// Competitive analytics composites: rank-average radar overlay + category neighbors.
+// Rendered to strings — no browser.
+
+import { test, expect } from 'vitest';
+import { Analytics, buildResultView } from '../functions/_result.tsx';
+
+const r = (node) => node.toString();
+
+const slim = {
+  domain: 'ex.com',
+  score: 30,
+  tier: 'Heavy',
+  grade: 'D',
+  triggered: [{ id: 'slop_fonts', label: 'AI-default font stack', short: 'Slop fonts', weight: 8 }],
+};
+
+const categories = buildResultView(slim).categories;
+
+test('radar draws rank-average polygon + legend only when catAvg present and count >= 5', () => {
+  const withAvg = r(
+    Analytics({
+      slim,
+      categories,
+      catAvg: categories.map((c) => c.cleanFraction * 0.8),
+      catAvgCount: 5,
+    })
+  );
+  expect(withAvg).toMatch(/stroke-dasharray="3 3"/);
+  expect(withAvg).toMatch(/--- rank avg/);
+  expect(withAvg).toMatch(/— you/);
+
+  const lowCount = r(
+    Analytics({ slim, categories, catAvg: categories.map((c) => 0.5), catAvgCount: 4 })
+  );
+  expect(lowCount).not.toMatch(/--- rank avg/);
+  expect(lowCount).not.toMatch(/stroke-dasharray="3 3"/);
+
+  const noAvg = r(Analytics({ slim, categories }));
+  expect(noAvg).not.toMatch(/--- rank avg/);
+});
+
+test('neighbors tile renders siblings, marks you, and links to /score', () => {
+  const html = r(
+    Analytics({
+      slim,
+      categories,
+      origin: 'https://slop-detect.com',
+      neighbors: {
+        categoryLabel: 'SaaS & dev tools',
+        rows: [
+          {
+            rank: 1,
+            name: 'Stripe',
+            domain: 'stripe.com',
+            score: 4,
+            grade: 'A',
+            tier: 'Clean',
+            you: false,
+          },
+          {
+            rank: 2,
+            name: 'Ex',
+            domain: 'ex.com',
+            score: 30,
+            grade: 'D',
+            tier: 'Heavy',
+            you: true,
+          },
+        ],
+      },
+    })
+  );
+  expect(html).toMatch(/SaaS &amp; dev tools neighbors/);
+  expect(html).toMatch(/href="https:\/\/slop-detect\.com\/score\/stripe\.com"/);
+  expect(html).toMatch(/href="https:\/\/slop-detect\.com\/score\/ex\.com"/);
+  expect(html).toMatch(/nb-you/);
+  expect(html).toMatch(/#2/);
+});
+
+test('neighbors tile omitted when data absent', () => {
+  const html = r(Analytics({ slim, categories, origin: 'https://slop-detect.com' }));
+  expect(html).not.toMatch(/class="nb-row/);
+  expect(html).not.toMatch(/ neighbors<\/div>/);
+});

--- a/apps/web/test/score.test.js
+++ b/apps/web/test/score.test.js
@@ -251,6 +251,48 @@ test('peer analytics renders rank-average overlay and neighbors when data is pre
   );
 });
 
+test('neighbors tile always includes the you row at true rank when domain ranks below top 6', async () => {
+  const kv = makeKv();
+  const s = slim({ domain: 'slow.com', score: 90, tier: 'Heavy', grade: 'F' });
+  await saveResult(kv, s);
+  await recordScan(kv, s);
+  const lbLarge = {
+    sites: [
+      { domain: 'a.com', category: 'saas', scored: true, score: 1, grade: 'A+', tier: 'Clean' },
+      { domain: 'b.com', category: 'saas', scored: true, score: 2, grade: 'A', tier: 'Clean' },
+      { domain: 'c.com', category: 'saas', scored: true, score: 3, grade: 'A', tier: 'Clean' },
+      { domain: 'd.com', category: 'saas', scored: true, score: 4, grade: 'A-', tier: 'Clean' },
+      { domain: 'e.com', category: 'saas', scored: true, score: 5, grade: 'B+', tier: 'Clean' },
+      { domain: 'f.com', category: 'saas', scored: true, score: 6, grade: 'B', tier: 'Clean' },
+      { domain: 'g.com', category: 'saas', scored: true, score: 7, grade: 'B-', tier: 'Clean' },
+      {
+        domain: 'slow.com',
+        category: 'saas',
+        scored: true,
+        score: 90,
+        grade: 'F',
+        tier: 'Heavy',
+        title: 'Slow',
+      },
+    ],
+  };
+  await withFetch(
+    async (url) => {
+      if (String(url).endsWith('/leaderboard.json')) {
+        return new Response(JSON.stringify(lbLarge), { status: 200 });
+      }
+      throw new Error('unexpected fetch: ' + url);
+    },
+    async () => {
+      const { html } = await render(kv, 'slow.com');
+      expect(html).toMatch(/SaaS &amp; dev tools neighbors/);
+      expect(html).toMatch(/nb-you/);
+      expect(html).toMatch(/#8/);
+      expect(html).toMatch(/href="https:\/\/slop-detect\.com\/score\/slow\.com"/);
+    }
+  );
+});
+
 test('peer analytics omits overlay and neighbors when data is insufficient', async () => {
   const kv = makeKv();
   const s = slim({ domain: 'orphan.com' });

--- a/apps/web/test/score.test.js
+++ b/apps/web/test/score.test.js
@@ -186,6 +186,91 @@ test('error/retry state renders when the scoring store is unavailable', async ()
   expect(html).toMatch(/name="robots" content="noindex"/);
 });
 
+const LB_SAMPLE = {
+  sites: [
+    {
+      domain: 'stripe.com',
+      category: 'saas',
+      scored: true,
+      score: 4,
+      grade: 'A',
+      tier: 'Clean',
+      title: 'Stripe',
+    },
+    {
+      domain: 'ex.com',
+      category: 'saas',
+      scored: true,
+      score: 30,
+      grade: 'D',
+      tier: 'Heavy',
+      title: 'Ex',
+    },
+    {
+      domain: 'news.ycombinator.com',
+      category: 'classic',
+      scored: true,
+      score: 6,
+      grade: 'A-',
+      tier: 'Clean',
+    },
+  ],
+};
+
+function withFetch(impl, fn) {
+  const orig = globalThis.fetch;
+  globalThis.fetch = impl;
+  return Promise.resolve(fn()).finally(() => {
+    globalThis.fetch = orig;
+  });
+}
+
+test('peer analytics renders rank-average overlay and neighbors when data is present', async () => {
+  const kv = makeKv();
+  const s = slim({ domain: 'ex.com' });
+  await saveResult(kv, s);
+  for (let i = 0; i < 5; i++) {
+    await recordScan(kv, slim({ id: 'seed' + i, domain: `d${i}.com`, score: 20 + i }));
+  }
+  await recordScan(kv, s);
+  await withFetch(
+    async (url) => {
+      if (String(url).endsWith('/leaderboard.json')) {
+        return new Response(JSON.stringify(LB_SAMPLE), { status: 200 });
+      }
+      throw new Error('unexpected fetch: ' + url);
+    },
+    async () => {
+      const { html } = await render(kv, 'ex.com');
+      expect(html).toMatch(/--- rank avg/);
+      expect(html).toMatch(/stroke-dasharray="3 3"/);
+      expect(html).toMatch(/SaaS &amp; dev tools neighbors/);
+      expect(html).toMatch(/href="https:\/\/slop-detect\.com\/score\/stripe\.com"/);
+      expect(html).toMatch(/nb-you/);
+    }
+  );
+});
+
+test('peer analytics omits overlay and neighbors when data is insufficient', async () => {
+  const kv = makeKv();
+  const s = slim({ domain: 'orphan.com' });
+  await saveResult(kv, s);
+  await recordScan(kv, s);
+  await withFetch(
+    async (url) => {
+      if (String(url).endsWith('/leaderboard.json')) {
+        return new Response(JSON.stringify(LB_SAMPLE), { status: 200 });
+      }
+      throw new Error('unexpected fetch: ' + url);
+    },
+    async () => {
+      const { html } = await render(kv, 'orphan.com');
+      expect(html).not.toMatch(/--- rank avg/);
+      expect(html).not.toMatch(/class="nb-row/);
+    }
+  );
+});
+
 test('the page is dogfood-clean: its own CSS uses no slop fonts, gradients, or clip-text', async () => {
   const kv = makeKv();
   const s = slim(); // slop_fonts triggered → fix copy QUOTES "Inter" in the body

--- a/apps/web/test/stats.test.js
+++ b/apps/web/test/stats.test.js
@@ -9,10 +9,13 @@ import {
   getHistory,
   getStats,
   getScoreDistribution,
+  getCategoryCleanAverages,
+  categoryCleanFractions,
   summarizeStats,
   percentileFromDistribution,
   percentileForScore,
 } from '../functions/_shared.ts';
+import { buildResultView } from '../functions/_result.tsx';
 
 function makeKv(seed = {}) {
   const store = new Map(Object.entries(seed));
@@ -37,6 +40,7 @@ function slim(over = {}) {
     score: 8,
     grade: 'A-',
     tier: 'Clean',
+    triggered: [],
     createdAt: '2026-06-01T00:00:00.000Z',
     ...over,
   };
@@ -140,4 +144,35 @@ test('percentileForScore reads the live distribution from KV', async () => {
   await recordScan(kv, slim({ id: 'b', domain: 'b.com', score: 5 }));
   // scoring 5: one site (30) is worse -> cleaner than 50% of 2
   expect(await percentileForScore(kv, 5)).toEqual({ count: 2, cleanerThanPct: 50 });
+});
+
+// ── per-category clean-fraction corpus averages (stats:catclean) ───────────────
+test('recordScan bumps category clean stats; getCategoryCleanAverages aggregates', async () => {
+  const kv = makeKv();
+  const a = slim({
+    id: 'a',
+    triggered: [{ id: 'slop_fonts', label: 'x', short: 'x', weight: 8 }],
+  });
+  const b = slim({ id: 'b', domain: 'b.com', triggered: [] });
+  await recordScan(kv, a);
+  await recordScan(kv, b);
+  const { averages, count } = await getCategoryCleanAverages(kv);
+  expect(count).toBe(2);
+  expect(averages.fonts).toBeGreaterThan(0);
+  expect(averages.fonts).toBeLessThan(1);
+  expect(averages.colors).toBe(1);
+});
+
+test('record-time clean fractions match buildResultView categories', () => {
+  const s = slim({
+    triggered: [
+      { id: 'slop_fonts', label: 'AI-default font stack', short: 'Slop fonts', weight: 8 },
+      { id: 'purple_accent', label: 'Purple accent', short: 'Purple', weight: 6 },
+    ],
+  });
+  const fracs = categoryCleanFractions(s);
+  const view = buildResultView(s);
+  for (const c of view.categories) {
+    expect(fracs[c.key]).toBe(c.cleanFraction);
+  }
 });


### PR DESCRIPTION
This PR closes the only remaining divergence between the live "Slop Detect" design (claude.ai/design 644611bf, Result.dc.html) and the shipped product. The Result/score page competitive-analytics block now renders the two peer-comparison elements the design shows and the product previously omitted, both from REAL data, never fabricated.

Problem: the design's radar carries a dashed rank-average overlay and the analytics block has a category-neighbors tile. The shipped product deliberately omitted both because per-category corpus averages were not persisted and the dogfood/no-fabrication rule bars faking them (documented at _result.tsx:710-712).

Solution:
- Rank-average overlay (pattern categories): new durable KV aggregate stats:catclean, bumped on every recordScan via a shared categoryCleanFractions helper that is the SAME source of truth as buildResultView's per-category cleanFraction (record-time and render-time cannot drift). The radar draws the dashed average polygon + legend only when the aggregate has >= 5 scans; otherwise it renders as before.
- Category-neighbors tile (business categories): the /score hub loads the curated leaderboard.json corpus, finds the domain's siblings in its category (cleanest-first, "you" highlighted, each linking to its /score hub). Omitted entirely when the domain is not in the corpus or has < 2 siblings — no invented category or peers.

Design screens: Result.dc.html (competitive analytics).

Acceptance checklist:
- [ ] Visual parity: dashed rank-avg overlay + legend; neighbors tile (ranks, chips, score+grade, "you" highlight)
- [ ] Honest data only: both render from real persisted/curated data; both OMIT (not fabricate) when data is insufficient (catAvg count < 5; domain not in corpus / < 2 siblings)
- [ ] No regressions: existing analytics charts + recordScan history/distribution unchanged
- [ ] Dogfood: no AI-default fonts, no purple CTA, no gradient/clip text on the new markup
- [ ] Real tests green; coverage not regressed (8 new tests; full web suite + typecheck + lint pass)
- [ ] Engine reused, not rewritten (only the new aggregate added; slim record shape unchanged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a non-TTL KV aggregate and an extra leaderboard fetch on score renders; behavior is gated and does not change scan persistence shape or existing history/distribution logic.
> 
> **Overview**
> Adds the two missing **competitive analytics** pieces on `/score/:domain`: a corpus **rank-average** on the cleanliness radar and a **category neighbors** tile, using real data only and omitting UI when thresholds are not met.
> 
> **Rank-average radar:** Each `recordScan` now updates durable KV `stats:catclean` with per-pattern-category clean fractions via shared `categoryCleanFractions` (same math as `buildResultView`). The radar draws a dashed peer-average polygon and legend only when the aggregate has **≥ 5** scans.
> 
> **Category neighbors:** The score hub fetches `leaderboard.json`, ranks same-business-category peers, and renders up to six rows (top six or five cleanest plus “you” at true rank). The tile is omitted when the domain is not in the corpus or has fewer than two siblings.
> 
> Tests cover KV aggregation, render gating, neighbor windowing, and integration on the score page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf697f182f732856947d8c9c2e73ae52eb9ecba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->