### PR TITLE
docs: document all four MCP tools (#85)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -9,9 +9,13 @@ Part of [slop-detect](https://slop-detect.com): the 16-rule fingerprint that cat
 | Tool | Input | What it does |
 | --- | --- | --- |
 | `scan_page` | `{ url }` | Scans the page and returns a grade, a 0-100 score (**lower is better**), the slop tier, a verdict, the triggered patterns, and a shareable result URL. |
+| `check_aeo` | `{ url }` | Checks whether AI engines (ChatGPT, Claude, Perplexity, Google AI Overviews) can read and cite the page. Returns an AEO score 0-100 (**higher is better**), a tier (AI-Ready / Partial / Invisible), and which checks failed. |
+| `check_design_system` | `{ url, design_md_url? }` | Checks whether the page honors its own DESIGN.md. Returns a compliance score 0-100 (**higher is better**), a tier (Aligned / Drifting / Off-system), and named drift. Default file is `<origin>/DESIGN.md`; pass `design_md_url` to override. |
 | `fix_prompt` | `{ url }` | Returns a copy-paste prompt that tells a coding agent exactly how to de-slop the page. |
 
-> **Score polarity:** `0` = no slop. Tiers are **Clean** (0–9), **Mild** (10–27), **Heavy** (28+).
+> **Score polarity:** slop `0` = clean (Clean 0–9, Mild 10–27, Heavy 28+). AEO and design-system scores are inverted: **higher is better**.
+
+Example asks: "scan https://example.com for slop", "can AI engines cite https://example.com?", "does https://example.com honor its DESIGN.md?", "give me a fix prompt for https://example.com".
 
 ## Install
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -9,7 +9,7 @@ Part of [slop-detect](https://slop-detect.com): the 16-rule fingerprint that cat
 | Tool | Input | What it does |
 | --- | --- | --- |
 | `scan_page` | `{ url }` | Scans the page and returns a grade, a 0-100 score (**lower is better**), the slop tier, a verdict, the triggered patterns, and a shareable result URL. |
-| `check_aeo` | `{ url }` | Checks whether AI engines (ChatGPT, Claude, Perplexity, Google AI Overviews) can read and cite the page. Returns an AEO score 0-100 (**higher is better**), a tier (AI-Ready / Partial / Invisible), and which checks failed. Unreachable pages can report a reduced denominator (e.g. `0/5`) rather than a full score. |
+| `check_aeo` | `{ url }` | Checks whether AI engines (ChatGPT, Claude, Perplexity, Google AI Overviews) can read and cite the page. Returns an AEO score 0-100 (**higher is better**), a tier (AI-Ready / Partial / Invisible), and which checks failed. |
 | `check_design_system` | `{ url, design_md_url? }` | Checks whether the page honors its own DESIGN.md. Returns a compliance score 0-100 (**higher is better**), a tier (Aligned / Drifting / Off-system / No system / No data), and named drift. Default file is `<origin>/DESIGN.md`; pass `design_md_url` to override. `No system` means no parseable DESIGN.md tokens; `No data` means nothing observable to check. |
 | `fix_prompt` | `{ url }` | Returns a copy-paste prompt that tells a coding agent exactly how to de-slop the page. |
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -9,8 +9,8 @@ Part of [slop-detect](https://slop-detect.com): the 16-rule fingerprint that cat
 | Tool | Input | What it does |
 | --- | --- | --- |
 | `scan_page` | `{ url }` | Scans the page and returns a grade, a 0-100 score (**lower is better**), the slop tier, a verdict, the triggered patterns, and a shareable result URL. |
-| `check_aeo` | `{ url }` | Checks whether AI engines (ChatGPT, Claude, Perplexity, Google AI Overviews) can read and cite the page. Returns an AEO score 0-100 (**higher is better**), a tier (AI-Ready / Partial / Invisible), and which checks failed. |
-| `check_design_system` | `{ url, design_md_url? }` | Checks whether the page honors its own DESIGN.md. Returns a compliance score 0-100 (**higher is better**), a tier (Aligned / Drifting / Off-system), and named drift. Default file is `<origin>/DESIGN.md`; pass `design_md_url` to override. |
+| `check_aeo` | `{ url }` | Checks whether AI engines (ChatGPT, Claude, Perplexity, Google AI Overviews) can read and cite the page. Returns an AEO score 0-100 (**higher is better**), a tier (AI-Ready / Partial / Invisible), and which checks failed. Unreachable pages can report a reduced denominator (e.g. `0/5`) rather than a full score. |
+| `check_design_system` | `{ url, design_md_url? }` | Checks whether the page honors its own DESIGN.md. Returns a compliance score 0-100 (**higher is better**), a tier (Aligned / Drifting / Off-system / No system / No data), and named drift. Default file is `<origin>/DESIGN.md`; pass `design_md_url` to override. `No system` means no parseable DESIGN.md tokens; `No data` means nothing observable to check. |
 | `fix_prompt` | `{ url }` | Returns a copy-paste prompt that tells a coding agent exactly how to de-slop the page. |
 
 > **Score polarity:** slop `0` = clean (Clean 0–9, Mild 10–27, Heavy 28+). AEO and design-system scores are inverted: **higher is better**.

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,7 @@
-// MCP server wiring. Exposes two tools — scan_page and fix_prompt — over the
-// stdio transport so any MCP client (Claude Code, Cursor, Windsurf) can drive
-// slop-detect.com without a browser or API key.
+// MCP server wiring. Exposes four tools — scan_page, check_aeo,
+// check_design_system, and fix_prompt — over the stdio transport so any MCP
+// client (Claude Code, Cursor, Windsurf) can drive slop-detect.com without a
+// browser or API key.
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
Closes #85

## What
Documents the two previously undocumented MCP tools (`check_aeo`, `check_design_system`) in `packages/mcp/README.md`, including inputs, polarity, exceptional tiers, and example asks. Corrects the `server.ts` header from "two tools" to four.

## Why
`createServer` already registers four tools. Agents reading only the README would miss AEO and design-system checks.

## How verified
- tests: existing MCP unit tests (9) still pass; no README harness
- manual: README tools table lists `scan_page`, `check_aeo`, `check_design_system`, `fix_prompt` matching `TOOLS` in `packages/mcp/src/server.ts`
- greptile: 2 rounds (round 1: 1 P2 documented exceptional responses — fixed)

## Notes for review
Did not change the stale "16-rule" README blurb — that is #84 (serialized after this PR because both touch `packages/mcp/README.md`).






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents all four MCP tools and corrects the server header to match the registered tool count.
- Adds inputs, score polarity, tiers, exceptional outcomes, and example prompts for `check_aeo` and `check_design_system`.
- Updates the `server.ts` header from two tools to four.
- Corrects the previously reported AEO denominator documentation to consistently describe a 0–100 score.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/mcp/README.md | Documents the AEO and design-system tools, including their inputs, score direction, tiers, exceptional responses, and example asks; the prior denominator issue is resolved. |
| packages/mcp/src/server.ts | Updates the file header to accurately list the four tools exposed by the MCP server. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/slop-detect/commit/c8d6f354742feb18430c0891b92c86d2b3f968c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58186860)</sub>

<!-- /greptile_comment -->