### PR TITLE
fix(web): make report() waitUntil optional to restore typecheck [OPS-1]

### DIFF
--- a/apps/web/functions/_report.ts
+++ b/apps/web/functions/_report.ts
@@ -11,7 +11,7 @@
 //
 // Keep payloads PII-free — never log emails or full page content.
 
-export function report(env, level, event, data = {}, waitUntil) {
+export function report(env, level, event, data = {}, waitUntil = undefined) {
   const line = { ts: new Date().toISOString(), level, event, ...data };
   // Structured log line (picked up by `wrangler tail` / Logpush).
   try {

--- a/apps/web/functions/api/fix-prompt.ts
+++ b/apps/web/functions/api/fix-prompt.ts
@@ -13,7 +13,7 @@ import { buildFixPrompt } from '@slop-detect/core';
 import { onRequestPost as scanHandler } from './scan.js';
 
 // CORS + rate-limit handled by functions/api/_middleware.js.
-export async function onRequestPost({ request, env }) {
+export async function onRequestPost({ request, env, waitUntil }) {
   let body;
   try {
     body = await request.json();
@@ -31,7 +31,7 @@ export async function onRequestPost({ request, env }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url: body.url, axes: body.axes, preset: body.preset, share: false }),
     });
-    const scanRes = await scanHandler({ request: scanReq, env });
+    const scanRes = await scanHandler({ request: scanReq, env, waitUntil });
     result = await scanRes.json();
     if (result.error) return text(`Scan failed: ${result.error}`, 502);
   }


### PR DESCRIPTION
Completion fix for OPS-1 (#78). T_FINAL's independent `bun run typecheck` caught 5 TS errors: #78 added waitUntil to report() but left it required, breaking 4-arg callers (_email.ts x3, cron/sweep.ts) and fix-prompt.ts's context object.

Solution (type-only, no runtime change): report()'s waitUntil now defaults to undefined (the runtime already guards typeof waitUntil === 'function'); fix-prompt.ts destructures and forwards context.waitUntil to the scan handler (matching scan.ts, which also enables webhook observability for URL-mode fix prompts).

Verification: bun run typecheck now reports 0 errors; build + test still pass. No behavior change to the webhook/waitUntil logic from #78. Finding: OPS-1 (completion).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-signature and context plumbing only; observability behavior unchanged except URL-mode fix-prompt scans gaining the same waitUntil forwarding scan already uses.
> 
> **Overview**
> Restores **typecheck** after `waitUntil` was added to `report()` without making it optional: **`report()`**’s fifth argument now defaults to `undefined`, so existing four-argument callers (`_email.ts`, cron sweep, etc.) typecheck again with **no runtime change** (webhook logic already skips `waitUntil` when it isn’t a function).
> 
> **`/api/fix-prompt`** now takes **`waitUntil`** from the Pages handler context and passes it into the internal **`/api/scan`** call in URL mode, aligning with `scan.ts` so error webhooks can complete after the response when fix-prompt triggers a scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec839f4bce71c8084360c5c9e729644b62454f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->