### PR TITLE
fix(web): register error webhook with waitUntil + observability [OPS-1]

### DIFF
--- a/apps/web/functions/_report.ts
+++ b/apps/web/functions/_report.ts
@@ -7,11 +7,11 @@
 //
 // Usage:
 //   import { report } from '../_report.js';
-//   report(env, 'error', 'scan_failed', { url, message: err.message });
+//   report(env, 'error', 'scan_failed', { url, message: err.message }, waitUntil);
 //
 // Keep payloads PII-free — never log emails or full page content.
 
-export function report(env, level, event, data = {}) {
+export function report(env, level, event, data = {}, waitUntil) {
   const line = { ts: new Date().toISOString(), level, event, ...data };
   // Structured log line (picked up by `wrangler tail` / Logpush).
   try {
@@ -28,13 +28,18 @@ export function report(env, level, event, data = {}) {
       const body = JSON.stringify({
         text: `slop-detect ${level}: ${event} ${JSON.stringify(data).slice(0, 800)}`,
       });
-      // ctx.waitUntil would be ideal, but report() is called from places without
-      // ctx; a detached promise still flushes on Workers within the request budget.
-      void fetch(hook, {
+      const promise = fetch(hook, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body,
       }).catch(() => {});
+      if (typeof waitUntil === 'function') {
+        waitUntil(promise);
+      } else {
+        // Callers without request context (e.g. _email.ts) fall back to a
+        // detached promise; not guaranteed to complete after the response.
+        void promise;
+      }
     } catch (_) {
       /* swallow — observability must never break the request */
     }

--- a/apps/web/functions/api/scan.ts
+++ b/apps/web/functions/api/scan.ts
@@ -51,7 +51,7 @@ function json(data, status = 200) {
   });
 }
 
-export async function onRequestPost({ request, env }) {
+export async function onRequestPost({ request, env, waitUntil }) {
   if (!env.BROWSER) {
     return json({ error: 'BROWSER binding missing — check wrangler.toml' }, 500);
   }
@@ -81,6 +81,8 @@ export async function onRequestPost({ request, env }) {
   const pageScript = buildPageScript({ includeSystem: wantsSystem });
 
   let browser;
+  let navMs;
+  let patternsErrored = 0;
   try {
     ({ browser } = await acquireBrowser(env.BROWSER));
     const page = await browser.newPage();
@@ -103,7 +105,7 @@ export async function onRequestPost({ request, env }) {
     await new Promise((r) => setTimeout(r, SCAN_PAGE_WAIT.postNetworkSettleMs));
     // REL-3: wait for web fonts before scoring (mirrors og/[id].ts).
     await page.evaluate(waitFontsReadyInPage, SCAN_PAGE_WAIT.fontsReadyTimeoutMs);
-    const navMs = Date.now() - navStart;
+    navMs = Date.now() - navStart;
 
     const browserVersion = await browser.version();
     const data = await page.evaluate(pageScript);
@@ -165,9 +167,11 @@ export async function onRequestPost({ request, env }) {
     }
 
     // Score on the Worker side (patterns metadata lives here, not on the page).
-    const { patterns, patternsErrored } = assemblePatternResults(data.signals);
+    const assembled = assemblePatternResults(data.signals);
+    const { patterns } = assembled;
+    patternsErrored = assembled.patternsErrored;
     if (patternsErrored > 0) {
-      report(env, 'warn', 'pattern_errors', { url, patternsErrored });
+      report(env, 'warn', 'pattern_errors', { url, navMs, patternsErrored }, waitUntil);
     }
 
     // Optional scoring preset (full|strict|marketing|minimal). All patterns are
@@ -258,17 +262,30 @@ export async function onRequestPost({ request, env }) {
       } catch (e) {
         // Sharing/monitoring is best-effort; never fail a scan over it — but do
         // surface the KV error so a silent storage outage is visible.
-        report(env, 'warn', 'persist_failed', { message: e && e.message ? e.message : String(e) });
+        report(
+          env,
+          'warn',
+          'persist_failed',
+          { url, navMs, patternsErrored, message: e && e.message ? e.message : String(e) },
+          waitUntil
+        );
       }
     }
 
     return json(result);
   } catch (err) {
     // Surface scan failures instead of swallowing them (no PII: url only).
-    report(env, 'error', 'scan_failed', {
-      url,
-      message: err && err.message ? err.message : String(err),
-    });
+    report(
+      env,
+      'error',
+      'scan_failed',
+      {
+        url,
+        message: err && err.message ? err.message : String(err),
+        ...(navMs != null && { navMs, patternsErrored }),
+      },
+      waitUntil
+    );
     return json({ error: err.message || String(err) }, 502);
   } finally {
     await releaseBrowser(browser);

--- a/apps/web/functions/api/scan.ts
+++ b/apps/web/functions/api/scan.ts
@@ -83,6 +83,7 @@ export async function onRequestPost({ request, env, waitUntil }) {
   let browser;
   let navMs;
   let patternsErrored = 0;
+  const scanStart = Date.now();
   try {
     ({ browser } = await acquireBrowser(env.BROWSER));
     const page = await browser.newPage();
@@ -282,7 +283,8 @@ export async function onRequestPost({ request, env, waitUntil }) {
       {
         url,
         message: err && err.message ? err.message : String(err),
-        ...(navMs != null && { navMs, patternsErrored }),
+        navMs: navMs ?? Date.now() - scanStart,
+        patternsErrored,
       },
       waitUntil
     );

--- a/apps/web/test/report.test.js
+++ b/apps/web/test/report.test.js
@@ -1,0 +1,57 @@
+// OPS-1: error-webhook fetch must register with ctx.waitUntil when available.
+
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { report } from '../functions/_report.ts';
+
+const origFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  vi.restoreAllMocks();
+});
+
+test('registers webhook fetch with waitUntil when provided', async () => {
+  let resolveFetch;
+  const fetchPromise = new Promise((r) => {
+    resolveFetch = r;
+  });
+  globalThis.fetch = vi.fn(() => fetchPromise);
+
+  const waitUntil = vi.fn();
+  const env = { ERROR_WEBHOOK: 'https://hooks.example/alert' };
+
+  report(env, 'error', 'scan_failed', { url: 'https://x.test', message: 'boom' }, waitUntil);
+
+  expect(globalThis.fetch).toHaveBeenCalledOnce();
+  expect(waitUntil).toHaveBeenCalledOnce();
+  const registered = waitUntil.mock.calls[0][0];
+  expect(registered).toBeInstanceOf(Promise);
+  resolveFetch(new Response('', { status: 200 }));
+  await registered;
+});
+
+test('falls back to detached fetch when waitUntil is absent', async () => {
+  const fetchPromise = Promise.resolve(new Response('', { status: 200 }));
+  globalThis.fetch = vi.fn(() => fetchPromise);
+
+  const env = { ERROR_WEBHOOK: 'https://hooks.example/alert' };
+
+  report(env, 'warn', 'persist_failed', { message: 'kv down' });
+
+  expect(globalThis.fetch).toHaveBeenCalledOnce();
+  await fetchPromise;
+});
+
+test('does not call fetch for info-level events', () => {
+  globalThis.fetch = vi.fn();
+  const waitUntil = vi.fn();
+
+  report({ ERROR_WEBHOOK: 'https://hooks.example/alert' }, 'info', 'monitor_sweep', {}, waitUntil);
+
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  expect(waitUntil).not.toHaveBeenCalled();
+});

--- a/apps/web/test/report.test.js
+++ b/apps/web/test/report.test.js
@@ -14,12 +14,19 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test('registers webhook fetch with waitUntil when provided', async () => {
-  let resolveFetch;
-  const fetchPromise = new Promise((r) => {
-    resolveFetch = r;
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
   });
-  globalThis.fetch = vi.fn(() => fetchPromise);
+  return { promise, resolve, reject };
+}
+
+test('registers webhook fetch with waitUntil and waits on the fetch promise', async () => {
+  const fetchDeferred = deferred();
+  globalThis.fetch = vi.fn(() => fetchDeferred.promise);
 
   const waitUntil = vi.fn();
   const env = { ERROR_WEBHOOK: 'https://hooks.example/alert' };
@@ -30,8 +37,31 @@ test('registers webhook fetch with waitUntil when provided', async () => {
   expect(waitUntil).toHaveBeenCalledOnce();
   const registered = waitUntil.mock.calls[0][0];
   expect(registered).toBeInstanceOf(Promise);
-  resolveFetch(new Response('', { status: 200 }));
+
+  let settled = false;
+  registered.then(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  expect(settled, 'must not settle before fetch completes').toBe(false);
+
+  fetchDeferred.resolve(new Response('', { status: 200 }));
   await registered;
+  expect(settled).toBe(true);
+});
+
+test('swallows fetch rejection so the waitUntil promise still resolves', async () => {
+  const fetchDeferred = deferred();
+  globalThis.fetch = vi.fn(() => fetchDeferred.promise);
+
+  const waitUntil = vi.fn();
+  const env = { ERROR_WEBHOOK: 'https://hooks.example/alert' };
+
+  report(env, 'error', 'scan_failed', { url: 'https://x.test', message: 'boom' }, waitUntil);
+
+  const registered = waitUntil.mock.calls[0][0];
+  fetchDeferred.reject(new Error('network down'));
+  await expect(registered).resolves.toBeUndefined();
 });
 
 test('falls back to detached fetch when waitUntil is absent', async () => {


### PR DESCRIPTION
Closes finding OPS-1 (P2) from docs/adversarial-review-fresh.md. Final finding of the run.

Problem: _report.ts fired the out-of-band error webhook as a detached promise (no ctx.waitUntil), so on Cloudflare Workers the runtime can cancel the fetch once the response returns — the page-a-human path (scan_failed/persist_failed) was the most likely to silently drop.

Solution: report() now takes an optional waitUntil; scan.ts passes ctx.waitUntil for the scan_failed, persist_failed, and pattern_errors webhook paths (mirroring the correct dashboard/link.ts pattern). Callers without ctx fall back to the detached fetch (documented). Failure reports now include navMs and patternsErrored for observability.

Acceptance: apps/web/test/report.test.js — report() called with a waitUntil spy and stubbed fetch asserts waitUntil is invoked with the fetch promise (no real network). Full build + 286 web tests pass. Finding: OPS-1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to async webhook delivery and log fields; scan behavior and API responses are unchanged aside from more reliable alerts.
> 
> **Overview**
> Fixes **OPS-1**: out-of-band `ERROR_WEBHOOK` posts from `report()` could be cut off when the Worker returned the HTTP response, because the webhook used a detached `fetch` instead of **`waitUntil`**.
> 
> `report()` now accepts an optional **`waitUntil`** and passes the webhook `fetch` promise through it when present; callers without request context (e.g. email) keep the documented detached fallback. **`scan.ts`** threads `waitUntil` into `pattern_errors`, `persist_failed`, and **`scan_failed`** reports.
> 
> Failure and warn payloads add **`navMs`** and **`patternsErrored`** where useful so alerts carry more scan context. New **`report.test.js`** covers `waitUntil` registration, rejection swallowing, detached fallback, and no webhook for `info` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f6b59df712554960b41c44c6c6b9b8ace13ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->