### PR TITLE
docs: adopt-readiness — full 'Slop Detect' design adoption verified

### DIFF
--- a/docs/adopt-readiness.md
+++ b/docs/adopt-readiness.md
@@ -1,0 +1,80 @@
+# Adopt-readiness: "Slop Detect" design, full adoption verified
+
+Final verification for adopting the claude.ai/design project 644611bf ("Slop Detect", the
+score-hub direction: Landing, Leaderboard, Result, Docs, Brand) across the slop-detect web
+product, both visually and feature-wise. Verified on `main` at the merge of PR #63
+(commit 8a25159).
+
+This complements docs/parity-readiness.md (the capstone for the original re-skin, PRs
+#39-62) with the one full-parity addition built afterward (PR #63).
+
+## Verdict
+
+Full adoption. Every screen in the live "Slop Detect" design is implemented on main and
+matches it visually and feature-wise; every prior product capability is preserved (the
+28-point must-not-regress floor in docs/parity-readiness.md); and the one element the
+shipped product had deliberately omitted is now built honestly. No half-migrated screens,
+no placeholders, no dead links. The dogfood guardrail holds.
+
+## Design-adoption matrix (live design 644611bf → product)
+
+| Design screen        | Product surface                         | Status   | Evidence |
+|----------------------|-----------------------------------------|----------|----------|
+| Landing.dc.html      | apps/web/public/index.html              | COMPLETE | re-skinned in place; live canvas diffed 1:1 (tokens, fonts, hero, stats strip, leaderboard preview, 4-axis explainer, dark continuity layer, research, CTA); PR #50 |
+| Leaderboard.dc.html  | functions/leaderboard.tsx + directory.tsx | COMPLETE | distribution histogram, cleanest-overall, by-category boards, opt-in dofollow directory; PRs #48, #53 |
+| Result.dc.html       | functions/score/[domain].tsx + _result.tsx | COMPLETE | DomainHeader, BigScore, CategoryBars, Breakdown, AxisStrip, System/AEO, Analytics (now incl. rank-avg overlay + neighbors), Fixes, Share/Embed, Claim, Monitor; PRs #51, #56, #63 |
+| Docs.dc.html         | functions/docs.tsx (/docs, alias /methodology) | COMPLETE | sticky sidebar, tier table, definitions version; PR #47 |
+| Brand.dc.html        | functions/brand.tsx (/brand)            | COMPLETE | numbered ledger, the 0/100 A+ dogfood proof; PR #49 |
+
+Supporting capabilities (badge, OG card, favicon, dashboard, blog, printable report, aux
+pages, SEO/sitemap, scan-contract test) shipped in PRs #42-#60 and are covered in
+docs/parity-readiness.md.
+
+## The full-parity addition (PR #63)
+
+The live Result design draws two peer-comparison elements the product previously omitted
+(documented in parity-readiness.md as a deliberate, dogfood-driven omission). Built here
+from real data per docs/gap-analytics-spec.md:
+
+- Rank-average radar overlay: a new durable KV aggregate `stats:catclean` accumulates the
+  per-pattern-category clean-fraction on every `recordScan`, via a shared
+  `categoryCleanFractions` helper that is the SAME source of truth as `buildResultView`'s
+  per-category fraction (record-time and render-time cannot drift). The dashed average
+  polygon + legend render only when the aggregate has >= 5 scans, else omitted.
+- Category-neighbors tile: sourced from the curated `leaderboard.json` corpus; shows the
+  domain's category siblings cleanest-first with the "you" row highlighted at its true
+  rank (windowed so the current domain is always included). Omitted when the domain is not
+  in the corpus or its category has < 2 members.
+
+Neither element fabricates data; both omit honestly when data is insufficient. The served
+page still passes slop-detect's own detector (no AI-default fonts, no purple CTA, no
+gradient/clip text).
+
+## Gates (main at 8a25159)
+
+| Gate      | Command             | Result                                            |
+|-----------|---------------------|---------------------------------------------------|
+| Install   | `bun install`       | clean                                             |
+| Typecheck | `bun run typecheck` | 7/7 turbo tasks, exit 0                            |
+| Lint      | `bun run lint`      | 3/3, no ESLint warnings or errors                 |
+| Test      | `bun run test`      | 6/6 turbo; web 24 files / 264 tests passed        |
+
+CLI golden suite (7 tests) stays gated behind `RUN_GOLDEN=1` (needs a Chromium binary; run
+in CI's smoke job), as documented in parity-readiness.md. PR #63 added 8 web tests
+(263 -> 264 includes the rank>6 neighbors regression test); coverage did not regress.
+
+## Residual risks / documented limitations
+
+- The rank-average overlay and neighbors tile only render once their data thresholds are
+  met (catAvg count >= 5; domain in the curated corpus). On a sparse corpus they omit
+  rather than fabricate — by design, per the dogfood guardrail.
+- The earlier limitation noted in parity-readiness.md (radar drew 3 charts, not 4, because
+  per-category corpus averages were not persisted) is now closed: the rank-average polygon
+  is the 4th element, drawn from the real `stats:catclean` aggregate.
+- CLI golden suite remains an environment gate (Chromium), not a coverage gap.
+
+## Merged PRs
+
+Original re-skin: #39-#62 (see docs/parity-readiness.md).
+Full-parity addition: #63 (result peer-analytics — rank-average radar overlay +
+category-neighbors tile, both from real data).

--- a/docs/gap-analytics-spec.md
+++ b/docs/gap-analytics-spec.md
@@ -1,0 +1,99 @@
+# Build spec (FROZEN): Result peer-analytics — rank-average radar overlay + neighbors tile
+
+Closes the only remaining divergence between the live "Slop Detect" design (project
+644611bf, Result.dc.html) and the shipped product. The design's competitive-analytics
+block draws two peer-comparison elements the product currently omits. User chose
+"Build both, real data" (full parity, dogfood-honest). This spec is the frozen contract;
+the reviewer grades against it.
+
+Branch: ravidsrk/result-peer-analytics · base: origin/main · one PR, commits preserved.
+
+## Non-negotiable: dogfood guardrail
+
+Both elements depend on data the backend does NOT currently persist. The mock
+(scandata.js) fabricates them (a flat `ringPts(0.58)`, a static neighbors array). That is
+BARRED. Every number rendered must come from real persisted/curated data. When the data
+is insufficient, OMIT the element (or show an honest empty state) — never fabricate. The
+served page must still pass slop-detect's own detector: no AI-default fonts, no purple
+CTA, no gradient/background-clip text, flat 1px surfaces, reuse `_theme.ts` tokens and
+`_ui.tsx`/`_result.tsx` components.
+
+## Element 1 — rank-average polygon (cleanliness radar overlay)
+
+Design: a dashed pentagon overlaid on the existing "you" radar, plus legend
+"— you · --- rank avg". Source today: none (see `_result.tsx:710-712`, the documented
+omission). Build a real rolling corpus average per PATTERN category.
+
+Data model (`apps/web/functions/_data.ts`):
+
+- New durable KV key `stats:catclean` (no TTL), parallel to `stats:dist`. Stores, per
+  pattern category, the running sum of clean-fractions and the count, e.g.
+  `{ <catId>: { sum: number, n: number }, ... }`.
+- `getCategoryCleanAverages(kv)` → `{ averages: Record<catId, number 0..1>, count: number }`
+  (count = number of scans contributing; per-category average = sum/n).
+- `bumpCategoryStats(kv, slim)` accumulates one scan's per-category clean-fractions.
+- Call `bumpCategoryStats` from `recordScan` (alongside `appendHistory` + `bumpScoreStats`),
+  so every persisted scan contributes. Read-modify-write, approximate under concurrency —
+  fine for an average, same as `stats:dist`.
+- The per-category clean-fraction MUST be computed from the SAME source of truth that
+  `buildResultView` uses to reconstruct radar categories (engine pattern catalogue +
+  `slim.triggered`). Extract a single pure helper (e.g. `categoryCleanFractions(slim)`)
+  and use it BOTH in `bumpCategoryStats` and wherever `buildResultView` derives
+  `categories[].cleanFraction`, so record-time and render-time can never drift. Key the
+  aggregate by the engine's stable category id; align order with `buildResultView`.
+
+Render (`apps/web/functions/_result.tsx` `Radar` + `Analytics`):
+
+- `Analytics`/`Radar` accept an optional `catAvg: number[] | null` aligned 1:1 with
+  `categories` (same order). When present AND the aggregate count >= 5, draw a second
+  polygon from `catAvg` using `stroke="#9A9B8E" stroke-dasharray="3 3" fill="none"`
+  (match the mock), and render the two-item legend. When absent or count < 5, render the
+  radar exactly as today (no overlay, no legend) — omit, don't fake.
+- Update the `:710-712` comment to describe the real overlay + its gate.
+
+Wire-in (`apps/web/functions/score/[domain].tsx`): load `getCategoryCleanAverages`, map
+to the `view.categories` order, pass `catAvg` (+ count gate) into `Analytics`.
+
+## Element 2 — category-neighbors tile
+
+Design: a "{category} neighbors" tile — a ranked list of sibling domains in the same
+BUSINESS category, "you" highlighted, each linking to its `/score` hub. Source: the
+curated corpus only (`leaderboard.json`, the same dataset `leaderboard.tsx` reads).
+
+Build:
+
+- In `score/[domain].tsx`, load `/leaderboard.json` (reuse the leaderboard's `loadData`
+  fetch pattern; fail soft to null). Find the current domain's corpus entry.
+- If found: neighbors = the domain's corpus siblings (same `category`), cleanest-first,
+  capped (~6), each `{ rank, name/domain, score, grade, tier, you }`, "you" row marked.
+  Pass into `Analytics`.
+- If the domain is NOT in the curated corpus, OR the category has < 2 members: omit the
+  tile (no invented category, no invented peers).
+- New `Neighbors` component in `_result.tsx`, rendered inside `Analytics` when neighbors
+  are present. Rows reuse the result token system; "you" row highlighted
+  (`rgba(31,168,94,0.08)` bg, matching the mock). Each domain links to `${origin}/score/<domain>`.
+
+## Acceptance criteria (reviewer grades against these)
+
+Visual parity with Result.dc.html competitive-analytics: dashed rank-avg overlay + legend;
+neighbors tile with ranks, letter-chips, name+domain, score+grade, "you" highlight.
+Feature parity, honest: both render from REAL data; both correctly OMIT (not fabricate)
+when data is insufficient (catAvg count < 5; domain not in corpus / < 2 siblings).
+No regressions: existing Analytics charts (score-over-time, radar base, distribution)
+unchanged; `recordScan` still records history + distribution; all existing tests green.
+Dogfood: page still passes the guardrail (assert no slop fonts / gradient text / purple
+CTA on the new markup).
+Tests (real, behavior-exercising; coverage must not regress):
+
+- `_data`: `bumpCategoryStats` accumulates; `getCategoryCleanAverages` returns correct
+  per-category averages + count; `recordScan` calls the bump; record-time clean-fraction
+  matches `buildResultView`'s for the same slim.
+- `_result`/analytics: radar draws the avg polygon + legend only when catAvg present AND
+  count >= 5; neighbors tile renders siblings, marks "you", links to /score; both omitted
+  when data absent.
+- `score/[domain]`: full result passes catAvg + neighbors; renders both when data present,
+  neither when absent; no fabricated values.
+
+Engine reuse, not rewrite: use the existing pattern catalogue + corpus; do NOT change the
+scoring engine or the slim record shape beyond the new aggregate. Commits authored
+Ravindra Kumar <ravidsrk@gmail.com>; no co-author / "Generated with" / agent trailers.


### PR DESCRIPTION
This PR records the final adoption-readiness verification for the "Slop Detect" design (claude.ai/design 644611bf) across the web product. It confirms full adoption — every design screen implemented and matching visually and feature-wise, the 28-point must-not-regress floor preserved, and the one previously-omitted Result analytics element (rank-average radar overlay + category-neighbors tile) now built from real data in PR #63.

Adds docs/adopt-readiness.md (the adoption matrix, gate results, residual risks, merged PR list) and docs/gap-analytics-spec.md (the frozen build spec PR #63 implemented). Docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR with no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **documentation only** — no application code changes.
> 
> **`docs/adopt-readiness.md`** records the capstone verification that design project 644611bf ("Slop Detect") is fully adopted on `main` after PR #63. It complements `docs/parity-readiness.md` with a design-screen → product-surface matrix (all COMPLETE), gate results at commit `8a25159`, residual risks (honest omission when data is sparse), and merged PR references (#39–#62 re-skin, #63 peer-analytics).
> 
> **`docs/gap-analytics-spec.md`** freezes the build contract PR #63 implemented: rank-average radar overlay from `stats:catclean` / `categoryCleanFractions`, category-neighbors from `leaderboard.json`, dogfood guardrails (no fabricated data), and acceptance/test criteria for reviewers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d0b948e02f104b5267859fc6333a096580925e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->