### PR TITLE
fix(web): burst-proof cost cap + document no-origin floor [COST-1, SEC-3]

### DIFF
--- a/apps/web/functions/api/_middleware.ts
+++ b/apps/web/functions/api/_middleware.ts
@@ -130,11 +130,11 @@ async function verifyTurnstile(token, secret, ip) {
   }
 }
 
-// In-memory, per-isolate fallback counter. Used ONLY when KV is unavailable so
-// the expensive scan route can still enforce a hard ceiling (fail-closed)
-// instead of letting an attacker drive unlimited headless-browser scans during
-// a KV outage. Coarse — each Worker isolate keeps its own map and Cloudflare may
-// run several — but it caps the blast radius. Entries self-expire after 60s.
+// In-memory, per-isolate counter. Ticks on every scan-route gate (happy path and
+// KV-degraded) so a single isolate cannot burst past the per-IP limit or daily
+// cap even when KV reads are stale — KV remains the eventually-consistent
+// cross-isolate backstop. A true hard cross-isolate cap needs a Durable Object
+// (future OPS; see functions/_data.ts). Entries self-expire after windowMs.
 const memCounters = new Map(); // key -> { count, resetAt }
 
 // Hard ceiling for the scan route when KV is down. Deliberately tighter than the
@@ -196,6 +196,13 @@ async function checkRateLimit(kv, bucket, route, limit) {
   }
 
   if (n >= limit) return { ok: false, used: n, limit, degraded: false };
+
+  // Per-isolate ceiling on the happy path: KV get→put is not atomic, so
+  // concurrent requests in one isolate can all read the same stale count.
+  if (isScan) {
+    const memN = memIncrement(key);
+    if (memN > limit) return { ok: false, used: memN, limit, degraded: false };
+  }
 
   // Increment with 60s TTL (effectively a rolling 60s window).
   let kvWriteOk = false;
@@ -408,8 +415,9 @@ export async function onRequest(context) {
   // Per-IP/per-key limits don't stop a distributed flood from running up the
   // Cloudflare Browser Rendering bill. Enforce an ACCOUNT-LEVEL daily ceiling and
   // a kill switch on the scan route so cost can't run away. `unlimited`-tier keys
-  // (our own/partners) bypass it. KV is eventually consistent, so this is an
-  // approximate budget guard, not an exact counter — that's fine for cost safety.
+  // (our own/partners) bypass it. KV get→put is not atomic; memIncrement above
+  // caps burst overshoot within one isolate. Cross-isolate exactness needs a
+  // Durable Object (future OPS).
   if (effectiveRoute === 'scan' && tierLabel !== 'unlimited') {
     if (env.SCAN_DISABLED === '1' || env.SCAN_DISABLED === 'true') {
       return jsonResponse(
@@ -446,6 +454,20 @@ export async function onRequest(context) {
         );
       }
       if (used >= cap) {
+        return jsonResponse(
+          {
+            error: 'daily_capacity_reached',
+            message:
+              'Free scan capacity for today is used up — this protects the project from runaway costs. Try again tomorrow, use an API key, or self-host (it is MIT).',
+            retryAfter: 3600,
+          },
+          503,
+          origin
+        );
+      }
+      // Per-isolate ceiling on the happy path (key includes the day; 24h window).
+      const memUsed = memIncrement(gkey, 86400000);
+      if (memUsed > cap) {
         return jsonResponse(
           {
             error: 'daily_capacity_reached',

--- a/apps/web/functions/api/_middleware.ts
+++ b/apps/web/functions/api/_middleware.ts
@@ -389,8 +389,14 @@ export async function onRequest(context) {
   }
 
   // ── Turnstile ───────────────────────────────────────────────────────────────
-  // Required for /api/scan from browser origins WITHOUT a valid key. A valid key
-  // is proof-of-human enough, so any keyed caller (browser or CLI) skips it.
+  // Required for /api/scan from trusted browser origins WITHOUT a valid key. A
+  // valid key is proof-of-human enough, so any keyed caller skips it.
+  //
+  // No-origin callers (curl, CLI, MCP) intentionally bypass Turnstile — see the
+  // origin classification above. The real anti-abuse floor for those callers is
+  // the per-IP rate limit (tighter for no-origin) plus the global daily cap,
+  // strengthened by the per-isolate memIncrement ceiling in COST-1.
+  //
   // Verified BEFORE the cost guard below: a failed/absent captcha must not burn
   // the global daily-scan budget (else a spoofed trusted Origin could inflate the
   // cap and 503 real users without ever running a scan).

--- a/apps/web/test/middleware.test.js
+++ b/apps/web/test/middleware.test.js
@@ -228,4 +228,30 @@ test('COST-1 parallel burst cannot overshoot per-IP limit via stale KV [COST-1]'
   ).toBeLessThanOrEqual(anonNoOriginLimit);
 });
 
+test('SEC-3 no-origin scan allowed only up to anon limit (Turnstile bypass floor) [SEC-3]', async () => {
+  // Turnstile is required only for trusted browser origins. No-origin callers
+  // (CLI/curl) bypass captcha by design; the per-IP limit is the real floor.
+  const anonNoOriginLimit = 3;
+  const okKv = { get: async () => '0', put: async () => {} };
+  const ip = '203.0.113.201';
+  let allowed = 0;
+  let got429 = false;
+  for (let i = 0; i < 8; i++) {
+    const req = makeRequest({
+      headers: { 'CF-Connecting-IP': ip },
+      body: { url: 'https://x.com' },
+    });
+    const res = await onRequest(
+      makeContext(req, { RATE_LIMIT: okKv, TURNSTILE_SECRET: 'secret' })
+    );
+    if (res.status === 200) allowed++;
+    if (res.status === 429) {
+      got429 = true;
+      break;
+    }
+  }
+  expect(got429, 'expected no-origin scans to hit the per-IP floor').toBeTruthy();
+  expect(allowed).toBeLessThanOrEqual(anonNoOriginLimit);
+});
+
 

--- a/apps/web/test/middleware.test.js
+++ b/apps/web/test/middleware.test.js
@@ -197,3 +197,35 @@ test('OPTIONS preflight returns 204 regardless of origin', async () => {
   const res = await onRequest(makeContext(req));
   expect(res.status).toBe(204);
 });
+
+test('COST-1 parallel burst cannot overshoot per-IP limit via stale KV [COST-1]', async () => {
+  // KV always returns 0 — simulates concurrent reads of the same stale counter.
+  // Without the per-isolate memIncrement ceiling, all K requests would pass.
+  const anonNoOriginLimit = 3; // Math.max(2, Math.floor(SCAN_LIMIT_PER_MIN / 2))
+  const staleKv = {
+    get: async () => '0',
+    put: async () => {},
+  };
+  const ip = '203.0.113.200';
+  const parallel = 8;
+  const results = await Promise.all(
+    Array.from({ length: parallel }, () =>
+      onRequest(
+        makeContext(
+          makeRequest({
+            headers: { 'CF-Connecting-IP': ip },
+            body: { url: 'https://x.com' },
+          }),
+          { RATE_LIMIT: staleKv }
+        )
+      )
+    )
+  );
+  const allowed = results.filter((r) => r.status === 200).length;
+  expect(
+    allowed,
+    `expected at most ${anonNoOriginLimit} parallel scans with stale KV, got ${allowed}`
+  ).toBeLessThanOrEqual(anonNoOriginLimit);
+});
+
+


### PR DESCRIPTION
Closes findings COST-1 (P2) and SEC-3 (P3) from docs/adversarial-review-fresh.md.

Problem: the per-IP limit and SCAN_DAILY_CAP are non-atomic KV read-modify-write that overshoot under concurrent bursts on a billed browser surface (COST-1). Turnstile is bypassable by omitting Origin, so the real anti-abuse floor is the per-IP KV limit + global cap (SEC-3).

Solution: COST-1 — the existing in-tree memIncrement per-isolate ceiling now ticks on the happy path (not just the KV-outage path), so a single isolate cannot burst past the limit even when KV is up; KV remains the eventually-consistent cross-isolate backstop. SEC-3 — documents the true no-origin floor in code and adds a no-origin limit test.

Acceptance: apps/web/test/middleware.test.js — a KV mock returning a stale count across K parallel onRequest calls asserts no more than `limit` return 200 (failed before); plus the no-origin floor test.

OPS/verify (recorded): the hard cross-isolate cap is a Durable Object (future OPS); burst-overshoot residual across isolates = verify-at-scale. Findings: COST-1, SEC-3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cost and abuse gates on the headless scan path; behavior is tighter (more 429/503 under burst) but mis-tuned limits could block legitimate parallel clients within one isolate.
> 
> **Overview**
> **Burst-proofing** for billed `/api/scan` traffic: the existing per-isolate `memIncrement` map now increments on the **happy path** (KV up), not only when KV is missing or failing. That blocks concurrent requests in one Worker isolate from all reading the same stale KV count and overshooting the per-minute per-IP limit or the account **SCAN_DAILY_CAP**. KV stays the cross-isolate backstop; comments note a Durable Object as the path to a hard global cap.
> 
> **SEC-3** is clarified in middleware comments: callers without an `Origin` (curl/CLI/MCP) skip Turnstile by design; the floor is the tighter no-origin per-IP limit, daily cap, and the new in-isolate ceiling. Tests add a parallel stale-KV burst case (COST-1) and a sequential no-origin scan cap case with Turnstile configured (SEC-3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaa0855031ae8d1f43998b80dd18eed7850ec759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->