### PR TITLE
fix: wire CLI --timeout through to ScanOptions (#86)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ npm install -g slop-detect
 slop-detect https://your-site.com
 ```
 
-The `postinstall` hook downloads a Chromium build (~150 MB) via Playwright.
+Chromium is installed lazily on the first local scan (~150 MB via Playwright), not at `npm install`. Set `SKIP_PLAYWRIGHT_DOWNLOAD=1` to skip the download when a browser is already present. `--remote` scans via the API and needs no Chromium.
 
 ## Usage
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ npm install -g slop-detect
 slop-detect https://your-site.com
 ```
 
-Chromium is installed lazily on the first local scan (~150 MB via Playwright), not at `npm install`. Set `SKIP_PLAYWRIGHT_DOWNLOAD=1` to skip the download when a browser is already present. `--remote` scans via the API and needs no Chromium.
+Chromium is installed lazily on the first local scan (~150 MB via Playwright), not at `npm install`. Set `SKIP_PLAYWRIGHT_DOWNLOAD=1` to skip that download when Playwright's Chromium is already installed (it does not select a system Chrome/Safari binary). `--remote` scans via the API and needs no Chromium.
 
 ## Usage
 

--- a/packages/cli/bin/slop.ts
+++ b/packages/cli/bin/slop.ts
@@ -135,6 +135,13 @@ if (urls.length === 0) {
   process.exit(2);
 }
 
+if (flags.timeout && flags.remote) {
+  console.error(
+    '--timeout applies to local Playwright navigation only; drop --remote or omit --timeout.'
+  );
+  process.exit(2);
+}
+
 // Normalize bare hostnames the way the web UI does: `slop-detect example.com`
 // should Just Work. Prepend https:// when no http(s) scheme is present. An
 // explicit non-http(s) scheme (file:, ftp:…) is rejected — we only scan pages.
@@ -184,7 +191,7 @@ Options:
                     higher is better. Local scans only for now.
   --fail-on <tier>  Exit non-zero (1) if any page scores at/above tier: mild | heavy.
                     A blocked or errored scan also exits 1. Use this to gate CI.
-  --timeout <ms>    Navigation timeout in milliseconds (default 30000)
+  --timeout <ms>    Local Playwright navigation timeout in ms (default 30000)
   --help, -h        Show this help
 
 Examples:

--- a/packages/cli/bin/slop.ts
+++ b/packages/cli/bin/slop.ts
@@ -24,6 +24,7 @@ const flags = {
   remote: false,
   api: null,
   designMd: null,
+  timeout: null,
 };
 
 // Tier severity ordering for --fail-on. A scan exits non-zero when its tier is
@@ -92,6 +93,20 @@ for (let i = 0; i < args.length; i++) {
       process.exit(2);
     }
     flags.failOn = val === 'mild' ? 'Mild' : 'Heavy';
+  } else if (a === '--timeout' || a.startsWith('--timeout=')) {
+    const raw = a.startsWith('--timeout=') ? a.slice('--timeout='.length) : args[++i];
+    const val = Number(raw);
+    if (
+      raw == null ||
+      String(raw).startsWith('--') ||
+      !Number.isFinite(val) ||
+      !Number.isInteger(val) ||
+      val <= 0
+    ) {
+      console.error('--timeout needs a positive integer (milliseconds), e.g. --timeout 30000.');
+      process.exit(2);
+    }
+    flags.timeout = val;
   } else if (a === '--help' || a === '-h') {
     help();
     process.exit(0);
@@ -169,6 +184,7 @@ Options:
                     higher is better. Local scans only for now.
   --fail-on <tier>  Exit non-zero (1) if any page scores at/above tier: mild | heavy.
                     A blocked or errored scan also exits 1. Use this to gate CI.
+  --timeout <ms>    Navigation timeout in milliseconds (default 30000)
   --help, -h        Show this help
 
 Examples:
@@ -397,6 +413,7 @@ function renderSystem(sys) {
         preset: flags.preset,
         axes: flags.axes,
         api: flags.api,
+        timeout: flags.timeout || undefined,
       };
       if (flags.designMd && !flags.remote) {
         const loaded = await loadDesignMd(flags.designMd, url);

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -66,3 +66,17 @@ test('invalid --timeout value exits 2 (usage error)', () => {
     expect(r.stderr).toMatch(/--timeout needs a positive integer/);
   }
 });
+
+test('valid --timeout is accepted at parse time (no URL still exits 2)', () => {
+  const r = run(['--timeout', '30000']);
+  expect(r.status).toBe(2);
+  expect(r.stderr).not.toMatch(/Unknown flag/);
+  expect(r.stderr).not.toMatch(/--timeout needs a positive integer/);
+  expect(r.stdout).toMatch(/Usage:/);
+});
+
+test('--timeout with --remote exits 2 before any scan', () => {
+  const r = run(['https://example.com', '--remote', '--timeout', '5000']);
+  expect(r.status).toBe(2);
+  expect(r.stderr).toMatch(/--timeout applies to local Playwright navigation only/);
+});

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -20,6 +20,7 @@ test('--help exits 0 and lists the dynamic pattern catalogue', () => {
   expect(r.status).toBe(0);
   expect(r.stdout).toMatch(/AI-design-slop patterns \(defs/);
   expect(r.stdout).toMatch(/--fail-on <tier>/);
+  expect(r.stdout).toMatch(/--timeout <ms>/);
   // The list is generated from PATTERNS — it must contain a known short name.
   expect(r.stdout).toMatch(/Slop fonts/);
 });
@@ -50,4 +51,18 @@ test('unknown flag exits 2 (usage error)', () => {
   const r = run(['https://example.com', '--nope']);
   expect(r.status).toBe(2);
   expect(r.stderr).toMatch(/Unknown flag/);
+});
+
+test('--timeout without a value exits 2 (usage error)', () => {
+  const r = run(['https://example.com', '--timeout']);
+  expect(r.status).toBe(2);
+  expect(r.stderr).toMatch(/--timeout needs a positive integer/);
+});
+
+test('invalid --timeout value exits 2 (usage error)', () => {
+  for (const val of ['0', '-1', 'bogus', '30000.5']) {
+    const r = run(['https://example.com', '--timeout', val]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/--timeout needs a positive integer/);
+  }
 });


### PR DESCRIPTION
Closes #86

## What
Wires CLI `--timeout` / `--timeout=<ms>` into `ScanOptions.timeout` for local Playwright navigation. Invalid values and `--timeout` combined with `--remote` exit 2. README install section now describes lazy Chromium install, not a `postinstall` hook.

## Why
The README already showed `--timeout 30000`, and `detector.ts` already reads `opts.timeout`, but `bin/slop.ts` treated `--timeout` as an unknown flag (exit 2). Chromium install moved to lazy `ensureChromium()`; the README still claimed `postinstall`.

## How verified
- tests: `packages/cli/test/cli.test.js` — help lists `--timeout`; missing/invalid values exit 2; valid `--timeout 30000` is accepted at parse time; `--remote --timeout` exits 2
- manual: `bun run --filter slop-detect test` → 10 passed, 10 skipped
- greptile: 2 rounds (round 1: remote timeout ignored, SKIP_PLAYWRIGHT_DOWNLOAD wording, valid-path test — fixed)

## Notes for review
`--timeout` is local-only because `scanRemote` never transmits it. Failing closed matches `--design-md` + `--remote`. Did not change the stale "16-rule" README blurb — that is #84.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR wires the CLI navigation timeout into local scan options and rejects invalid or remote timeout usage.
- Adds parsing, validation, help text, and local forwarding for `--timeout`.
- Adds CLI coverage for accepted and rejected timeout combinations.
- Updates installation documentation to describe lazy Chromium installation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/bin/slop.ts | Parses and validates the local-only timeout option and forwards it through the existing scan options path. |
| packages/cli/test/cli.test.js | Covers timeout help text, invalid and missing values, valid parse-time acceptance, and rejection with remote scanning. |
| packages/cli/README.md | Correctly updates Chromium installation guidance to reflect lazy installation and the existing skip environment variable. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/slop-detect/commit/e916067c6722b6153d28b84b643b7c1163a5c8fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58186861)</sub>

<!-- /greptile_comment -->