### PR TITLE
fix: use gray-dark GitHub Action branding (#87)

### DIFF
--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -21,7 +21,7 @@ author: 'Ravindra Kumar'
 
 branding:
   icon: 'eye'
-  color: 'purple'
+  color: 'gray-dark'
 
 inputs:
   url:


### PR DESCRIPTION
Closes #87

## What
Changes GitHub Action Marketplace branding color from `purple` to `gray-dark`.

## Why
AGENTS.md bans purple as an AI-slop tell. `packages/action/action.yml` used `branding.color: purple` — the Marketplace tile, the most public surface of the action.

## How verified
- tests: no harness for action.yml branding; YAML-only change
- manual: `packages/action/action.yml` branding.color is `gray-dark` (GitHub-supported value)
- greptile: 1 round, confidence 5/5, 0 findings

## Notes for review
`gray-dark` chosen over `black` as the closest on-brand GitHub branding token. No behavior change.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the GitHub Action Marketplace branding color without changing action behavior.
- Replaces the `purple` branding token with the GitHub-supported `gray-dark` token.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The change is limited to a supported Marketplace branding color token and does not affect action inputs, execution, or runtime behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/action/action.yml | Changes only the Marketplace branding color from `purple` to `gray-dark`; no functional issues identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use gray-dark GitHub Action brandin..."](https://github.com/ravidsrk/slop-detect/commit/0221f876a06fa6793088a78dfc2285ba34c87cc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58186635)</sub>

<!-- /greptile_comment -->