### PR TITLE
docs: mark assets-raw as a 2026.08 evidence snapshot (#91)

### DIFF
--- a/assets-raw/README.md
+++ b/assets-raw/README.md
@@ -2,7 +2,7 @@
 
 Dated evidence snapshots. **Not** the live scoring engine.
 
-The live catalogue is `@slop-detect/core` (`DEFINITIONS_VERSION`, currently `2026.09`) and `GET /api/patterns`. Do not regenerate these files to chase the engine.
+The live catalogue is `@slop-detect/core` (`DEFINITIONS_VERSION`) and `GET /api/patterns`. Do not regenerate these files to chase the engine.
 
 | File | What it is |
 | --- | --- |

--- a/assets-raw/README.md
+++ b/assets-raw/README.md
@@ -1,0 +1,13 @@
+# assets-raw
+
+Dated evidence snapshots. **Not** the live scoring engine.
+
+The live catalogue is `@slop-detect/core` (`DEFINITIONS_VERSION`, currently `2026.09`) and `GET /api/patterns`. Do not regenerate these files to chase the engine.
+
+| File | What it is |
+| --- | --- |
+| `patterns.json` | Catalogue dump at definitions **2026.08** (`version` + 27 design patterns). |
+| `scan-hn.json` | Raw scan of `https://news.ycombinator.com` under defs **2026.08**. |
+| `scan-bolt.json` | Raw scan of `https://bolt.new` under defs **2026.08**. |
+
+Kept byte-stable on purpose (see root `.prettierignore` / ESLint ignore). Scores in the scan JSON are comparable only within `2026.08`.


### PR DESCRIPTION
Closes #91

## What
Adds `assets-raw/README.md` stating that `patterns.json`, `scan-hn.json`, and `scan-bolt.json` are dated **2026.08** evidence snapshots, not the live catalogue.

## Why
`assets-raw/patterns.json` is stamped `2026.08` while `@slop-detect/core` `DEFINITIONS_VERSION` is `2026.09`. Nothing in the repo consumes these files (they are prettier/eslint-ignored). They are raw scan evidence, not a stale engine dump to regenerate.

## How verified
- tests: no harness for ignored snapshot JSON; files are unused by build/test
- manual: `patterns.json` `"version":"2026.08"`; scan JSON `definitionsVersion":"2026.08"`; no imports of `assets-raw`
- greptile: 2 rounds, confidence 5/5, 1 finding fixed (do not hardcode live defs version)

## Notes for review
JSON cannot carry a header comment, so the annotation is a sibling README. Live version is referenced as `DEFINITIONS_VERSION` without pinning the current string.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds documentation clarifying that `assets-raw` contains fixed 2026.08 evidence snapshots rather than the live scoring catalogue.

- Identifies `@slop-detect/core` and `GET /api/patterns` as the live catalogue sources.
- Documents the snapshot version, contents, scan targets, byte-stability intent, and score-comparability boundary.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new documentation matches the snapshot metadata, live catalogue implementation, ignore configuration, and repository guidance on version-scoped score comparability.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| assets-raw/README.md | Accurately documents the three raw evidence files, their 2026.08 version, and their separation from the live catalogue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/slop-detect/commit/ae7477ce5a92c013deeb36ca0d7c83340cfe74b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58187744)</sub>

<!-- /greptile_comment -->