### PR TITLE
ci: de-gate deploy from live HN scan + SHA-pin Actions [OPS-2, DEP-1]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Non-gating live canary — informational only; deploy is not blocked by it.
-  schedule:
-    - cron: '0 6 * * *'
 
 jobs:
   lint:
@@ -83,27 +80,3 @@ jobs:
             exit 1
           fi
 
-  smoke-live-canary:
-    name: Live scan canary (non-gating)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    if: github.event_name == 'schedule'
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.3.5
-      - run: bun install
-      - name: Build CLI + core
-        run: bun run --filter @slop-detect/core build && bun run --filter slop-detect build
-      - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
-      - name: Scan live HN (informational)
-        env:
-          SKIP_PLAYWRIGHT_DOWNLOAD: 1
-        run: |
-          cd packages/cli
-          node dist/bin/slop.js https://news.ycombinator.com --json > result.json
-          cat result.json
-          score=$(node -e "console.log(JSON.parse(require('fs').readFileSync('result.json')).score)")
-          echo "Live HN score: $score (non-gating — does not block deploy)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Non-gating live canary — informational only; deploy is not blocked by it.
+  schedule:
+    - cron: '0 6 * * *'
 
 jobs:
   lint:
@@ -55,18 +58,52 @@ jobs:
         run: bun run --filter @slop-detect/core build && bun run --filter slop-detect build
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
-      - name: Scan a known-clean page (HN)
+      - name: Serve local clean fixture
+        run: |
+          cd packages/cli/test/fixtures
+          python3 -m http.server 8765 &
+          for i in $(seq 1 30); do
+            curl -sf http://127.0.0.1:8765/clean-artisan.html >/dev/null && break
+            sleep 0.2
+          done
+          echo "FIXTURE_URL=http://127.0.0.1:8765/clean-artisan.html" >> "$GITHUB_ENV"
+      - name: Scan hermetic clean fixture
         env:
           # Chromium was installed above — skip the CLI's lazy installer so its
           # download progress can't pollute stdout (which is redirected to JSON).
           SKIP_PLAYWRIGHT_DOWNLOAD: 1
         run: |
           cd packages/cli
-          node dist/bin/slop.js https://news.ycombinator.com --json > result.json
+          node dist/bin/slop.js "$FIXTURE_URL" --json > result.json
           cat result.json
           score=$(node -e "console.log(JSON.parse(require('fs').readFileSync('result.json')).score)")
           echo "Score: $score"
           if [ "$score" -gt 12 ]; then
-            echo "::error::Hacker News should score Clean (< 12), got $score"
+            echo "::error::Clean artisan fixture should score Clean (< 12), got $score"
             exit 1
           fi
+
+  smoke-live-canary:
+    name: Live scan canary (non-gating)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+      - run: bun install
+      - name: Build CLI + core
+        run: bun run --filter @slop-detect/core build && bun run --filter slop-detect build
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+      - name: Scan live HN (informational)
+        env:
+          SKIP_PLAYWRIGHT_DOWNLOAD: 1
+        run: |
+          cd packages/cli
+          node dist/bin/slop.js https://news.ycombinator.com --json > result.json
+          cat result.json
+          score=$(node -e "console.log(JSON.parse(require('fs').readFileSync('result.json')).score)")
+          echo "Live HN score: $score (non-gating — does not block deploy)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: Lint & format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
       - run: bun install
@@ -26,8 +26,8 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
       - run: bun install
@@ -37,8 +37,8 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
       - run: bun install
@@ -49,8 +49,8 @@ jobs:
     name: Smoke test CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
       - run: bun install
@@ -89,8 +89,8 @@ jobs:
     continue-on-error: true
     if: github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
       - run: bun install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,12 @@ jobs:
     # workflow_dispatch and tag pushes always proceed (no upstream run to gate on).
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # On workflow_run, check out the exact commit that passed CI (defaults
           # would grab the branch HEAD). Empty ref on other triggers = default.
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
 
@@ -64,7 +64,7 @@ jobs:
       - run: bun run test
 
       - name: Publish (wrangler pages deploy)
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/smoke-live-canary.yml
+++ b/.github/workflows/smoke-live-canary.yml
@@ -1,0 +1,34 @@
+name: smoke-live-canary
+
+# Informational live scan — does NOT gate deploy. Kept separate from `ci` so a
+# scheduled success cannot trigger deploy.yml (which watches workflow_run: ci).
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  live-scan:
+    name: Live scan canary (non-gating)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.5
+      - run: bun install
+      - name: Build CLI + core
+        run: bun run --filter @slop-detect/core build && bun run --filter slop-detect build
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+      - name: Scan live HN (informational)
+        env:
+          SKIP_PLAYWRIGHT_DOWNLOAD: 1
+        run: |
+          cd packages/cli
+          node dist/bin/slop.js https://news.ycombinator.com --json > result.json
+          cat result.json
+          score=$(node -e "console.log(JSON.parse(require('fs').readFileSync('result.json')).score)")
+          echo "Live HN score: $score (non-gating — does not block deploy)"


### PR DESCRIPTION
This PR closes two CI/supply-chain findings from the frozen adversarial review (docs/adversarial-review-fresh.md).

Problem
- OPS-2 (P2): the smoke-cli job scanned live https://news.ycombinator.com and failed on score>12; deploy.yml triggers on ci success, so a third-party outage/redesign could block production deploys.
- DEP-1 (P3): deploy/ci workflows (which hold CLOUDFLARE_API_TOKEN) used third-party actions pinned to mutable major tags, not SHAs.

Solution
- OPS-2: smoke-cli now scans a hermetic local fixture; the live scan is retained only as a non-gating canary. Deploy is no longer reachable from a third-party outage. (.github/workflows/ci.yml, deploy.yml)
- DEP-1: actions/checkout, oven-sh/setup-bun, cloudflare/wrangler-action pinned to full 40-char commit SHAs with version comments.

Acceptance: CI passes with the upstream site unreachable (smoke points at the local fixture); all non-first-party actions reference @<40-char-sha>.

OPS / verify (recorded, not in scope here): standing live canary schedule + Dependabot for the actions ecosystem are OPS follow-ups in docs/arch-build-progress.md.

Findings: OPS-2, DEP-1. Evidence: .github/workflows/ci.yml, .github/workflows/deploy.yml. No deploy triggered; gitleaks clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that reduce deploy coupling to external sites and tighten action pinning; no application runtime or secret-handling logic changes.
> 
> **Overview**
> **CI no longer depends on live Hacker News** for the gating CLI smoke test. `smoke-cli` serves `packages/cli/test/fixtures/clean-artisan.html` locally and asserts score &lt; 12, so third-party outages or redesigns cannot fail `ci` and block deploys triggered by `workflow_run: ci`.
> 
> **Supply-chain hardening:** `actions/checkout`, `oven-sh/setup-bun`, and `cloudflare/wrangler-action` in `ci.yml` and `deploy.yml` are pinned to full commit SHAs (with version comments) instead of mutable major tags.
> 
> **Live HN coverage moved out of the gate:** new `smoke-live-canary.yml` runs a daily (and manual) scan of news.ycombinator.com with `continue-on-error: true` and is **not** named `ci`, so its success cannot satisfy deploy’s `workflow_run` trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 899044312351ff8cb599513be0ffcc70e07f5b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->