### PR TITLE
fix: stream-cap all fetched bodies (AEO + DESIGN.md) [SEC-2]

### DIFF
--- a/apps/web/functions/api/scan.ts
+++ b/apps/web/functions/api/scan.ts
@@ -18,6 +18,7 @@ import {
   combineAxes,
   SCAN_PAGE_WAIT,
   waitFontsReadyInPage,
+  readCapped,
 } from '@slop-detect/core';
 import {
   newId,
@@ -228,7 +229,7 @@ export async function onRequestPost({ request, env }) {
           { headers: { Accept: 'text/markdown,text/plain,*/*' } },
           { timeoutMs: 8000 }
         );
-        if (res?.ok) mdText = (await res.text()).slice(0, 200_000);
+        if (res?.ok) mdText = await readCapped(res, 200_000);
       }
       result.system = scoreSystemCompliance(
         mdText ? parseDesignMd(mdText) : null,

--- a/apps/web/test/scan-contract.test.js
+++ b/apps/web/test/scan-contract.test.js
@@ -15,6 +15,7 @@
 
 import { test, expect, vi, beforeEach } from 'vitest';
 import { onRequestPost } from '../functions/api/scan.ts';
+import * as shared from '../functions/_shared.ts';
 
 // Shared, mutable mock state. vi.hoisted runs before the vi.mock factory and the
 // scan.ts import, so the factory can close over it and each test can drive the
@@ -452,4 +453,50 @@ test('502 when puppeteer.launch fails', async () => {
   expect(res.status).toBe(502);
   const r = await res.json();
   expect(r.error).toMatch(/Browser binding unavailable/);
+});
+
+test('DESIGN.md fetch stream-caps oversized bodies without buffering past 200KB', async () => {
+  const DESIGN_MD_CAP = 200_000;
+  const oversized = DESIGN_MD_CAP + 400_000;
+  let sent = 0;
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (sent >= oversized) {
+        controller.close();
+        return;
+      }
+      const chunk = new Uint8Array(64 * 1024).fill(97);
+      controller.enqueue(chunk);
+      sent += chunk.byteLength;
+    },
+  });
+  const fetchSpy = vi.spyOn(shared, 'fetchAllowedUrl').mockResolvedValue(
+    new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/markdown; charset=utf-8' },
+    })
+  );
+
+  mock.pageData = healthyPageData({
+    systemContext: {
+      fontFamilies: ['Inter'],
+      colors: ['#111111'],
+      borderRadius: ['8px'],
+    },
+  });
+
+  const res = await onRequestPost({
+    request: postReq({
+      url: 'https://acme.example.com',
+      designMd: 'https://acme.example.com/DESIGN.md',
+    }),
+    env: { BROWSER: {} },
+  });
+  expect(res.status).toBe(200);
+  const r = await res.json();
+  expect(r.system).toBeTruthy();
+  expect(r.system.source).toBe('https://acme.example.com/DESIGN.md');
+  expect(sent).toBeLessThan(oversized);
+
+  fetchSpy.mockRestore();
 });

--- a/packages/core/src/aeo.ts
+++ b/packages/core/src/aeo.ts
@@ -208,8 +208,8 @@ function pickCheck(id) {
 // Read a response body with a hard byte cap so a hostile/huge target page can't
 // exhaust memory (AEO only inspects <head>/meta/robots-ish prefixes). Streams and
 // stops at the cap rather than buffering the whole body via res.text().
-const MAX_HTML_BYTES = 2 * 1024 * 1024; // 2 MB
-async function readCapped(res, maxBytes = MAX_HTML_BYTES) {
+export const MAX_HTML_BYTES = 2 * 1024 * 1024; // 2 MB
+export async function readCapped(res, maxBytes = MAX_HTML_BYTES) {
   if (!res.body || typeof res.body.getReader !== 'function') {
     const t = await res.text();
     return t.length > maxBytes ? t.slice(0, maxBytes) : t;
@@ -238,6 +238,16 @@ async function readCapped(res, maxBytes = MAX_HTML_BYTES) {
     off += c.byteLength;
   }
   return new TextDecoder('utf-8', { fatal: false }).decode(merged.subarray(0, maxBytes));
+}
+
+// Optional fast-path: skip streaming when Content-Length already exceeds the cap.
+function readBodyCapped(res, maxBytes = MAX_HTML_BYTES) {
+  const cl = res.headers.get('content-length');
+  if (cl) {
+    const n = Number(cl);
+    if (Number.isFinite(n) && n > maxBytes) return Promise.resolve('');
+  }
+  return readCapped(res, maxBytes);
 }
 
 async function fetchWithTimeout(url, init, timeoutMs, fetchImpl, isUrlAllowed) {
@@ -410,7 +420,7 @@ export async function runAeoChecks(
       fetchImpl,
       isUrlAllowed
     );
-    htmlBody = await readCapped(html);
+    htmlBody = await readBodyCapped(html);
   } catch (e) {
     htmlErr = e instanceof Error ? e.message : String(e);
   }
@@ -437,7 +447,7 @@ export async function runAeoChecks(
       fetchImpl,
       isUrlAllowed
     );
-    await bot.text();
+    await readBodyCapped(bot);
   } catch (e) {
     botErr = e instanceof Error ? e.message : String(e);
   }
@@ -466,7 +476,7 @@ export async function runAeoChecks(
       isUrlAllowed
     );
     if (r.ok) {
-      robotsTxt = await r.text();
+      robotsTxt = await readBodyCapped(r);
       robotsFetched = true;
     }
   } catch {
@@ -512,7 +522,7 @@ export async function runAeoChecks(
       fetchImpl,
       isUrlAllowed
     );
-    await md.text();
+    await readBodyCapped(md);
   } catch {
     /* no twin */
   }
@@ -556,7 +566,7 @@ export async function runAeoChecks(
       fetchImpl,
       isUrlAllowed
     );
-    await llms.text();
+    await readBodyCapped(llms);
   } catch {
     /* none */
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,8 @@ export {
   aiBotsBlockedByRobots,
   toMarkdownUrl,
   runAeoChecks,
+  readCapped,
+  MAX_HTML_BYTES,
 } from './aeo.js';
 export {
   parseDesignMd,

--- a/packages/core/test/aeo.test.js
+++ b/packages/core/test/aeo.test.js
@@ -9,6 +9,8 @@ import {
   aiBotsBlockedByRobots,
   toMarkdownUrl,
   runAeoChecks,
+  readCapped,
+  MAX_HTML_BYTES,
 } from '@slop-detect/core';
 
 // ── detectAIBot ──────────────────────────────────────────────────────────────
@@ -147,4 +149,96 @@ test('runAeoChecks: site that blocks GPTBot + has noindex fails the required che
 test('AEO_CHECKS weights total 100', () => {
   const total = AEO_CHECKS.reduce((s, c) => s + c.weight, 0);
   expect(total).toBe(100);
+});
+
+// ── readCapped / SEC-2 body caps ─────────────────────────────────────────────
+function makeOversizedStream(totalBytes, chunkSize = 64 * 1024) {
+  let sent = 0;
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const size = Math.min(chunkSize, totalBytes - sent);
+      controller.enqueue(new Uint8Array(size).fill(97));
+      sent += size;
+    },
+  });
+  return {
+    stream,
+    get sent() {
+      return sent;
+    },
+  };
+}
+
+test('readCapped: oversized stream decodes <= cap and stops before the full body', async () => {
+  const cap = 50_000;
+  const oversized = cap + 200_000;
+  const handle = makeOversizedStream(oversized);
+  const res = new Response(handle.stream, { headers: { 'content-type': 'text/plain' } });
+  const text = await readCapped(res, cap);
+  expect(text.length).toBeLessThanOrEqual(cap);
+  expect(handle.sent).toBeLessThan(oversized);
+});
+
+test('runAeoChecks: oversized robots.txt and llms.txt are stream-capped', async () => {
+  const cap = MAX_HTML_BYTES;
+  const oversized = cap + 500_000;
+  const streams = {};
+
+  const fetchImpl = async (url) => {
+    const u = new URL(url);
+    if (u.pathname === '/') {
+      return new Response('<html><head></head><body>hi</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+    if (u.pathname === '/robots.txt' || u.pathname === '/llms.txt' || u.pathname === '/index.md') {
+      const handle = makeOversizedStream(oversized);
+      streams[u.pathname] = handle;
+      const ct =
+        u.pathname === '/index.md' ? 'text/markdown; charset=utf-8' : 'text/plain; charset=utf-8';
+      return new Response(handle.stream, { status: 200, headers: { 'content-type': ct } });
+    }
+    return new Response('not found', { status: 404 });
+  };
+
+  const r = await runAeoChecks('https://huge.example', { fetchImpl, timeoutMs: 5000 });
+  expect(r.axis).toBe('aeo');
+  for (const path of ['/robots.txt', '/llms.txt', '/index.md']) {
+    expect(streams[path]?.sent).toBeLessThan(oversized);
+  }
+});
+
+test('runAeoChecks: oversized Content-Length short-circuits without streaming', async () => {
+  const fetchImpl = async (url) => {
+    const u = new URL(url);
+    if (u.pathname === '/') {
+      return new Response('<html><head></head><body>hi</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+    if (u.pathname === '/robots.txt') {
+      const stream = new ReadableStream({
+        pull() {
+          throw new Error('must not stream-read robots.txt when Content-Length exceeds cap');
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          'content-type': 'text/plain',
+          'content-length': String(MAX_HTML_BYTES + 1_000_000),
+        },
+      });
+    }
+    return new Response('not found', { status: 404 });
+  };
+
+  const r = await runAeoChecks('https://cl.example', { fetchImpl, timeoutMs: 2000 });
+  expect(r.axis).toBe('aeo');
 });


### PR DESCRIPTION
Closes finding SEC-2 (P2) from docs/adversarial-review-fresh.md.

Problem: the AEO axis capped only the main HTML body; the GPTBot probe, robots.txt, markdown twin, and /llms.txt were read with unbounded .text(). scan.ts read a user-controllable DESIGN.md fully before slicing (text().slice(0,200_000)). A hostile target serving hundreds of MB on any of these forced the worker to buffer it, blowing the isolate budget.

Solution: reuse the existing readCapped streaming primitive (unchanged — validated strength #11) via a readBodyCapped wrapper with an optional Content-Length short-circuit, applied to every AEO body; scan.ts now uses readCapped(res, 200_000) instead of text().slice().

Acceptance: packages/core/test/aeo.test.js + apps/web/test/scan-contract.test.js mock a body stream that yields more than the cap and assert the read stops before the full payload is buffered. Full build + tests pass. Finding: SEC-2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive fetch paths in the scan worker and AEO runner; behavior is intentionally stricter (empty body when Content-Length exceeds cap) but limits memory exhaustion risk.
> 
> **Overview**
> Addresses **SEC-2** by ensuring hostile or huge HTTP bodies cannot force the worker to buffer unbounded data before caps apply.
> 
> **AEO** now reads every auxiliary response through `readBodyCapped` (2 MB default): main HTML (already capped), GPTBot probe, `robots.txt`, markdown twin, and `/llms.txt`—replacing unbounded `res.text()`. A **Content-Length** fast path skips streaming when the declared size is already over the cap.
> 
> **Scan** loads optional `DESIGN.md` via exported `readCapped(res, 200_000)` instead of `res.text().slice(0, 200_000)`, so oversized streams stop early.
> 
> `readCapped` and `MAX_HTML_BYTES` are **re-exported** from `@slop-detect/core`. New contract/unit tests assert oversized streams are not fully consumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125d81c77dc555f8a51efcbf1a60882f261a5fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->