### PR TITLE
feat(action): pull_request_target least-trust guidance + notice [SEC-4]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "apps/web": {
       "name": "slop-detect-web",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.1.0",
         "@slop-detect/core": "workspace:*",
@@ -73,6 +73,9 @@
         "slop-detect": "workspace:*",
         "typescript": "^5.0.0",
       },
+    },
+    "packages/action": {
+      "name": "@slop-detect/action",
     },
     "packages/cli": {
       "name": "slop-detect",
@@ -455,6 +458,8 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@slop-detect/action": ["@slop-detect/action@workspace:packages/action"],
 
     "@slop-detect/core": ["@slop-detect/core@workspace:packages/core"],
 

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -12,6 +12,34 @@ Heavy `28+`), surfaced as a letter grade (`A+ … F`).
 
 ---
 
+## Security (`pull_request_target` and `url`)
+
+This action works on `pull_request` and `pull_request_target`. It does **not**
+check out or run PR code — it forwards `url` to the public slop-detect API via
+`fetch` and may post a sticky PR comment.
+
+`pull_request_target` is different: GitHub supplies a **write-scoped token even
+for fork PRs**. That is safe here only when `url` is a **trusted, workflow-derived
+deploy-preview URL** (resolved from your Vercel/Netlify/Cloudflare API or a
+deployment status your workflow controls). **Never** pass a URL taken from PR
+body, title, branch name, or other PR-controlled fields — especially on fork PRs.
+
+Treat the `url` input as **untrusted**. The action already limits it to a single
+`fetch` against the scan API; the risk is workflow misconfiguration, not code
+execution inside the action.
+
+Grant **least privilege** in your workflow:
+
+```yaml
+permissions:
+  contents: read          # omit if you do not checkout
+  pull-requests: write    # required for the sticky comment
+```
+
+Prefer `pull_request` when your preview URL does not require `pull_request_target`.
+
+---
+
 ## Usage
 
 ```yaml

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -4,6 +4,17 @@
 # with zero external deps (built-in fetch), so there's nothing to bundle and no
 # node_modules to commit. The runner already ships Node 20, so `node scan.mjs`
 # just works. See scan.mjs for the actual logic.
+#
+# Security — pull_request_target and the url input:
+#   This action accepts pull_request and pull_request_target events (see scan.mjs).
+#   pull_request_target runs with a write-scoped GITHUB_TOKEN even for fork PRs.
+#   The action does not check out or execute PR code — it only POSTs `url` to the
+#   public slop-detect API and may post a sticky PR comment — but a misconfigured
+#   workflow that passes a PR-controlled URL while using pull_request_target is a
+#   footgun. Use pull_request_target ONLY when `url` is a trusted, workflow-derived
+#   deploy-preview URL (from your host's API or deployment status), never from PR
+#   body/title/branch content. Treat `url` as untrusted user input. Grant least
+#   privilege: `permissions: pull-requests: write` (plus `contents: read` if needed).
 name: 'Slop Detect'
 description: 'Score a landing page against the 16-rule AI-design-slop fingerprint and gate PRs.'
 author: 'Ravindra Kumar'
@@ -14,7 +25,7 @@ branding:
 
 inputs:
   url:
-    description: 'The page (URL) to scan — typically a deploy-preview URL.'
+    description: 'The page (URL) to scan — typically a trusted, workflow-derived deploy-preview URL. Treat as untrusted input: pass only URLs your workflow resolves from your host, never PR-controlled content (especially on pull_request_target).'
     required: true
   fail-under:
     # NOTE on semantics: the slop score is 0–100 where LOWER is better. So

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@slop-detect/action",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  }
+}

--- a/packages/action/scan.mjs
+++ b/packages/action/scan.mjs
@@ -10,6 +10,7 @@
 // exit non-zero if the page is too sloppy.
 
 import { appendFileSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 // ---------------------------------------------------------------------------
 // Tiny helpers
@@ -20,6 +21,18 @@ import { appendFileSync, readFileSync } from 'node:fs';
 const log = (msg) => process.stdout.write(`${msg}\n`);
 const ghError = (msg) => log(`::error::${msg}`);
 const ghNotice = (msg) => log(`::notice::${msg}`);
+
+// SEC-4: surface misconfiguration risk when running on pull_request_target.
+export const PULL_REQUEST_TARGET_NOTICE =
+  'pull_request_target runs with a write-scoped token even for fork PRs. ' +
+  'Pass only a trusted, workflow-derived deploy-preview URL in `url` — never a value from PR-controlled content. ' +
+  'Grant least privilege: permissions: pull-requests: write only.';
+
+export function noticeIfPullRequestTarget(eventName = process.env.GITHUB_EVENT_NAME || '') {
+  if (eventName !== 'pull_request_target') return false;
+  ghNotice(PULL_REQUEST_TARGET_NOTICE);
+  return true;
+}
 
 // Fail fast with a clear annotation. Used for any unrecoverable problem so we
 // never post a misleading comment off a broken/empty scan.
@@ -289,6 +302,8 @@ async function main() {
 
   if (!url) die('Input "url" is required.');
 
+  noticeIfPullRequestTarget();
+
   log(`Scanning ${url} via ${apiBase} …`);
   const result = await scan(apiBase, url);
   const resultUrl = result.resultUrl || `${apiBase.replace(/\/+$/, '')}/r/${result.id}`;
@@ -334,4 +349,6 @@ async function main() {
   }
 }
 
-main().catch((err) => die(`Unexpected error: ${err?.stack || err?.message || err}`));
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => die(`Unexpected error: ${err?.stack || err?.message || err}`));
+}

--- a/packages/action/test/scan.test.js
+++ b/packages/action/test/scan.test.js
@@ -1,0 +1,29 @@
+import { test, expect, afterEach } from 'vitest';
+import { noticeIfPullRequestTarget, PULL_REQUEST_TARGET_NOTICE } from '../scan.mjs';
+
+const realWrite = process.stdout.write.bind(process.stdout);
+let captured = '';
+
+afterEach(() => {
+  process.stdout.write = realWrite;
+  captured = '';
+});
+
+function captureStdout() {
+  process.stdout.write = (chunk) => {
+    captured += String(chunk);
+    return true;
+  };
+}
+
+test('noticeIfPullRequestTarget emits a GitHub notice on pull_request_target', () => {
+  captureStdout();
+  expect(noticeIfPullRequestTarget('pull_request_target')).toBe(true);
+  expect(captured).toBe(`::notice::${PULL_REQUEST_TARGET_NOTICE}\n`);
+});
+
+test('noticeIfPullRequestTarget is silent on pull_request', () => {
+  captureStdout();
+  expect(noticeIfPullRequestTarget('pull_request')).toBe(false);
+  expect(captured).toBe('');
+});


### PR DESCRIPTION
Closes finding SEC-4 (P3) from docs/adversarial-review-fresh.md.

Problem: the composite Action reads a PR number from both pull_request and pull_request_target (scan.mjs). pull_request_target runs with a write-scoped token even for fork PRs; the example workflow gave no least-trust guidance. Direct risk is low (the action only forwards the url input to the public API + posts a sticky comment, no PR code checkout/exec), but the misconfiguration footgun was undocumented.

Solution: action.yml + README document that pull_request_target must be used only with a trusted, workflow-derived deploy-preview URL (never a PR-controlled URL) and recommend least privilege (permissions: pull-requests: write). scan.mjs logs a ::notice:: at runtime when GITHUB_EVENT_NAME=pull_request_target so misconfiguration is visible. The url input is treated as untrusted (only reaches fetch).

Acceptance: packages/action/test/scan.test.js asserts the notice is emitted on pull_request_target. Note: package.json/bun.lock changed — reviewer to confirm any added dev-dep is justified/minimal. Finding: SEC-4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, a diagnostic GitHub Actions notice, and unit tests—no scan API, auth, or PR code execution behavior.
> 
> **Overview**
> Addresses **SEC-4** by making the composite GitHub Action’s `pull_request_target` footgun explicit and visible at run time.
> 
> **Docs:** `action.yml` and `packages/action/README.md` now state that `url` must be a **trusted, workflow-derived** deploy-preview URL (never PR-controlled fields), recommend **`pull_request`** when possible, and show **least-privilege** `permissions` (`pull-requests: write`).
> 
> **Runtime:** `scan.mjs` exports `noticeIfPullRequestTarget`, which logs a `::notice::` when `GITHUB_EVENT_NAME` is `pull_request_target`; `main` is only auto-run when the file is executed directly so tests can import the helper. The `url` input description is tightened to match.
> 
> **Tests / monorepo:** Adds `packages/action/package.json` with a `vitest` test script and `scan.test.js` for the notice behavior; registers `@slop-detect/action` in the lockfile. Also bumps `apps/web` to **0.8.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc32e44569bc4166436f8d94b9d87be935eccf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->