### PR TITLE
feat(web): scanning lands on the full Result page (design flow)

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -989,6 +989,14 @@ form.addEventListener('submit', async (e) => {
       return;
     }
     if (!r.ok || data.error) throw new Error(data.error || ('HTTP ' + r.status));
+    // Design flow (Landing -> Result): a scan lands on the full per-domain Result
+    // page. When the scan persisted a shareable snapshot, navigate to its permalink
+    // (/r/<id>); only fall back to the inline result when sharing is off (no id).
+    if (data.id) {
+      statusEl.textContent = 'Scan complete. Opening the result…';
+      window.location.href = '/r/' + encodeURIComponent(data.id);
+      return;
+    }
     render(data, Date.now() - t0);
     statusEl.classList.remove('show');
   } catch (err) {

--- a/apps/web/test/landing.test.js
+++ b/apps/web/test/landing.test.js
@@ -252,3 +252,18 @@ test('programmatic scan-field values are stripped of their scheme', () => {
   // The helper strips only a leading scheme (anchored, case-insensitive), nothing else.
   expect(/replace\(\/\^https\?:\\\/\\\/\/i, ''\)/.test(html), 'anchored scheme strip').toBeTruthy();
 });
+
+// ── scan lands on the full Result page (design flow: Landing -> Result) ───────
+// A completed scan navigates to its permalink /r/<id> (the rich Result page),
+// rather than only rendering a compact card inline on the landing page.
+test('a completed scan navigates to the full /r/<id> result page', () => {
+  expect(
+    /window\.location\.href = '\/r\/' \+ encodeURIComponent\(data\.id\)/.test(html),
+    'scan success navigates to the permalink result page'
+  ).toBeTruthy();
+  // the inline render stays as the fallback when there is no shareable id
+  expect(
+    /render\(data, Date\.now\(\) - t0\)/.test(html),
+    'inline render fallback kept'
+  ).toBeTruthy();
+});


### PR DESCRIPTION
In the design, the landing page scan navigates to a dedicated Result page (Result.dc.html). The implementation instead rendered a compact result card inline on the landing page and never sent you to the full Result page — which exists and is fully built at /score/<domain> and /r/<id> (big score, category bars, breakdown, the four axes, system/AEO, competitive analytics incl. the rank-avg radar + neighbors, fixes, share/embed, claim, monitor) but was unreachable from the scan flow.

This wires the homepage scan to navigate to its permalink /r/<id> (the full Result page) on success, matching the design's Landing -> Result flow. The inline render stays as a fallback only when sharing is off (no minted id). Example chips and the ?url= deep link go through the same handler, so they land on the Result page too.

Test: landing.test.js asserts the success path navigates to /r/<id> and keeps the inline fallback. Gates green: typecheck 7/7, lint, format, web tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side navigation change on scan success with a preserved inline fallback; no auth or API contract changes beyond using an existing response field.
> 
> **Overview**
> **Homepage scans now follow the Landing → Result design flow.** After a successful `/api/scan`, when the response includes a persisted shareable **`data.id`**, the client sets status to “Opening the result…” and navigates to **`/r/<id>`** instead of staying on the landing page.
> 
> The existing **`render()`** inline result card remains **only as a fallback** when no id is returned (e.g. sharing off). Example chips and **`?url=`** deep links use the same submit handler, so they get the same redirect behavior.
> 
> **`landing.test.js`** adds a regression test for the redirect pattern and that the inline render path is still present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b38111e02ae87fd9e2d563f45431b1b11047e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->