### PR TITLE
fix(web): browser session reuse + /og kill-switch [REL-1, REL-2]

### DIFF
--- a/apps/web/functions/_browser.ts
+++ b/apps/web/functions/_browser.ts
@@ -1,0 +1,63 @@
+// Shared Cloudflare Browser Rendering acquire/release seam.
+//
+// @cloudflare/puppeteer@1.1.0 exposes sessions()/connect()/launch() on the
+// default export. Prefer connecting to an idle warm session (no connectionId)
+// before cold-launching; release via disconnect() so the session stays warm.
+
+import puppeteer from '@cloudflare/puppeteer';
+
+const DEFAULT_KEEP_ALIVE_MS = 60_000;
+
+export type AcquiredBrowser = {
+  browser: Awaited<ReturnType<typeof puppeteer.launch>>;
+  /** true when connect() reused an idle session instead of launch(). */
+  reused: boolean;
+};
+
+function isScanDisabled(env: { SCAN_DISABLED?: string }) {
+  return env.SCAN_DISABLED === '1' || env.SCAN_DISABLED === 'true';
+}
+
+/** True when browser rendering is paused (kill switch). */
+export { isScanDisabled };
+
+/**
+ * Connect to a free warm session when one exists, otherwise launch a new one.
+ * Requires @cloudflare/puppeteer sessions()/connect() (v1.1.0+).
+ */
+export async function acquireBrowser(
+  binding: Parameters<typeof puppeteer.launch>[0],
+  options: { keep_alive?: number } = {}
+): Promise<AcquiredBrowser> {
+  const keepAlive = options.keep_alive ?? DEFAULT_KEEP_ALIVE_MS;
+
+  if (typeof puppeteer.sessions === 'function') {
+    const sessions = await puppeteer.sessions(binding);
+    const idle = sessions.find((s) => !s.connectionId);
+    if (idle) {
+      try {
+        const browser = await puppeteer.connect(binding, idle.sessionId);
+        return { browser, reused: true };
+      } catch (_) {
+        // Session may have closed between sessions() and connect(); fall through.
+      }
+    }
+  }
+
+  const browser = await puppeteer.launch(binding, { keep_alive: keepAlive });
+  return { browser, reused: false };
+}
+
+/** Drop the worker connection but keep the browser session warm for reuse. */
+export async function releaseBrowser(
+  browser: { disconnect?: () => Promise<void>; close?: () => Promise<void> } | null | undefined
+): Promise<void> {
+  if (!browser) return;
+  try {
+    if (typeof browser.disconnect === 'function') {
+      await browser.disconnect();
+    } else {
+      await browser.close?.();
+    }
+  } catch (_) {}
+}

--- a/apps/web/functions/api/scan.ts
+++ b/apps/web/functions/api/scan.ts
@@ -4,7 +4,7 @@
 // Rendering Chromium. Requires a BROWSER binding on the Pages project. Opt into
 // the copy-slop axis with { axes: ['design','copy'] } (or 'all').
 
-import puppeteer from '@cloudflare/puppeteer';
+import { acquireBrowser, releaseBrowser } from '../_browser.js';
 import {
   PATTERNS,
   createColorHelpers,
@@ -85,7 +85,7 @@ export async function onRequestPost({ request, env }) {
 
   let browser;
   try {
-    browser = await puppeteer.launch(env.BROWSER);
+    ({ browser } = await acquireBrowser(env.BROWSER));
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 800 });
     await page.setUserAgent('Mozilla/5.0 SlopDetector/1.0 (+slop-detector.pages.dev)');
@@ -272,9 +272,7 @@ export async function onRequestPost({ request, env }) {
     });
     return json({ error: err.message || String(err) }, 502);
   } finally {
-    try {
-      await browser?.close();
-    } catch (_) {}
+    await releaseBrowser(browser);
   }
 }
 

--- a/apps/web/functions/og/[id].ts
+++ b/apps/web/functions/og/[id].ts
@@ -5,7 +5,7 @@
 // Falls back to the static /og.png if anything goes wrong (a broken unfurl is
 // worse than a generic one).
 
-import puppeteer from '@cloudflare/puppeteer';
+import { acquireBrowser, isScanDisabled, releaseBrowser } from '../_browser.js';
 import { getResult } from '../_shared.js';
 import { cardHtml } from '../_card.js';
 
@@ -30,6 +30,10 @@ export async function onRequestGet({ params, env, request }) {
     } catch (_) {}
   }
 
+  if (isScanDisabled(env)) {
+    return Response.redirect(new URL('/og.png', request.url).toString(), 302);
+  }
+
   const slim = await getResult(env.RESULTS, id);
   if (!slim || !env.BROWSER) {
     return Response.redirect(new URL('/og.png', request.url).toString(), 302);
@@ -37,7 +41,7 @@ export async function onRequestGet({ params, env, request }) {
 
   let browser;
   try {
-    browser = await puppeteer.launch(env.BROWSER);
+    ({ browser } = await acquireBrowser(env.BROWSER));
     const page = await browser.newPage();
     await page.setViewport({ width: 1200, height: 630, deviceScaleFactor: 1 });
     await page.setContent(cardHtml(slim), { waitUntil: 'networkidle0', timeout: 15000 });
@@ -62,8 +66,6 @@ export async function onRequestGet({ params, env, request }) {
   } catch (_) {
     return Response.redirect(new URL('/og.png', request.url).toString(), 302);
   } finally {
-    try {
-      await browser?.close();
-    } catch (_) {}
+    await releaseBrowser(browser);
   }
 }

--- a/apps/web/functions/og/[id].ts
+++ b/apps/web/functions/og/[id].ts
@@ -12,6 +12,10 @@ import { cardHtml } from '../_card.js';
 const OG_TTL = 60 * 60 * 24 * 30; // 30 days
 
 export async function onRequestGet({ params, env, request }) {
+  if (isScanDisabled(env)) {
+    return Response.redirect(new URL('/og.png', request.url).toString(), 302);
+  }
+
   const id = String(params.id || '')
     .replace(/\.png$/i, '')
     .replace(/[^a-z0-9]/gi, '')
@@ -28,10 +32,6 @@ export async function onRequestGet({ params, env, request }) {
       const cached = await env.RESULTS.get(`og:${id}`, 'arrayBuffer');
       if (cached) return new Response(cached, { headers: pngHeaders });
     } catch (_) {}
-  }
-
-  if (isScanDisabled(env)) {
-    return Response.redirect(new URL('/og.png', request.url).toString(), 302);
   }
 
   const slim = await getResult(env.RESULTS, id);

--- a/apps/web/test/browser-reuse.test.js
+++ b/apps/web/test/browser-reuse.test.js
@@ -1,0 +1,89 @@
+// REL-1: shared browser acquire/release reuses idle sessions via connect().
+
+import { test, expect, vi, beforeEach } from 'vitest';
+
+const mock = vi.hoisted(() => ({
+  idleSessionId: null,
+  sessionsError: null,
+  connectError: null,
+  launchError: null,
+  calls: { sessions: 0, connect: 0, launch: 0, disconnect: 0, close: 0 },
+}));
+
+function makeBrowser() {
+  return {
+    newPage: async () => ({}),
+    disconnect: async () => {
+      mock.calls.disconnect++;
+    },
+    close: async () => {
+      mock.calls.close++;
+    },
+  };
+}
+
+vi.mock('@cloudflare/puppeteer', () => ({
+  default: {
+    sessions: async () => {
+      mock.calls.sessions++;
+      if (mock.sessionsError) throw mock.sessionsError;
+      if (!mock.idleSessionId) return [];
+      return [{ sessionId: mock.idleSessionId, startTime: Date.now() }];
+    },
+    connect: async (_binding, sessionId) => {
+      mock.calls.connect++;
+      if (mock.connectError) throw mock.connectError;
+      return { ...makeBrowser(), sessionId };
+    },
+    launch: async () => {
+      mock.calls.launch++;
+      if (mock.launchError) throw mock.launchError;
+      return makeBrowser();
+    },
+  },
+}));
+
+import { acquireBrowser, releaseBrowser } from '../functions/_browser.ts';
+
+beforeEach(() => {
+  mock.idleSessionId = null;
+  mock.sessionsError = null;
+  mock.connectError = null;
+  mock.launchError = null;
+  mock.calls = { sessions: 0, connect: 0, launch: 0, disconnect: 0, close: 0 };
+});
+
+test('acquireBrowser connects to an idle session without launching', async () => {
+  mock.idleSessionId = 'warm-sess-42';
+  const { browser, reused } = await acquireBrowser({});
+  expect(reused).toBe(true);
+  expect(mock.calls.sessions).toBe(1);
+  expect(mock.calls.connect).toBe(1);
+  expect(mock.calls.launch).toBe(0);
+  expect(browser).toBeTruthy();
+});
+
+test('acquireBrowser launches when no idle session is available', async () => {
+  const { browser, reused } = await acquireBrowser({});
+  expect(reused).toBe(false);
+  expect(mock.calls.sessions).toBe(1);
+  expect(mock.calls.connect).toBe(0);
+  expect(mock.calls.launch).toBe(1);
+  expect(browser).toBeTruthy();
+});
+
+test('acquireBrowser launches when connect to idle session fails', async () => {
+  mock.idleSessionId = 'stale-sess';
+  mock.connectError = new Error('session gone');
+  const { reused } = await acquireBrowser({});
+  expect(reused).toBe(false);
+  expect(mock.calls.connect).toBe(1);
+  expect(mock.calls.launch).toBe(1);
+});
+
+test('releaseBrowser disconnects instead of closing', async () => {
+  const { browser } = await acquireBrowser({});
+  await releaseBrowser(browser);
+  expect(mock.calls.disconnect).toBe(1);
+  expect(mock.calls.close).toBe(0);
+});

--- a/apps/web/test/og-route.test.js
+++ b/apps/web/test/og-route.test.js
@@ -100,6 +100,21 @@ test('SCAN_DISABLED serves the static fallback without launching a browser', asy
   expect(mock.calls.sessions).toBe(0);
 });
 
+test('SCAN_DISABLED serves the fallback even when og cache is populated', async () => {
+  const kv = makeKv({
+    'r:abc123def456': JSON.stringify(slim),
+    'og:abc123def456': mock.screenshotBytes,
+  });
+  const res = await onRequestGet(
+    ogCtx('abc123def456', { RESULTS: kv, BROWSER: {}, SCAN_DISABLED: '1' })
+  );
+  expect(res.status).toBe(302);
+  expect(res.headers.get('Location')).toBe('https://slop-detect.com/og.png');
+  expect(mock.calls.launch).toBe(0);
+  expect(mock.calls.connect).toBe(0);
+  expect(mock.calls.sessions).toBe(0);
+});
+
 test('cache miss with a valid id launches at most once', async () => {
   const kv = makeKv({ 'r:abc123def456': JSON.stringify(slim) });
   const res = await onRequestGet(ogCtx('abc123def456', { RESULTS: kv, BROWSER: {} }));

--- a/apps/web/test/og-route.test.js
+++ b/apps/web/test/og-route.test.js
@@ -1,0 +1,122 @@
+// REL-2: /og/:id.png honors SCAN_DISABLED and routes browser I/O through _browser.
+
+import { test, expect, vi, beforeEach } from 'vitest';
+
+const mock = vi.hoisted(() => ({
+  idleSessionId: null,
+  calls: { sessions: 0, connect: 0, launch: 0 },
+  screenshotBytes: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+}));
+
+function makePage() {
+  return {
+    setViewport: async () => {},
+    setContent: async () => {},
+    evaluate: async () => {},
+    screenshot: async () => mock.screenshotBytes,
+  };
+}
+
+function makeBrowser() {
+  return {
+    newPage: async () => makePage(),
+    disconnect: async () => {},
+    close: async () => {},
+  };
+}
+
+vi.mock('@cloudflare/puppeteer', () => ({
+  default: {
+    sessions: async () => {
+      mock.calls.sessions++;
+      if (!mock.idleSessionId) return [];
+      return [{ sessionId: mock.idleSessionId, startTime: Date.now() }];
+    },
+    connect: async () => {
+      mock.calls.connect++;
+      return makeBrowser();
+    },
+    launch: async () => {
+      mock.calls.launch++;
+      return makeBrowser();
+    },
+  },
+}));
+
+import { onRequestGet } from '../functions/og/[id].ts';
+
+const slim = {
+  id: 'abc123def456',
+  domain: 'example.com',
+  score: 22,
+  tier: 'Mild',
+  grade: 'C',
+  verdict: 'Some patterns flagged.',
+  patternsFlagged: 4,
+  patternsTotal: 27,
+  triggered: [{ short: 'Centered hero', label: 'Centered hero' }],
+};
+
+function makeKv(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    async get(k, type) {
+      if (!store.has(k)) return null;
+      const v = store.get(k);
+      if (type === 'arrayBuffer' && typeof v === 'string') {
+        return new TextEncoder().encode(v).buffer;
+      }
+      return v;
+    },
+    async put(k, v) {
+      store.set(k, v);
+    },
+  };
+}
+
+function ogCtx(id, env, url = 'https://slop-detect.com/og/abc123def456.png') {
+  return {
+    params: { id },
+    env,
+    request: { url },
+  };
+}
+
+beforeEach(() => {
+  mock.idleSessionId = null;
+  mock.calls = { sessions: 0, connect: 0, launch: 0 };
+});
+
+test('SCAN_DISABLED serves the static fallback without launching a browser', async () => {
+  const kv = makeKv({ 'r:abc123def456': JSON.stringify(slim) });
+  const res = await onRequestGet(
+    ogCtx('abc123def456', { RESULTS: kv, BROWSER: {}, SCAN_DISABLED: '1' })
+  );
+  expect(res.status).toBe(302);
+  expect(res.headers.get('Location')).toBe('https://slop-detect.com/og.png');
+  expect(mock.calls.launch).toBe(0);
+  expect(mock.calls.connect).toBe(0);
+  expect(mock.calls.sessions).toBe(0);
+});
+
+test('cache miss with a valid id launches at most once', async () => {
+  const kv = makeKv({ 'r:abc123def456': JSON.stringify(slim) });
+  const res = await onRequestGet(ogCtx('abc123def456', { RESULTS: kv, BROWSER: {} }));
+  expect(res.status).toBe(200);
+  expect(res.headers.get('Content-Type')).toBe('image/png');
+  expect(mock.calls.launch).toBe(1);
+  expect(mock.calls.connect).toBe(0);
+});
+
+test('cache hit never launches a browser', async () => {
+  const png = mock.screenshotBytes;
+  const kv = makeKv({
+    'r:abc123def456': JSON.stringify(slim),
+    'og:abc123def456': png,
+  });
+  const res = await onRequestGet(ogCtx('abc123def456', { RESULTS: kv, BROWSER: {} }));
+  expect(res.status).toBe(200);
+  expect(mock.calls.launch).toBe(0);
+  expect(mock.calls.connect).toBe(0);
+});

--- a/apps/web/test/scan-contract.test.js
+++ b/apps/web/test/scan-contract.test.js
@@ -26,32 +26,43 @@ const mock = vi.hoisted(() => ({
   gotoError: null, // if set, page.goto throws (navigation failure)
   evalError: null, // if set, page.evaluate throws (page crashed)
   screenshotError: null, // if set, page.screenshot throws (handled, non-fatal)
+  idleSessionId: null, // when set, acquireBrowser should connect instead of launch
 }));
+
+function makeMockBrowser() {
+  return {
+    newPage: async () => ({
+      setViewport: async () => {},
+      setUserAgent: async () => {},
+      goto: async () => {
+        if (mock.gotoError) throw mock.gotoError;
+        return { url: () => mock.gotoResponseUrl };
+      },
+      waitForNetworkIdle: async () => {},
+      evaluate: async () => {
+        if (mock.evalError) throw mock.evalError;
+        return mock.pageData;
+      },
+      screenshot: async () => {
+        if (mock.screenshotError) throw mock.screenshotError;
+        return Buffer.from('fake-jpeg-bytes');
+      },
+    }),
+    disconnect: async () => {},
+    close: async () => {},
+  };
+}
 
 vi.mock('@cloudflare/puppeteer', () => ({
   default: {
+    sessions: async () => {
+      if (!mock.idleSessionId) return [];
+      return [{ sessionId: mock.idleSessionId, startTime: Date.now() }];
+    },
+    connect: async () => makeMockBrowser(),
     launch: async () => {
       if (mock.launchError) throw mock.launchError;
-      return {
-        newPage: async () => ({
-          setViewport: async () => {},
-          setUserAgent: async () => {},
-          goto: async () => {
-            if (mock.gotoError) throw mock.gotoError;
-            return { url: () => mock.gotoResponseUrl };
-          },
-          waitForNetworkIdle: async () => {},
-          evaluate: async () => {
-            if (mock.evalError) throw mock.evalError;
-            return mock.pageData;
-          },
-          screenshot: async () => {
-            if (mock.screenshotError) throw mock.screenshotError;
-            return Buffer.from('fake-jpeg-bytes');
-          },
-        }),
-        close: async () => {},
-      };
+      return makeMockBrowser();
     },
   },
 }));
@@ -138,6 +149,7 @@ beforeEach(() => {
   mock.gotoError = null;
   mock.evalError = null;
   mock.screenshotError = null;
+  mock.idleSessionId = null;
 });
 
 // ── Success contract (MNR-1) ────────────────────────────────────────────────


### PR DESCRIPTION
Closes findings REL-1 (P1) and REL-2 (P2) from docs/adversarial-review-fresh.md. Builds on the merged SEC-1 boundary in scan.ts.

Problem: both browser entry points (scan.ts, og/[id].ts) cold-launched a fresh browser per request on a capacity-capped pool (REL-1); /og launched a browser outside every /api cost control, including the SCAN_DISABLED kill switch (REL-2).

Solution: new apps/web/functions/_browser.ts seam — acquireBrowser() connects to an idle warm @cloudflare/puppeteer session (verified present in v1.1.0: sessions()/connect()) before cold-launching, with a runtime guard so it degrades gracefully if the session API is absent; releaseBrowser() disconnect()s to keep the session warm. Both scan.ts and og/[id].ts route through it. og/[id].ts now honors SCAN_DISABLED (serves the static fallback, never launches) — confined to og, no _middleware.ts edits.

Acceptance: apps/web/test/browser-reuse.test.js (connect-when-idle vs launch-when-none, mock BROWSER) and og-route.test.js (SCAN_DISABLED serves fallback w/o launch; cache-miss launches at most once). SEC-1 scan-contract tests updated and still pass. No live binding.

OPS/verify (recorded): real reliability under the platform concurrent-browser cap = verify-at-scale (load/telemetry). Findings: REL-1, REL-2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how browser capacity is acquired and released across two production entry points; behavior is mostly additive with graceful fallback, but warm-session reuse can affect concurrency under load until verified at scale.
> 
> **Overview**
> Introduces a shared **`_browser`** seam so scan and OG rendering stop cold-launching Chromium on every request. **`acquireBrowser`** prefers an idle warm session via `sessions()`/`connect()` and falls back to `launch()` with keep-alive; **`releaseBrowser`** uses `disconnect()` so sessions stay warm for reuse.
> 
> **`scan.ts`** and **`og/[id].ts`** now route browser I/O through that seam instead of direct `puppeteer.launch`/`close`. The OG handler also checks **`SCAN_DISABLED`** up front and redirects to static `/og.png` without touching the browser pool (closing a gap where `/og` bypassed scan cost controls).
> 
> Vitest coverage adds **`browser-reuse.test.js`** and **`og-route.test.js`**, and **`scan-contract.test.js`** mocks are updated for the acquire path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12263abb5bfef1ebd844b02f7192a49b4f7b989c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->