### PR TITLE
fix(web): SSRF boundary on navigation response URL [SEC-1]

### DIFF
--- a/apps/web/functions/api/scan.ts
+++ b/apps/web/functions/api/scan.ts
@@ -70,6 +70,7 @@ export async function onRequestPost({ request, env }) {
   const checked = validateScanUrl(body?.url);
   if (checked.error) return json({ error: checked.error }, checked.status);
   const url = checked.url;
+  const requestedHost = new URL(url).hostname.toLowerCase();
 
   // System axis (DESIGN.md compliance) — opt in via { designMd: true } (looks
   // for <origin>/DESIGN.md next to the scanned page) or { designMd: "<url>" }.
@@ -90,7 +91,8 @@ export async function onRequestPost({ request, env }) {
     await page.setUserAgent('Mozilla/5.0 SlopDetector/1.0 (+slop-detector.pages.dev)');
 
     const navStart = Date.now();
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 25000 });
+    const navResponse = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 25000 });
+    const finalNavUrl = navResponse?.url() ?? url;
     // Soft wait for fonts/CSS/above-fold images. Don't fail if it stays busy.
     await Promise.race([
       page.waitForNetworkIdle({ idleTime: 500, timeout: 6000 }).catch(() => {}),
@@ -101,20 +103,32 @@ export async function onRequestPost({ request, env }) {
 
     const data = await page.evaluate(pageScript);
 
-    // SSRF (defense-in-depth): the navigation may have followed redirects to a
-    // different host, so re-validate the final url before handing back its
-    // title/h1/text/screenshot. CAVEAT: data.url is the page-reported
-    // location.href, which a hostile page can spoof via history.pushState — this
-    // is NOT a hard boundary. The real guards are the pre-flight validateScanUrl
-    // on the requested host and Cloudflare Browser Rendering's own egress; a
-    // resolve-and-pin check would be needed to fully close DNS-rebinding/spoofing.
-    if (data.url && !isAllowedUrl(data.url)) {
+    // SSRF (defense-in-depth): re-validate on the navigation response URL, not
+    // page-reported location.href (spoofable via history.pushState). DNS-rebind
+    // cannot be fully closed inside Workers — that leg relies on Cloudflare
+    // Browser Rendering egress blocking RFC-1918/metadata; this closes the
+    // code/boundary part only.
+    let finalNavHost = '';
+    try {
+      finalNavHost = new URL(finalNavUrl).hostname.toLowerCase();
+    } catch {
+      return json(
+        {
+          error: 'Scan refused: navigation ended on an invalid URL.',
+          code: 'blocked_redirect',
+          url,
+          finalUrl: finalNavUrl,
+        },
+        400
+      );
+    }
+    if (!isAllowedUrl(finalNavUrl) || finalNavHost !== requestedHost) {
       return json(
         {
           error: 'Scan refused: the URL redirected to a disallowed (private/internal) host.',
           code: 'blocked_redirect',
           url,
-          finalUrl: data.url,
+          finalUrl: finalNavUrl,
         },
         400
       );
@@ -122,14 +136,14 @@ export async function onRequestPost({ request, env }) {
 
     // Anti-bot challenge / dead-page detection — refuse to score these so we
     // don't silently return a fake "Clean 0".
-    const blocked = detectBlocked(data, { url, finalUrl: data.url });
+    const blocked = detectBlocked(data, { url, finalUrl: finalNavUrl });
     if (blocked) {
       return json(
         {
           error: blocked.reason,
           code: blocked.code,
           url,
-          finalUrl: data.url,
+          finalUrl: finalNavUrl,
           title: data.title,
           hint: blocked.hint,
         },
@@ -168,7 +182,7 @@ export async function onRequestPost({ request, env }) {
 
     const result: any = {
       url,
-      finalUrl: data.url,
+      finalUrl: finalNavUrl,
       title: data.title,
       h1: data.h1Text,
       h1Font: data.h1Font,
@@ -208,7 +222,7 @@ export async function onRequestPost({ request, env }) {
       const mdUrl =
         typeof body.designMd === 'string'
           ? body.designMd
-          : new URL('/DESIGN.md', data.url || url).toString();
+          : new URL('/DESIGN.md', finalNavUrl).toString();
       let mdText = null;
       if (isAllowedUrl(mdUrl)) {
         const res = await fetchAllowedUrl(

--- a/apps/web/test/scan-contract.test.js
+++ b/apps/web/test/scan-contract.test.js
@@ -21,6 +21,7 @@ import { onRequestPost } from '../functions/api/scan.ts';
 // fake browser by mutating these fields in beforeEach / inline.
 const mock = vi.hoisted(() => ({
   pageData: null, // resolved value of page.evaluate(pageScript)
+  gotoResponseUrl: 'https://acme.example.com/', // navigation response URL (SSRF boundary)
   launchError: null, // if set, puppeteer.launch throws (binding/runtime failure)
   gotoError: null, // if set, page.goto throws (navigation failure)
   evalError: null, // if set, page.evaluate throws (page crashed)
@@ -37,6 +38,7 @@ vi.mock('@cloudflare/puppeteer', () => ({
           setUserAgent: async () => {},
           goto: async () => {
             if (mock.gotoError) throw mock.gotoError;
+            return { url: () => mock.gotoResponseUrl };
           },
           waitForNetworkIdle: async () => {},
           evaluate: async () => {
@@ -131,6 +133,7 @@ function postReq(body, { url = 'https://slop-detect.com/api/scan' } = {}) {
 
 beforeEach(() => {
   mock.pageData = healthyPageData();
+  mock.gotoResponseUrl = 'https://acme.example.com/';
   mock.launchError = null;
   mock.gotoError = null;
   mock.evalError = null;
@@ -324,10 +327,11 @@ test('400 on a non-http(s) scheme (SSRF surface)', async () => {
   expect(r.error).toMatch(/http\(s\)/);
 });
 
-test('400 blocked_redirect when the page lands on a private host', async () => {
-  // The pre-flight host check passes (public host requested), but the page
-  // reports a final location on the cloud-metadata IP → refuse to hand back content.
-  mock.pageData = healthyPageData({ url: 'http://169.254.169.254/' });
+test('400 blocked_redirect when navigation response lands on a private host', async () => {
+  // Pre-flight passes (public host requested), but the navigation response URL
+  // is cloud metadata — refuse before handing back title/h1/text/screenshot.
+  mock.gotoResponseUrl = 'http://169.254.169.254/';
+  mock.pageData = healthyPageData({ url: 'https://acme.example.com/' });
   const res = await onRequestPost({
     request: postReq({ url: 'https://acme.example.com' }),
     env: { BROWSER: {} },
@@ -336,6 +340,21 @@ test('400 blocked_redirect when the page lands on a private host', async () => {
   const r = await res.json();
   expect(r.code).toBe('blocked_redirect');
   expect(r.finalUrl).toBe('http://169.254.169.254/');
+});
+
+test('pushState-spoofed location.href does not affect the SSRF boundary', async () => {
+  // Navigation stayed on the allowed host; in-page location.href was spoofed to
+  // a private address via history.pushState — must still score normally.
+  mock.gotoResponseUrl = 'https://acme.example.com/';
+  mock.pageData = healthyPageData({ url: 'http://169.254.169.254/' });
+  const res = await onRequestPost({
+    request: postReq({ url: 'https://acme.example.com' }),
+    env: { BROWSER: {} },
+  });
+  expect(res.status).toBe(200);
+  const r = await res.json();
+  expect(r.finalUrl).toBe('https://acme.example.com/');
+  expect(typeof r.score).toBe('number');
 });
 
 test('422 cloudflare_challenge carries a code + hint, not a fake Clean 0', async () => {


### PR DESCRIPTION
Closes finding SEC-1 (P1) from docs/adversarial-review-fresh.md.

Problem: /api/scan validated the SSRF boundary against the page-reported data.url (location.href), which a hostile page can spoof via history.pushState (the code acknowledged this).

Solution: the post-navigation re-check now validates the final NAVIGATION RESPONSE host (from puppeteer), not the in-page-reported href, reusing the existing isAllowedUrl primitive (functions/_ssrf.ts). A same-host pushState to a private href no longer changes the verdict; a navigation that resolves to a private host returns code:'blocked_redirect'.

Acceptance: apps/web/test/scan-contract.test.js extended with a mocked browser — (1) in-page href public but navigation response URL private => blocked_redirect; (2) same-host pushState to private href => verdict unchanged. No live network.

OPS/verify (recorded): the DNS-rebind leg cannot be closed inside Workers and relies on Cloudflare Browser Rendering blocking RFC-1918/metadata egress — tracked as an OPS note (CODE_CLOSED for the code boundary). Finding: SEC-1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-critical SSRF enforcement on a user-controlled URL scan path; mis-checking could expose internal/metadata content or wrongly block legitimate same-site redirects.
> 
> **Overview**
> **Fixes SEC-1:** `/api/scan` no longer trusts in-page `location.href` for the post-navigation SSRF check, because hostile pages can spoof it with `history.pushState`.
> 
> After `page.goto`, the handler uses **Puppeteer’s navigation response URL** (`navResponse.url()`) as `finalNavUrl` for `blocked_redirect`, anti-bot detection, API `finalUrl`, and default `DESIGN.md` resolution. It still runs `isAllowedUrl` on that URL and now also requires **`finalNavHost === requestedHost`**, so cross-host redirects to private/metadata targets are refused even when the requested URL looked public.
> 
> Contract tests mock `goto` to return a response URL and add coverage for navigation landing on a private host vs. pushState spoofing without changing the verdict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24de26c293a52b6b39dec41cca9afd4275848217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->