### PR TITLE
Adversarial release-review fixes: SSRF, email-bomb, privacy, headers, stats, packaging

### DIFF
--- a/.changeset/core-ship-notice.md
+++ b/.changeset/core-ship-notice.md
@@ -1,0 +1,8 @@
+---
+'@slop-detect/core': patch
+---
+
+Ship the NOTICE file in the published tarball. The core package adapts
+Apache-2.0-licensed detection logic from Impeccable, so Apache License 2.0
+section 4(d) requires the NOTICE to travel with redistributed copies. It existed
+in the repo but was missing from the package `files` allowlist.

--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -18,8 +18,8 @@ jobs:
   calibrate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
       - run: bun install
@@ -34,7 +34,7 @@ jobs:
             cat cal-out.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: calibration-report
           path: cal-report.json

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
       - name: Scan corpus → public/leaderboard.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ core.[0-9]*
 
 # Pika MCP token (secret — never commit)
 .mogra/pika/tok.json
+.gstack/

--- a/apps/web/functions/_data.ts
+++ b/apps/web/functions/_data.ts
@@ -221,6 +221,29 @@ export async function emailIndexKey(email: string): Promise<string> {
   return `${EMAIL_INDEX_PREFIX}${await emailHash(email)}`;
 }
 
+// ── Per-recipient confirmation-email cap (anti email-bomb) ────────────────────
+// /api/watch issues a double-opt-in email to a CALLER-SUPPLIED address, so the
+// per-IP middleware limit alone lets one IP mail an arbitrary victim ~20×/min
+// and burn sender reputation. Cap the SEND per recipient, keyed on the HASHED
+// address (never store a raw email in a rate-limit key — same reason the index
+// is hashed). Mirrors dashLinkAllowed in api/dashboard/link.ts. Fail CLOSED: if
+// the counter store is missing or erroring we skip the send, because the abuse
+// here is the outbound mail itself, so "store down" must mean "don't mail".
+const WATCH_VERIFY_LIMIT = 3;
+const WATCH_VERIFY_WINDOW_SEC = 60 * 60; // 3 confirmation emails per address per hour
+export async function watchVerifyAllowed(kv, email) {
+  if (!kv || !email) return false;
+  try {
+    const key = `rl:watchverify:${await emailHash(email)}`;
+    const n = parseInt(await kv.get(key), 10) || 0;
+    if (n >= WATCH_VERIFY_LIMIT) return false;
+    await kv.put(key, String(n + 1), { expirationTtl: WATCH_VERIFY_WINDOW_SEC });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Domains monitored by one email — one kv.get. Used by the magic-link endpoint
 // where we only need a count, not full watch records.
 export async function getEmailDomains(kv, email) {

--- a/apps/web/functions/_data.ts
+++ b/apps/web/functions/_data.ts
@@ -211,7 +211,7 @@ export async function consumeDashboardToken(kv, token) {
 // subscribe, pruned on unsubscribe; listWatchesByEmail self-heals stale rows.
 const EMAIL_INDEX_PREFIX = 'e:';
 
-async function emailHash(email: string): Promise<string> {
+export async function emailHash(email: string): Promise<string> {
   const want = String(email).trim().toLowerCase();
   const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(want));
   return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('');

--- a/apps/web/functions/_data.ts
+++ b/apps/web/functions/_data.ts
@@ -382,6 +382,10 @@ function historyPoint(slim) {
 // are approximate under heavy concurrency, which is fine for a percentile.
 const STATS_DIST_KEY = 'stats:dist';
 const STATS_CATCLEAN_KEY = 'stats:catclean';
+// Marker: this domain has already contributed to the GLOBAL aggregates. One slot
+// per domain so a re-scanned (or attacker-hammered) domain can't skew the public
+// score distribution or per-category averages — see claimStatsContribution.
+const STATS_CONTRIB_PREFIX = 'gs:';
 
 type CatCleanStore = { cats: Record<string, { sum: number; n: number }>; count: number };
 
@@ -499,11 +503,33 @@ export async function percentileForScore(kv, score) {
 // appendHistory call de-dupes against this one by scan id.
 export async function recordScan(kv, slim) {
   if (!kv || !slim || !slim.domain) return;
+  // The per-domain timeline records EVERY scan, but the global aggregates count
+  // each domain once — otherwise re-scanning a single domain (a legitimate
+  // redesign, or an attacker hammering /api/scan) would skew the public score
+  // distribution, the per-category averages, and every other domain's percentile.
+  const firstContribution = await claimStatsContribution(kv, slim.domain);
   await Promise.all([
     appendHistory(kv, slim.domain, historyPoint(slim)),
-    bumpScoreStats(kv, slim.score),
-    bumpCategoryStats(kv, slim),
+    ...(firstContribution ? [bumpScoreStats(kv, slim.score), bumpCategoryStats(kv, slim)] : []),
   ]);
+}
+
+// Claim a domain's single slot in the global aggregates. Returns true the first
+// time a domain is recorded, false on every later scan of that domain. The
+// marker is durable (no TTL): letting it expire would re-open the dedup, so an
+// attacker could just wait out the window. Get-then-put is not atomic — a rare
+// concurrent race double-counts one domain, which is harmless for an aggregate.
+// On a KV error we fall back to counting (a lost dedup beats dropping a real
+// first scan from the stats).
+async function claimStatsContribution(kv, domain) {
+  const key = `${STATS_CONTRIB_PREFIX}${domain}`;
+  try {
+    if (await kv.get(key)) return false;
+    await kv.put(key, '1');
+  } catch {
+    return true;
+  }
+  return true;
 }
 
 // Decide whether `current` is a regression from `baseline`. Pure — unit-tested.

--- a/apps/web/functions/_email.ts
+++ b/apps/web/functions/_email.ts
@@ -46,7 +46,12 @@ export async function sendEmail(
     });
     if (!res.ok) {
       const body = await res.text().catch(() => '');
-      report(env, 'error', 'email_send_failed', { status: res.status, body: body.slice(0, 200) });
+      // The provider echoes the recipient address back in error bodies, and this
+      // log can be forwarded to an external ERROR_WEBHOOK — scrub any email first.
+      report(env, 'error', 'email_send_failed', {
+        status: res.status,
+        body: scrubEmails(body).slice(0, 200),
+      });
       return { sent: false, reason: `http_${res.status}` };
     }
     const data = await res.json().catch(() => ({}));
@@ -63,4 +68,10 @@ function redact(addr) {
   const at = s.indexOf('@');
   if (at < 1) return '***';
   return `${s[0]}***${s.slice(at)}`;
+}
+
+// Replace any email addresses embedded in free-form provider text before it is
+// logged or forwarded to an external webhook.
+function scrubEmails(text) {
+  return String(text == null ? '' : text).replace(/[\w.+-]+@[\w-]+\.[\w.-]+/g, '[redacted-email]');
 }

--- a/apps/web/functions/_middleware.ts
+++ b/apps/web/functions/_middleware.ts
@@ -1,0 +1,42 @@
+// Root Pages middleware — runs for EVERY Function route (it nests above
+// functions/api/_middleware.ts, which handles /api/*).
+//
+// Why this exists: Cloudflare Pages applies the public/_headers rules ONLY to
+// static assets, not to Function-rendered responses. So every server-rendered
+// HTML page (/dashboard, /r/:id, /score/:domain, /report/:domain, /directory,
+// /leaderboard, /blog/:slug, /brand, /docs, the watch-confirm page) was shipping
+// with no Content-Security-Policy, X-Frame-Options, nosniff, or HSTS — the
+// dashboard sign-in page was framable. Add the same headers _headers declares,
+// once, to every text/html Function response.
+//
+// Scope guards:
+//   - Only text/html responses are touched, so JSON (/api/*), OG PNGs, and badge
+//     SVGs pass straight through unchanged.
+//   - We never override a header a route set itself (and _headers, applied by the
+//     platform to static assets, carries identical values), so this can't clash.
+
+const SECURITY_HEADERS = {
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+  'Permissions-Policy': 'geolocation=(), microphone=(), camera=(), browsing-topics=()',
+  'X-Frame-Options': 'SAMEORIGIN',
+  // Identical to the /* CSP in public/_headers: scoped to Google Fonts and
+  // Cloudflare Turnstile, with 'unsafe-inline' for the existing inline
+  // <style>/<script>/JSON-LD. Tightening to nonces is a separate follow-up.
+  'Content-Security-Policy':
+    "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; connect-src 'self' https://challenges.cloudflare.com",
+};
+
+export async function onRequest(context) {
+  const res = await context.next();
+  const contentType = res.headers.get('Content-Type') || '';
+  // Only decorate HTML; leave JSON, images (OG/badge), and other assets alone.
+  if (!contentType.includes('text/html')) return res;
+
+  const merged = new Response(res.body, res);
+  for (const [k, v] of Object.entries(SECURITY_HEADERS)) {
+    if (!merged.headers.has(k)) merged.headers.set(k, v);
+  }
+  return merged;
+}

--- a/apps/web/functions/_ssrf.ts
+++ b/apps/web/functions/_ssrf.ts
@@ -85,7 +85,14 @@ export function validateScanUrl(raw) {
     return { error: 'Only http(s) URLs can be scanned', status: 400 };
   }
 
-  const host = parsed.hostname.toLowerCase();
+  // Strip any trailing dot(s): `localhost.`, `foo.internal.`, and
+  // `svc.cluster.local.` are fully-qualified DNS names that resolve identically
+  // to their dot-free form, but `new URL()` PRESERVES the root dot on names (it
+  // only normalizes it away for IP literals). Without this, the exact-match set
+  // and the `.endsWith('.internal'/'.local'/'.localhost')` suffix checks below
+  // all miss the trailing-dot variant — an SSRF allow-list bypass to internal
+  // services. Also hardens the IPv4 path if a runtime keeps the dot on a literal.
+  const host = parsed.hostname.toLowerCase().replace(/\.+$/, '');
   const blocked =
     PRIVATE_HOSTNAMES.has(host) ||
     host.endsWith('.localhost') ||

--- a/apps/web/functions/api/_middleware.ts
+++ b/apps/web/functions/api/_middleware.ts
@@ -141,7 +141,7 @@ const memCounters = new Map(); // key -> { count, resetAt }
 // normal per-IP limit: a degraded mode should be conservative, not generous.
 const SCAN_FALLBACK_CEILING = 3;
 
-function memIncrement(key, windowMs = 60000) {
+function memIncrement(key, windowMs = 60000, inc = 1) {
   const now = Date.now();
   // Opportunistic sweep of expired entries so the map can't grow unbounded in a
   // long-lived isolate (it's only touched during KV-degraded mode, so this is
@@ -151,12 +151,22 @@ function memIncrement(key, windowMs = 60000) {
   }
   const cur = memCounters.get(key);
   if (!cur || now >= cur.resetAt) {
-    const fresh = { count: 1, resetAt: now + windowMs };
+    const fresh = { count: inc, resetAt: now + windowMs };
     memCounters.set(key, fresh);
     return fresh.count;
   }
-  cur.count += 1;
+  cur.count += inc;
   return cur.count;
+}
+
+// Daily-cap cost weight per route. A browser scan is one unit. /api/aeo does NOT
+// drive the browser but fans out to ~30 outbound fetches per call (5 fetch
+// families × up to 6 redirect hops), so against the shared global daily budget
+// one aeo call is worth several scan-equivalents of outbound work. Charging it a
+// heavier weight bounds the total daily fan-out a distributed flood can inflict.
+const AEO_COST_UNITS = 3;
+function dailyCostUnits(route) {
+  return route === 'aeo' ? AEO_COST_UNITS : 1;
 }
 
 // Rate-limit gate. Returns { ok, used, limit, degraded }.
@@ -472,7 +482,10 @@ export async function onRequest(context) {
         );
       }
       // Per-isolate ceiling on the happy path (key includes the day; 24h window).
-      const memUsed = memIncrement(gkey, 86400000);
+      // aeo charges several units (see dailyCostUnits) for its fan-out; a browser
+      // scan and a fix-prompt {url} re-scan each charge one.
+      const costUnits = dailyCostUnits(route);
+      const memUsed = memIncrement(gkey, 86400000, costUnits);
       if (memUsed > cap) {
         return jsonResponse(
           {
@@ -486,7 +499,7 @@ export async function onRequest(context) {
         );
       }
       try {
-        await env.RATE_LIMIT.put(gkey, String(used + 1), { expirationTtl: 172800 });
+        await env.RATE_LIMIT.put(gkey, String(used + costUnits), { expirationTtl: 172800 });
       } catch (_) {
         /* best-effort */
       }

--- a/apps/web/functions/api/dashboard/link.ts
+++ b/apps/web/functions/api/dashboard/link.ts
@@ -6,7 +6,7 @@
 // middleware (cheap rate limit, CORS, foreign-origin rejection; no Turnstile).
 // Configured-off without an email provider + SESSION_SECRET, like alerts.
 
-import { isValidEmail, getEmailDomains, issueDashboardToken } from '../../_shared.js';
+import { isValidEmail, getEmailDomains, issueDashboardToken, emailHash } from '../../_shared.js';
 import { emailConfigured, sendEmail } from '../../_email.js';
 import { buildDashboardLinkEmail } from '../../_alerts.js';
 
@@ -24,7 +24,9 @@ const DASHLINK_WINDOW_SEC = 3600;
 
 async function dashLinkAllowed(kv, email) {
   if (!kv) return true;
-  const key = `rl:dashlink:${email}`;
+  // Key on the hashed address, never the raw email, so a rate-limit counter is
+  // not a place a plaintext address sits at rest.
+  const key = `rl:dashlink:${await emailHash(email)}`;
   try {
     const n = parseInt(await kv.get(key), 10) || 0;
     if (n >= DASHLINK_LIMIT) return false;

--- a/apps/web/functions/api/watch.ts
+++ b/apps/web/functions/api/watch.ts
@@ -29,6 +29,7 @@ import {
   issueWatchToken,
   addToEmailIndex,
   removeFromEmailIndex,
+  watchVerifyAllowed,
 } from '../_shared.js';
 import { emailConfigured, sendEmail } from '../_email.js';
 import { buildVerificationEmail } from '../_alerts.js';
@@ -206,7 +207,12 @@ export async function onRequestPost({ request, env }) {
   const origin = new URL(request.url).origin;
   const alertsLive = emailConfigured(env);
   let verificationSent = false;
-  if (alertsLive && !watch.verified) {
+  // Per-recipient cap: the confirmation email goes to a caller-supplied address,
+  // so without a per-email throttle one IP could bomb a victim's inbox (the
+  // per-IP middleware limit alone allows ~20/min). Gate the whole issue+send on
+  // a hashed-email counter (fail-closed). Subscribing still succeeds; only the
+  // email is throttled, so the consent record and monitoring are unaffected.
+  if (alertsLive && !watch.verified && (await watchVerifyAllowed(env.RATE_LIMIT, email))) {
     try {
       const token = await issueWatchToken(env.RESULTS, domain);
       if (token) {

--- a/apps/web/public/privacy.md
+++ b/apps/web/public/privacy.md
@@ -1,6 +1,6 @@
 # Slop Detector — Privacy Policy
 
-_Last updated: 2026-06-05 · Policy version: 2026.06_
+_Last updated: 2026-06-28 · Policy version: 2026.06_
 
 Slop Detector is an open-source project. We collect as little as possible and we
 never sell data. This page is the plain-language record of what is stored, why,
@@ -11,13 +11,32 @@ and how to remove it.
 | Data | When | Why | Retention |
 | --- | --- | --- | --- |
 | **Scanned URL + scan result** (score, triggered patterns, title/H1) | Every scan you run on the web/API | To render the result, the shareable permalink, and the per-domain badge | ~90 days (KV TTL) |
-| **Your email address** | Only if you start **monitoring** a domain (`POST /api/watch`) | To send regression alerts ("your score dropped") for that domain | Until you unsubscribe; otherwise up to 1 year |
-| **Per-IP rate-limit counters** | Every API request | Abuse / cost protection | 60 seconds |
+| **Your email address** | Only if you start **monitoring** a domain (`POST /api/watch`) or request a dashboard sign-in link (`POST /api/dashboard/link`) | To send regression alerts ("your score dropped") and the sign-in link you asked for. We store it hashed (SHA-256) in the lookup index. | Until you unsubscribe; otherwise up to 1 year |
+| **Dashboard sign-in session** (`sd_session` cookie) | Only after you click an emailed sign-in link | To keep you signed in to the agency dashboard. It is a single HttpOnly, Secure, SameSite=Lax cookie holding a signed token, not an advertising/tracking ID. | 30 days, or until you sign out |
+| **Sign-in / confirmation link tokens** | When you request a dashboard link or start monitoring | Single-use tokens that verify the emailed link | 15 minutes (sign-in) / 7 days (monitoring confirmation) |
+| **Per-IP and per-email rate-limit counters** | Every API request / email send | Abuse, cost, and inbox-spam protection | 60 seconds to 1 hour |
 
 We do **not** store full page content, screenshots (unless you explicitly request
-one in a scan, and even then it is not persisted to the directory), cookies, or
-any advertising/tracking identifiers. We do not use third-party analytics that
+one in a scan, and even then it is not persisted to the directory), advertising or
+cross-site tracking identifiers, or behavioural profiles. The only cookie we set
+is the functional `sd_session` sign-in cookie described above, and only after you
+deliberately sign in to the dashboard. We do not use third-party analytics that
 profile you.
+
+## Third parties (sub-processors)
+
+To run the service we rely on a few providers. Visiting the site necessarily
+shares your IP address with them, the same way loading any website does:
+
+| Provider | Role | What it receives |
+| --- | --- | --- |
+| **Cloudflare** | Hosting, the headless-scan browser, and the Turnstile anti-abuse challenge | Request metadata including your IP; Turnstile runs on the scan form to block bots |
+| **Google Fonts** | Serves the web fonts used by the site | Your IP and user-agent when your browser fetches the font files |
+| **Resend** | Sends the monitoring and sign-in emails | The recipient address and message, only when an email is actually sent |
+
+None of these are used for advertising. If you would rather not share anything
+with Google or Cloudflare, self-host (see below); the fonts and challenge are the
+only third-party assets the pages load.
 
 ## Lawful basis & consent
 

--- a/apps/web/test/middleware.test.js
+++ b/apps/web/test/middleware.test.js
@@ -156,6 +156,37 @@ test('global daily cap fails closed when KV read errors', async () => {
   expect((await res.json()).error).toBe('scanning_paused');
 });
 
+test('/api/aeo charges several daily-cap units for its fan-out; a scan charges one', async () => {
+  // aeo does not drive the browser but fans out to ~30 outbound fetches, so it
+  // must consume more of the shared daily budget than a single scan.
+  const puts = [];
+  const countingKv = {
+    get: async () => '0',
+    put: async (k, v) => {
+      puts.push([k, v]);
+    },
+  };
+  const aeoReq = makeRequest({
+    path: '/api/aeo',
+    headers: { 'CF-Connecting-IP': '203.0.113.71' },
+    body: { url: 'https://x.com' },
+  });
+  await onRequest(makeContext(aeoReq, { RATE_LIMIT: countingKv, SCAN_DAILY_CAP: '10000' }));
+  const aeoGlobal = puts.find(([k]) => k.startsWith('rl:global:scan:'));
+  expect(aeoGlobal, 'aeo increments the global daily cap').toBeTruthy();
+  expect(aeoGlobal[1], 'aeo charges AEO_COST_UNITS').toBe('3');
+
+  puts.length = 0;
+  const scanReq = makeRequest({
+    path: '/api/scan',
+    headers: { 'CF-Connecting-IP': '203.0.113.72' },
+    body: { url: 'https://x.com' },
+  });
+  await onRequest(makeContext(scanReq, { RATE_LIMIT: countingKv, SCAN_DAILY_CAP: '10000' }));
+  const scanGlobal = puts.find(([k]) => k.startsWith('rl:global:scan:'));
+  expect(scanGlobal[1], 'a browser scan charges one unit').toBe('1');
+});
+
 test('SCAN_DISABLED kill switch returns 503 scanning_paused', async () => {
   const okKv = { get: async () => '0', put: async () => {} };
   const req = makeRequest({

--- a/apps/web/test/security-headers.test.js
+++ b/apps/web/test/security-headers.test.js
@@ -1,0 +1,56 @@
+// Root middleware tests — security headers are added to Function-rendered HTML
+// (which public/_headers does NOT cover) but not to JSON / image responses.
+
+import { test, expect } from 'vitest';
+import { onRequest } from '../functions/_middleware.ts';
+
+function ctx(response) {
+  return { next: async () => response };
+}
+
+test('text/html Function responses get CSP, X-Frame-Options, nosniff, and HSTS', async () => {
+  const html = new Response('<!doctype html><title>x</title>', {
+    status: 200,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+  const res = await onRequest(ctx(html));
+  expect(res.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'self'");
+  expect(res.headers.get('X-Frame-Options')).toBe('SAMEORIGIN');
+  expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  expect(res.headers.get('Strict-Transport-Security')).toContain('max-age=31536000');
+  expect(res.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+  // Body and status survive the re-wrap.
+  expect(res.status).toBe(200);
+  expect(await res.text()).toContain('<!doctype html>');
+});
+
+test('JSON and image responses are left untouched', async () => {
+  const json = new Response('{"ok":true}', {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+  const jr = await onRequest(ctx(json));
+  expect(jr.headers.get('Content-Security-Policy')).toBe(null);
+  expect(jr.headers.get('X-Frame-Options')).toBe(null);
+
+  const svg = new Response('<svg/>', {
+    status: 200,
+    headers: { 'Content-Type': 'image/svg+xml' },
+  });
+  const sr = await onRequest(ctx(svg));
+  expect(sr.headers.get('Content-Security-Policy')).toBe(null);
+});
+
+test('a header a route set itself is not overridden', async () => {
+  const html = new Response('<title>x</title>', {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html',
+      'X-Frame-Options': 'DENY',
+    },
+  });
+  const res = await onRequest(ctx(html));
+  expect(res.headers.get('X-Frame-Options')).toBe('DENY');
+  // ...but the headers the route did NOT set are still added.
+  expect(res.headers.get('Content-Security-Policy')).toBeTruthy();
+});

--- a/apps/web/test/ssrf.test.js
+++ b/apps/web/test/ssrf.test.js
@@ -39,6 +39,15 @@ const BLOCKED = [
   'http://[::169.254.169.254]/', // IPv4-compatible metadata (::/96)
   'http://[::ffff:10.0.0.5]/', // IPv4-mapped RFC-1918
   'http://[::ffff:192.168.1.1]/', // IPv4-mapped RFC-1918
+  // Regression: trailing-dot FQDNs resolve identically to their dot-free form but
+  // `new URL()` keeps the root dot on NAMES, so the exact-match + suffix block
+  // checks used to miss these — an SSRF allow-list bypass to internal services.
+  'http://localhost.', // loopback name as FQDN
+  'http://app.localhost.', // *.localhost suffix as FQDN
+  'http://foo.internal.', // *.internal suffix as FQDN
+  'http://api.svc.cluster.local.', // k8s service FQDN
+  'http://db.local.', // *.local suffix as FQDN
+  'http://127.0.0.1.', // loopback IP literal with trailing dot
   'file:///etc/passwd',
   'data:text/html,<script>',
   'ftp://example.com',
@@ -55,6 +64,10 @@ const ALLOWED = [
   // A PUBLIC IPv4-mapped address must still be allowed (we decode + apply the v4
   // rule, not block the whole form) — guards against over-blocking the fix.
   ['http://[::ffff:8.8.8.8]/', 'http://[::ffff:8.8.8.8]/'],
+  // A legitimate PUBLIC FQDN with a trailing dot must still pass (we only strip
+  // the dot for the block decision, not from the returned URL) — guards against
+  // the trailing-dot fix over-blocking real fully-qualified names.
+  ['http://example.com.', 'http://example.com.'],
 ];
 
 test('SSRF guard blocks private/loopback/metadata/non-http hosts', () => {

--- a/apps/web/test/stats.test.js
+++ b/apps/web/test/stats.test.js
@@ -101,6 +101,27 @@ test('recordScan bumps the score distribution; getStats aggregates it', async ()
   expect(stats.slopShare).toBe(67); // 2 of 3 score >= 10
 });
 
+test('global stats count each domain once, even across re-scans (anti-poisoning)', async () => {
+  const kv = makeKv();
+  // An attacker hammers /api/scan for one domain they control, 5 times.
+  for (let i = 0; i < 5; i++) {
+    await recordScan(kv, slim({ id: `spam${i}`, domain: 'spam.com', score: 95, tier: 'Heavy' }));
+  }
+  // One honest, distinct domain.
+  await recordScan(kv, slim({ id: 'honest', domain: 'honest.com', score: 4, tier: 'Clean' }));
+
+  const stats = await getStats(kv);
+  expect(stats.count, 'spam.com contributes ONE slot, not five').toBe(2);
+  expect(stats.heavy).toBe(1);
+  expect(stats.clean).toBe(1);
+  // The category corpus is deduped the same way.
+  const { count } = await getCategoryCleanAverages(kv);
+  expect(count).toBe(2);
+  // ...but the per-domain timeline still records every re-scan.
+  const hist = await getHistory(kv, 'spam.com');
+  expect(hist.length).toBe(5);
+});
+
 test('getScoreDistribution returns a 101-bucket array, empty when unseeded', async () => {
   const kv = makeKv();
   const dist = await getScoreDistribution(kv);

--- a/apps/web/test/watch.test.js
+++ b/apps/web/test/watch.test.js
@@ -2,7 +2,7 @@
 // recordScanForWatch hook + the /api/watch handlers, all driven against an
 // in-memory KV mock — no real Cloudflare KV, browser, or network.
 
-import { test, expect } from 'vitest';
+import { test, expect, afterEach } from 'vitest';
 import {
   normalizeDomain,
   isValidEmail,
@@ -13,8 +13,14 @@ import {
   getHistory,
   emailIndexKey,
   getEmailDomains,
+  watchVerifyAllowed,
 } from '../functions/_shared.ts';
 import { onRequestPost, onRequestGet } from '../functions/api/watch.ts';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
 
 // Minimal CF-KV-shaped mock: string values, TTL ignored.
 function makeKv(seed = {}) {
@@ -250,4 +256,52 @@ test('GET /api/watch on an unwatched domain says monitoring:false', async () => 
   const res = await onRequestGet({ request: makeGetReq('unseen.com'), env });
   const j = await res.json();
   expect(j.monitoring).toBe(false);
+});
+
+// ── Per-recipient confirmation-email cap (anti email-bomb) ────────────────────
+test('watchVerifyAllowed caps confirmation emails per recipient and fails closed', async () => {
+  const kv = makeKv();
+  // 3 sends allowed in the window, the 4th is blocked.
+  expect(await watchVerifyAllowed(kv, 'victim@x.io')).toBe(true);
+  expect(await watchVerifyAllowed(kv, 'victim@x.io')).toBe(true);
+  expect(await watchVerifyAllowed(kv, 'victim@x.io')).toBe(true);
+  expect(await watchVerifyAllowed(kv, 'victim@x.io')).toBe(false);
+  // A different recipient has its own budget.
+  expect(await watchVerifyAllowed(kv, 'other@x.io')).toBe(true);
+  // The key is the hashed address, never the raw email.
+  expect([...kv.store.keys()].some((k) => k.includes('victim@x.io'))).toBe(false);
+  // No counter store → fail closed (do not send).
+  expect(await watchVerifyAllowed(null, 'victim@x.io')).toBe(false);
+});
+
+test('POST /api/watch stops emailing one address after the per-recipient cap', async () => {
+  let sends = 0;
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('api.resend.com')) {
+      sends++;
+      return new Response(JSON.stringify({ id: `e${sends}` }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw new Error(`unexpected fetch to ${url}`);
+  };
+  const env = {
+    RESULTS: makeKv(),
+    RATE_LIMIT: makeKv(),
+    RESEND_API_KEY: 're_test',
+    ALERT_FROM: 'Slop Detect <alerts@slop-detect.com>',
+  };
+  // An attacker re-POSTs the same victim address; the confirmation email must be
+  // capped regardless of how many times they hit the endpoint.
+  const results = [];
+  for (let i = 0; i < 5; i++) {
+    const res = await onRequestPost({
+      request: makePostReq({ domain: 'attacker-chosen.com', email: 'victim@x.io' }),
+      env,
+    });
+    results.push((await res.json()).verificationSent);
+  }
+  expect(results).toEqual([true, true, true, false, false]);
+  expect(sends, 'only 3 emails reach the victim, not 5').toBe(3);
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,8 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "NOTICE"
   ],
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
This PR lands the fixes from an end-to-end adversarial review of the app ahead of public release. The review (9 dimensions, refute-by-default verification) confirmed the architecture is sound: no critical/RCE/auth-bypass, and SSRF, scan cost controls, sessions, output encoding, and KV isolation all hold. It surfaced a set of real abuse, SSRF, privacy, and packaging gaps; each is fixed here as its own commit, with a regression test where the behavior is testable.

Blockers fixed:

- SSRF allow-list bypass (functions/_ssrf.ts): `new URL()` preserves the root dot on hostnames, so `localhost.`, `foo.internal.`, and `svc.cluster.local.` slipped past the exact-match and `.endsWith()` internal-host checks and reached the scanner and the AEO fetcher. Strip trailing dots before the block decision. Verified live: `http://localhost.` and `http://foo.internal.` now return 400 through the real middleware and handler.
- Email-bomb on /api/watch (functions/api/watch.ts): the double-opt-in confirmation email went to a caller-supplied address with only the per-IP middleware limit (~20/min) gating it. Add a per-recipient cap (3/hour, hashed-email key, fail-closed) mirroring the one dashboard/link.ts already had.
- False privacy claim (public/privacy.md): the policy said "we do not store cookies" while the dashboard sets a 30-day sd_session cookie. Correct it, disclose the cookie and its flags, add the previously-undisclosed stores, and add a sub-processors section (Cloudflare, Google Fonts, Resend) with the visitor-IP transfer each entails.

Hardening:

- /api/aeo cost weight (functions/api/_middleware.ts): aeo fans out to ~30 outbound fetches but charged one daily-cap unit like a scan. Charge it AEO_COST_UNITS (3) so total daily fan-out is bounded.
- Security headers on Function HTML (new functions/_middleware.ts): public/_headers only decorates static assets, so every server-rendered route (dashboard, /r/:id, score, report, directory, leaderboard, blog) shipped with no CSP/X-Frame-Options/nosniff/HSTS and the sign-in page was framable. A root middleware stamps the same headers _headers declares onto every text/html Function response, gated by content-type so JSON and images are untouched. Verified live across /, /directory, /leaderboard, and /dashboard.
- Global stats poisoning (functions/_data.ts): recordScan bumped the global score distribution and category averages on every scan, so re-scanning one domain skewed public stats and peer percentiles. Count each domain once via a durable marker; the per-domain timeline still records every scan.
- core npm NOTICE (packages/core): core adapts Apache-2.0 code from Impeccable, so section 4(d) requires shipping NOTICE; it was missing from the package files allowlist.
- SHA-pin CI actions (publish/calibrate/leaderboard workflows): these hold NPM_TOKEN/SLOP_API_KEY but used mutable @v4/@v2 tags; pin to the SHAs ci.yml already uses.
- Email privacy (functions/_email.ts, functions/api/dashboard/link.ts): scrub recipient emails from the Resend error log (it can flow to an external webhook) and key the dashlink rate limit on the hashed address instead of the cleartext email.

Gates: typecheck, eslint, build, prettier all green; tests 294 in web (7 new regression tests), 71 core, 9 mcp, 2 action. gstack /qa run live against `wrangler pages dev` found no new bugs and confirmed the header, SSRF, and watch changes in the real runtime.

Reviewed with codex (gpt-5.5): no P0 or P1, verdict SHIP, each fix independently confirmed correct. The one P2 is that the CSP still allows `'unsafe-inline'`, so it is not a script-injection XSS backstop; that is a known follow-up (the original review verified every output path is already escaped, and both `_headers` and the new middleware comment flag nonce-based CSP as separate work), so it is not bundled here.

Deliberately deferred (documented, not fixed here, all low/info): stateless 30-day sessions have no revocation if SESSION_SECRET leaks (revisiting that means a server-side session store, against the deliberate stateless design); the standalone CLI has no SSRF guard (operator-local tool, not the hosted service); and domainOf vs normalizeDomain disagree on trailing-dot/IDN hosts (a normalization refactor that touches many read/write paths, too risky to bundle with security fixes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF validation, outbound email throttling, global stats writes, and API cost accounting—security-sensitive paths—but changes are narrow guards with new tests rather than architectural rewrites.
> 
> **Overview**
> Pre-release security and abuse fixes across the hosted web app, with regression tests for each behavior change.
> 
> **SSRF:** `validateScanUrl` now strips trailing dots on hostnames before internal-host checks, closing a bypass where FQDNs like `localhost.` slipped past block rules.
> 
> **Email abuse & privacy:** Watch double-opt-in sends are capped at 3/hour per hashed recipient (`watchVerifyAllowed`, fail-closed). Dashboard magic-link rate limits use hashed emails instead of plaintext keys. Resend error bodies are scrubbed before logging/webhooks. `privacy.md` documents the `sd_session` cookie, dashboard flows, and sub-processors (Cloudflare, Google Fonts, Resend).
> 
> **Cost & middleware:** `/api/aeo` counts as **3** units against the shared daily scan budget (vs 1 for a browser scan). New root Pages middleware applies CSP, HSTS, `X-Frame-Options`, and related headers to **text/html** Function responses only (static `_headers` did not cover SSR routes).
> 
> **Stats integrity:** Global score distribution and category aggregates increment **once per domain** via a durable `gs:` marker; per-domain history still records every scan.
> 
> **Packaging & CI:** `@slop-detect/core` publishes `NOTICE` for Apache 2.0 compliance. Publish/calibrate/leaderboard workflows pin GitHub Actions to commit SHAs. `.gitignore` adds `.gstack/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0db7435e5de36412f28bb8cc26d96e59907930d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->