### PR TITLE
fix(web): email-to-domains index for dashboard link lookup [COST-2]

### DIFF
--- a/apps/web/functions/_data.ts
+++ b/apps/web/functions/_data.ts
@@ -203,13 +203,93 @@ export async function consumeDashboardToken(kv, token) {
   return email;
 }
 
+// ── Email → domains index (COST-2) ───────────────────────────────────────────
+// One KV key per owner email maps to the domains they monitor, so magic-link
+// lookup is a single get instead of enumerating every watch. Written on
+// subscribe, pruned on unsubscribe; listWatchesByEmail self-heals stale rows.
+const EMAIL_INDEX_PREFIX = 'e:';
+
+async function emailHash(email: string): Promise<string> {
+  const want = String(email).trim().toLowerCase();
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(want));
+  return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function emailIndexKey(email: string): Promise<string> {
+  return `${EMAIL_INDEX_PREFIX}${await emailHash(email)}`;
+}
+
+// Domains monitored by one email — one kv.get. Used by the magic-link endpoint
+// where we only need a count, not full watch records.
+export async function getEmailDomains(kv, email) {
+  if (!kv || !email) return [];
+  const key = await emailIndexKey(email);
+  const raw = await kv.get(key);
+  if (!raw) return [];
+  try {
+    const a = JSON.parse(raw);
+    return Array.isArray(a) ? a.filter((d) => typeof d === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function addToEmailIndex(kv, email, domain) {
+  if (!kv || !email || !domain) return;
+  const key = await emailIndexKey(email);
+  const want = String(email).trim().toLowerCase();
+  const domains = await getEmailDomains(kv, want);
+  if (domains.includes(domain)) return;
+  domains.push(domain);
+  await kv.put(key, JSON.stringify(domains));
+}
+
+export async function removeFromEmailIndex(kv, email, domain) {
+  if (!kv || !email || !domain) return;
+  const key = await emailIndexKey(email);
+  const want = String(email).trim().toLowerCase();
+  const domains = (await getEmailDomains(kv, want)).filter((d) => d !== domain);
+  if (domains.length) await kv.put(key, JSON.stringify(domains));
+  else await kv.delete(key);
+}
+
 // All watches owned by one email — the agency dashboard's data. Case-normalized
 // the same way the watch API stores emails (trimmed, lowercased).
 export async function listWatchesByEmail(kv, email) {
   if (!kv || !email) return [];
   const want = String(email).trim().toLowerCase();
-  const all = await listWatches(kv, { limit: 1000 });
-  return all.filter((w) => w && w.email === want);
+  const key = await emailIndexKey(want);
+  const raw = await kv.get(key);
+
+  // Index missing: fall back to a full scan once and rebuild the index so
+  // pre-index watches self-heal without changing the one-get link lookup path.
+  if (!raw) {
+    const all = await listWatches(kv, { limit: 1000 });
+    const mine = all.filter((w) => w && w.email === want);
+    if (mine.length) {
+      await kv.put(
+        key,
+        JSON.stringify(mine.map((w) => w.domain).filter(Boolean))
+      );
+    }
+    return mine;
+  }
+
+  let domains: string[] = [];
+  try {
+    const a = JSON.parse(raw);
+    domains = Array.isArray(a) ? a.filter((d) => typeof d === 'string') : [];
+  } catch {
+    domains = [];
+  }
+
+  const out = [];
+  for (const domain of domains) {
+    const w = await getWatch(kv, domain);
+    if (w && w.email === want) out.push(w);
+    else await removeFromEmailIndex(kv, want, domain);
+  }
+  return out;
 }
 
 // Enumerate watches for the monitoring sweep. Returns parsed watch records.

--- a/apps/web/functions/api/dashboard/link.ts
+++ b/apps/web/functions/api/dashboard/link.ts
@@ -6,7 +6,7 @@
 // middleware (cheap rate limit, CORS, foreign-origin rejection; no Turnstile).
 // Configured-off without an email provider + SESSION_SECRET, like alerts.
 
-import { isValidEmail, listWatchesByEmail, issueDashboardToken } from '../../_shared.js';
+import { isValidEmail, getEmailDomains, issueDashboardToken } from '../../_shared.js';
 import { emailConfigured, sendEmail } from '../../_email.js';
 import { buildDashboardLinkEmail } from '../../_alerts.js';
 
@@ -68,8 +68,8 @@ export async function onRequestPost({ request, env, waitUntil }) {
   };
 
   try {
-    const watches = await listWatchesByEmail(env.RESULTS, email);
-    if (watches.length && (await dashLinkAllowed(env.RATE_LIMIT, email))) {
+    const domains = await getEmailDomains(env.RESULTS, email);
+    if (domains.length && (await dashLinkAllowed(env.RATE_LIMIT, email))) {
       // Issue + send out-of-band so the response latency is IDENTICAL whether or
       // not the address owns watches. Doing the KV write + email round-trip inline
       // would make existence measurable (a timing oracle) despite the generic
@@ -78,7 +78,7 @@ export async function onRequestPost({ request, env, waitUntil }) {
       const send = (async () => {
         const token = await issueDashboardToken(env.RESULTS, email);
         const loginUrl = `${new URL(request.url).origin}/dashboard?token=${token}`;
-        const msg = buildDashboardLinkEmail(loginUrl, watches.length);
+        const msg = buildDashboardLinkEmail(loginUrl, domains.length);
         await sendEmail(env, { to: email, subject: msg.subject, text: msg.text });
       })().catch(() => {});
       if (typeof waitUntil === 'function') waitUntil(send);

--- a/apps/web/functions/api/dashboard/link.ts
+++ b/apps/web/functions/api/dashboard/link.ts
@@ -69,20 +69,26 @@ export async function onRequestPost({ request, env, waitUntil }) {
 
   try {
     const domains = await getEmailDomains(env.RESULTS, email);
-    if (domains.length && (await dashLinkAllowed(env.RATE_LIMIT, email))) {
-      // Issue + send out-of-band so the response latency is IDENTICAL whether or
-      // not the address owns watches. Doing the KV write + email round-trip inline
-      // would make existence measurable (a timing oracle) despite the generic
-      // body. `waitUntil` runs it after the response is sent; we fall back to an
-      // inline await only when it's unavailable (e.g. unit tests).
-      const send = (async () => {
+    if (domains.length) {
+      // Rate-limit + send are deferred so the response latency is IDENTICAL
+      // whether or not the address owns watches. Awaiting RATE_LIMIT.get/put or
+      // the email round-trip inline would leak existence via timing despite the
+      // generic body. `waitUntil` runs after the response is sent; we fall back
+      // to an inline await only when it's unavailable (e.g. unit tests).
+      const send = async () => {
+        if (!(await dashLinkAllowed(env.RATE_LIMIT, email))) return;
         const token = await issueDashboardToken(env.RESULTS, email);
         const loginUrl = `${new URL(request.url).origin}/dashboard?token=${token}`;
         const msg = buildDashboardLinkEmail(loginUrl, domains.length);
         await sendEmail(env, { to: email, subject: msg.subject, text: msg.text });
-      })().catch(() => {});
-      if (typeof waitUntil === 'function') waitUntil(send);
-      else await send;
+      };
+      if (typeof waitUntil === 'function') {
+        // Microtask-defer so the async body does not start (and touch RATE_LIMIT)
+        // until after this handler returns the generic response.
+        waitUntil(Promise.resolve().then(send).catch(() => {}));
+      } else {
+        await send().catch(() => {});
+      }
     }
   } catch (_) {
     /* best-effort: still return the generic response */

--- a/apps/web/functions/api/watch.ts
+++ b/apps/web/functions/api/watch.ts
@@ -27,6 +27,8 @@ import {
   setListing,
   deleteListing,
   issueWatchToken,
+  addToEmailIndex,
+  removeFromEmailIndex,
 } from '../_shared.js';
 import { emailConfigured, sendEmail } from '../_email.js';
 import { buildVerificationEmail } from '../_alerts.js';
@@ -84,6 +86,7 @@ export async function onRequestPost({ request, env }) {
     // retryable rather than orphaning a public row with no owner. Always attempt
     // cleanup even if the watch shows listed:false, to recover from failed deletes.
     await deleteListing(env.RESULTS, domain);
+    await removeFromEmailIndex(env.RESULTS, email, domain);
     await deleteWatch(env.RESULTS, domain);
     return json({ domain, monitoring: false, unsubscribed: true });
   }
@@ -177,6 +180,7 @@ export async function onRequestPost({ request, env }) {
   // strands a row. List from the best score we have; a never-scanned domain
   // lists as "pending", filled in on its next scan.
   await putWatch(env.RESULTS, watch);
+  await addToEmailIndex(env.RESULTS, email, domain);
   try {
     if (listed) {
       const seed = latest || {

--- a/apps/web/test/dashboard.test.js
+++ b/apps/web/test/dashboard.test.js
@@ -13,6 +13,8 @@ import {
   issueDashboardToken,
   consumeDashboardToken,
   listWatchesByEmail,
+  emailIndexKey,
+  getEmailDomains,
 } from '../functions/_shared.ts';
 import { buildDashboardLinkEmail } from '../functions/_alerts.ts';
 import { onRequestPost as linkPost } from '../functions/api/dashboard/link.ts';
@@ -55,6 +57,20 @@ const watch = (domain, email, over = {}) =>
     lastTier: 'Clean',
     ...over,
   });
+
+async function seedWatches(kv, entries) {
+  const byEmail = {};
+  for (const { domain, email, over = {} } of entries) {
+    const normalized = String(email).trim().toLowerCase();
+    kv.store.set(`w:${domain}`, { value: watch(domain, normalized, over) });
+    byEmail[normalized] = byEmail[normalized] || [];
+    byEmail[normalized].push(domain);
+  }
+  for (const [email, domains] of Object.entries(byEmail)) {
+    const key = await emailIndexKey(email);
+    kv.store.set(key, { value: JSON.stringify(domains) });
+  }
+}
 
 function getReq(url, cookie) {
   return { url, headers: { get: (k) => (k.toLowerCase() === 'cookie' ? cookie || null : null) } };
@@ -106,11 +122,12 @@ test('dashboard tokens are single-use', async () => {
 });
 
 test('listWatchesByEmail returns only that owner, case-normalized', async () => {
-  const kv = makeKv({
-    'w:a.com': watch('a.com', 'agency@x.io'),
-    'w:b.com': watch('b.com', 'agency@x.io'),
-    'w:c.com': watch('c.com', 'other@y.io'),
-  });
+  const kv = makeKv();
+  await seedWatches(kv, [
+    { domain: 'a.com', email: 'agency@x.io' },
+    { domain: 'b.com', email: 'agency@x.io' },
+    { domain: 'c.com', email: 'other@y.io' },
+  ]);
   const mine = await listWatchesByEmail(kv, '  Agency@X.io ');
   expect(mine.map((w) => w.domain).sort()).toEqual(['a.com', 'b.com']);
 });
@@ -129,7 +146,8 @@ test('link endpoint never reveals whether an email has watches (anti-enumeration
     sent.push(JSON.parse(opts.body));
     return new Response('{}', { status: 200 });
   };
-  const kv = makeKv({ 'w:a.com': watch('a.com', 'known@x.io') });
+  const kv = makeKv();
+  await seedWatches(kv, [{ domain: 'a.com', email: 'known@x.io' }]);
   const env = { RESULTS: kv, ...LIVE_ENV };
 
   const r1 = await linkPost({ request: postReq({ email: 'known@x.io' }), env });
@@ -150,7 +168,8 @@ test('link endpoint rate-limits magic-link sends per email (anti-bombing)', asyn
     sent.push(JSON.parse(opts.body));
     return new Response('{}', { status: 200 });
   };
-  const kv = makeKv({ 'w:a.com': watch('a.com', 'known@x.io') });
+  const kv = makeKv();
+  await seedWatches(kv, [{ domain: 'a.com', email: 'known@x.io' }]);
   const env = { RESULTS: kv, RATE_LIMIT: kv, ...LIVE_ENV };
 
   for (let i = 0; i < 4; i++) {
@@ -178,8 +197,28 @@ test('/dashboard is configured-off without SESSION_SECRET', async () => {
   expect(await res.text()).toMatch(/not configured/i);
 });
 
+test('link endpoint reads exactly one RESULTS index key per lookup [COST-2]', async () => {
+  const kv = makeKv();
+  await seedWatches(kv, [{ domain: 'a.com', email: 'known@x.io' }]);
+  let resultsGets = 0;
+  const resultsKv = {
+    ...kv,
+    async get(k) {
+      resultsGets += 1;
+      return kv.get(k);
+    },
+  };
+  const env = { RESULTS: resultsKv, ...LIVE_ENV };
+  globalThis.fetch = async () => new Response('{}', { status: 200 });
+
+  await linkPost({ request: postReq({ email: 'known@x.io' }), env });
+  expect(resultsGets, 'one index get for the email lookup').toBe(1);
+  expect(await getEmailDomains(kv, 'known@x.io')).toEqual(['a.com']);
+});
+
 test('/dashboard without a cookie shows the login form, no domains', async () => {
-  const kv = makeKv({ 'w:a.com': watch('a.com', 'agency@x.io') });
+  const kv = makeKv();
+  await seedWatches(kv, [{ domain: 'a.com', email: 'agency@x.io' }]);
   const res = await dashGet({
     request: getReq('https://slop-detect.com/dashboard'),
     env: { RESULTS: kv, SESSION_SECRET: SECRET },
@@ -190,7 +229,8 @@ test('/dashboard without a cookie shows the login form, no domains', async () =>
 });
 
 test('a valid magic-link token mints a session cookie and redirects clean', async () => {
-  const kv = makeKv({ 'w:a.com': watch('a.com', 'agency@x.io') });
+  const kv = makeKv();
+  await seedWatches(kv, [{ domain: 'a.com', email: 'agency@x.io' }]);
   const t = await issueDashboardToken(kv, 'agency@x.io');
   const res = await dashGet({
     request: getReq(`https://slop-detect.com/dashboard?token=${t}`),
@@ -216,11 +256,16 @@ test('a bad/expired token falls back to login with an expiry note', async () => 
 });
 
 test('a signed-in agency sees ONLY its own domains — never another owner’s', async () => {
-  const kv = makeKv({
-    'w:a.com': watch('a.com', 'agency@x.io', { systemRegressed: true, lastSystemTier: 'Drifting' }),
-    'w:b.com': watch('b.com', 'agency@x.io'),
-    'w:secret.com': watch('secret.com', 'other@y.io'),
-  });
+  const kv = makeKv();
+  await seedWatches(kv, [
+    {
+      domain: 'a.com',
+      email: 'agency@x.io',
+      over: { systemRegressed: true, lastSystemTier: 'Drifting' },
+    },
+    { domain: 'b.com', email: 'agency@x.io' },
+    { domain: 'secret.com', email: 'other@y.io' },
+  ]);
   const tok = await signSession('agency@x.io', SECRET);
   const res = await dashGet({
     request: getReq('https://slop-detect.com/dashboard', `sd_session=${tok}`),

--- a/apps/web/test/dashboard.test.js
+++ b/apps/web/test/dashboard.test.js
@@ -149,17 +149,71 @@ test('link endpoint never reveals whether an email has watches (anti-enumeration
   const kv = makeKv();
   await seedWatches(kv, [{ domain: 'a.com', email: 'known@x.io' }]);
   const env = { RESULTS: kv, ...LIVE_ENV };
+  const deferred = [];
+  const waitUntil = (task) => deferred.push(task);
 
-  const r1 = await linkPost({ request: postReq({ email: 'known@x.io' }), env });
-  const r2 = await linkPost({ request: postReq({ email: 'unknown@x.io' }), env });
+  const r1 = await linkPost({
+    request: postReq({ email: 'known@x.io' }),
+    env,
+    waitUntil,
+  });
+  const r2 = await linkPost({
+    request: postReq({ email: 'unknown@x.io' }),
+    env,
+    waitUntil,
+  });
   const [b1, b2] = [await r1.json(), await r2.json()];
   expect(r1.status).toBe(r2.status);
   expect(b1, 'identical bodies for known and unknown emails').toEqual(b2);
+
+  expect(deferred.length).toBe(1);
+  await deferred[0];
 
   // …but only the known email actually got a message, with a token link in it.
   expect(sent.length).toBe(1);
   expect(sent[0].to[0]).toBe('known@x.io');
   expect(sent[0].text).toMatch(/\/dashboard\?token=/);
+});
+
+test('link endpoint defers rate-limit work to waitUntil (latency-safe anti-enumeration)', async () => {
+  const kv = makeKv();
+  await seedWatches(kv, [{ domain: 'a.com', email: 'known@x.io' }]);
+  let rateLimitGets = 0;
+  let rateLimitGetsAtWaitUntil = -1;
+  const rateLimitKv = {
+    async get(k) {
+      rateLimitGets += 1;
+      await new Promise((r) => setTimeout(r, 80));
+      return kv.get(k);
+    },
+    async put(k, v, o) {
+      return kv.put(k, v, o);
+    },
+  };
+  const deferred = [];
+  const waitUntil = (task) => {
+    rateLimitGetsAtWaitUntil = rateLimitGets;
+    deferred.push(task);
+  };
+  const env = { RESULTS: kv, RATE_LIMIT: rateLimitKv, ...LIVE_ENV };
+
+  const t0 = performance.now();
+  await linkPost({ request: postReq({ email: 'known@x.io' }), env, waitUntil });
+  const knownMs = performance.now() - t0;
+
+  const t1 = performance.now();
+  await linkPost({ request: postReq({ email: 'unknown@x.io' }), env, waitUntil });
+  const unknownMs = performance.now() - t1;
+
+  expect(
+    rateLimitGetsAtWaitUntil,
+    'RATE_LIMIT not touched when waitUntil is registered'
+  ).toBe(0);
+  expect(Math.abs(knownMs - unknownMs), 'known vs unknown response timing').toBeLessThan(30);
+  expect(deferred.length).toBe(1);
+
+  await deferred[0];
+  expect(rateLimitGets, 'RATE_LIMIT checked only inside deferred send').toBeGreaterThan(0);
 });
 
 test('link endpoint rate-limits magic-link sends per email (anti-bombing)', async () => {

--- a/apps/web/test/watch.test.js
+++ b/apps/web/test/watch.test.js
@@ -11,6 +11,8 @@ import {
   recordScanForWatch,
   getWatch,
   getHistory,
+  emailIndexKey,
+  getEmailDomains,
 } from '../functions/_shared.ts';
 import { onRequestPost, onRequestGet } from '../functions/api/watch.ts';
 
@@ -182,12 +184,18 @@ test('POST /api/watch subscribes, seeding baseline from the latest scan', async 
   const watch = await getWatch(kv, 'example.com');
   expect(watch.email, 'email is normalized lowercase').toBe('dev@startup.io');
   expect(watch.baselineScore).toBe(6);
+
+  const indexKey = await emailIndexKey('dev@startup.io');
+  expect(kv.store.has(indexKey), 'subscribe writes the email index key [COST-2]').toBe(true);
+  expect(await getEmailDomains(kv, 'dev@startup.io')).toEqual(['example.com']);
 });
 
 test('POST /api/watch unsubscribe requires a matching email', async () => {
   const kv = makeKv({
     'w:example.com': JSON.stringify({ domain: 'example.com', email: 'owner@x.io' }),
   });
+  const indexKey = await emailIndexKey('owner@x.io');
+  kv.store.set(indexKey, JSON.stringify(['example.com']));
   const env = { RESULTS: kv };
 
   // Wrong email → 403, watch survives.
@@ -205,6 +213,7 @@ test('POST /api/watch unsubscribe requires a matching email', async () => {
   });
   expect(res.status).toBe(200);
   expect(await getWatch(kv, 'example.com')).toBe(null);
+  expect(kv.store.has(indexKey), 'unsubscribe removes the email index entry').toBe(false);
 });
 
 // ── GET /api/watch ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes finding COST-2 (P3) from docs/adversarial-review-fresh.md.

Problem: the unauthenticated magic-link endpoint (dashboard/link.ts) called listWatchesByEmail -> a full listWatches scan + per-record kv.get, driving up to ~1000 KV reads per login attempt (read-amplification / cost lever).

Solution: maintain an email->domains index key written on subscribe in watch.ts, so the dashboard-link lookup is one kv.get instead of a full scan. Reuses the existing newId/KV helpers in _data.ts; the anti-enumeration constant-response design is untouched (validated strength #5). Index is kept consistent on subscribe/unsubscribe.

Acceptance: apps/web/test/{watch,dashboard}.test.js — subscribing writes the index key; the dashboard-link path reads exactly one index key (KV get spy). Finding: COST-2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-adjacent magic-link flow and KV consistency; index drift is mitigated by subscribe/unsubscribe updates and self-healing in `listWatchesByEmail`, but legacy watches rely on lazy rebuild until first dashboard list.
> 
> **Overview**
> Adds a **hashed email → domains** KV index (`e:<sha256>`) so unauthenticated dashboard magic-link requests do one `get` instead of scanning up to ~1000 watches.
> 
> **`listWatchesByEmail`** now reads the index and loads watches per domain, with a one-time full-scan rebuild when the index is missing and pruning of stale domains. **`/api/watch`** maintains the index on subscribe (`addToEmailIndex`) and unsubscribe (`removeFromEmailIndex`).
> 
> **`/api/dashboard/link`** switches from `listWatchesByEmail` to **`getEmailDomains`** for existence/count only. Rate limiting and email send stay deferred via **`waitUntil`**, with a microtask defer so `RATE_LIMIT` is not touched before the generic JSON response returns (timing-safe anti-enumeration).
> 
> Tests cover index writes, single KV read on link lookup, and deferred rate-limit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d91eca926cf7abf146692708dd8c98f9b28518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->