### PR TITLE
fix(web): scan field no longer doubles the https:// prefix

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -943,7 +943,7 @@ async function ensureTurnstileToken() {
 }
 
 document.querySelectorAll('.examples button').forEach(b => {
-  b.addEventListener('click', () => { urlInput.value = b.dataset.url; form.requestSubmit(); });
+  b.addEventListener('click', () => { urlInput.value = stripScheme(b.dataset.url); form.requestSubmit(); });
 });
 
 form.addEventListener('submit', async (e) => {
@@ -1143,6 +1143,13 @@ function domainOf(u) {
   try { return new URL(u).hostname.replace(/^www\./, ''); } catch { return u; }
 }
 
+// Strip a leading http(s):// before putting a value in the scan field — the field
+// already shows a static "https://" prefix, so a scheme here renders "https://
+// https://…". Bare hosts scan fine: the API re-adds https:// (_ssrf validateScanUrl).
+function stripScheme(u) {
+  return String(u == null ? '' : u).trim().replace(/^https?:\/\//i, '');
+}
+
 function sharePanel(d) {
   if (!d.resultUrl) return '';  // sharing unavailable (KV off / opted out)
   const dom = domainOf(d.finalUrl || d.url);
@@ -1331,7 +1338,7 @@ copyBtn.addEventListener('click', async () => {
 (function prefillFromQuery() {
   try {
     const q = new URLSearchParams(location.search).get('url');
-    if (q) { urlInput.value = q; form.requestSubmit(); }
+    if (q) { urlInput.value = stripScheme(q); form.requestSubmit(); }
   } catch (_) {}
 })();
 </script>

--- a/apps/web/test/landing.test.js
+++ b/apps/web/test/landing.test.js
@@ -227,3 +227,28 @@ test('/report wears the landing brand and keeps its print stylesheet', async () 
   for (const re of BRAND_MARKS) expect(out).toMatch(re);
   expect(out).toMatch(/@media print/);
 });
+
+// ── scan field never doubles the static "https://" prefix ──────────────────────
+// The hero field renders a decorative "https://" prefix, so any value placed into
+// it must be a bare host. Regression for the chip + ?url= prefill double-scheme bug
+// ("https:// https://news.ycombinator.com"). The API re-adds https:// for bare hosts.
+test('programmatic scan-field values are stripped of their scheme', () => {
+  expect(/function stripScheme\(/.test(html), 'stripScheme helper present').toBeTruthy();
+  // Every programmatic set routes through stripScheme...
+  expect(
+    /urlInput\.value = stripScheme\(b\.dataset\.url\)/.test(html),
+    'chip click strips the scheme'
+  ).toBeTruthy();
+  expect(
+    /urlInput\.value = stripScheme\(q\)/.test(html),
+    'deep-link prefill strips the scheme'
+  ).toBeTruthy();
+  // ...and no raw scheme-bearing assignment survives.
+  expect(
+    /urlInput\.value\s*=\s*b\.dataset\.url\b/.test(html),
+    'no raw chip URL assignment'
+  ).toBeFalsy();
+  expect(/urlInput\.value\s*=\s*q\b/.test(html), 'no raw query-param assignment').toBeFalsy();
+  // The helper strips only a leading scheme (anchored, case-insensitive), nothing else.
+  expect(/replace\(\/\^https\?:\\\/\\\/\/i, ''\)/.test(html), 'anchored scheme strip').toBeTruthy();
+});


### PR DESCRIPTION
The homepage scan field shows a decorative "https://" prefix, but the example chips (data-url="https://...") and the /?url= deep-link prefill copied a full URL into the field, rendering "https:// https://news.ycombinator.com".

Fix: a stripScheme() helper removes a leading http(s):// before any programmatic set (chip click + ?url= prefill), so the field holds a bare host. Bare hosts scan fine — the API re-adds https:// (_ssrf validateScanUrl). Adds a landing.test.js regression guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side UX fix on the landing page with static HTML assertions; no API or auth changes.
> 
> **Overview**
> Fixes a **double `https://` display** on the homepage scan input: the UI already shows a decorative `https://` prefix, but example chips and `/?url=` prefill were copying full URLs into the field (e.g. `https:// https://news.ycombinator.com`).
> 
> Adds **`stripScheme()`** to trim a leading `http(s)://` before any programmatic `urlInput` assignment (chip click and deep-link prefill), so the field holds a bare host. Scan behavior is unchanged—**`/api/scan`** still normalizes bare hosts via `validateScanUrl`.
> 
> **`landing.test.js`** gains a regression test that asserts `stripScheme` exists, both code paths use it, and raw scheme-bearing assignments are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab8b5f27fca0dd03a9d9de368dd6c2caea0384c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->