### PR TITLE
docs: stop hardcoding a 16-rule pattern count (#84)

### DIFF
--- a/apps/web/API.md
+++ b/apps/web/API.md
@@ -1,7 +1,7 @@
 # slop-detect Public API
 
 Public REST API for [slop-detect.com](https://slop-detect.com) — scan a URL for
-AI-design-slop patterns (live catalogue: [`/api/patterns`](/api/patterns)), get a
+AI-design-slop patterns (live catalogue: [`/api/patterns`](https://slop-detect.com/api/patterns)), get a
 remediation prompt, and embed live badges.
 
 - **Base URL:** `https://slop-detect.com` (also `https://slop-detector-8by.pages.dev`)

--- a/apps/web/API.md
+++ b/apps/web/API.md
@@ -1,8 +1,8 @@
 # slop-detect Public API
 
 Public REST API for [slop-detect.com](https://slop-detect.com) — scan a URL for
-the 16 "AI slop" design patterns, get a remediation prompt, and embed live
-badges.
+AI-design-slop patterns (live catalogue: [`/api/patterns`](/api/patterns)), get a
+remediation prompt, and embed live badges.
 
 - **Base URL:** `https://slop-detect.com` (also `https://slop-detector-8by.pages.dev`)
 - **Auth:** optional API key (see [Authentication](#authentication)). No key = anonymous tier.

--- a/apps/web/test/seo-version.test.js
+++ b/apps/web/test/seo-version.test.js
@@ -87,3 +87,18 @@ test('the llms developer surfaces advertise the full MCP tool list', () => {
     }
   }
 });
+
+test('published surfaces do not hardcode a 16-rule pattern count', () => {
+  const files = [
+    '../../../packages/cli/README.md',
+    '../../../packages/mcp/README.md',
+    '../../../packages/action/README.md',
+    '../../../packages/action/action.yml',
+    '../API.md',
+  ];
+  for (const rel of files) {
+    const txt = read(rel);
+    expect(txt.includes('16-rule'), rel).toBeFalsy();
+    expect(txt.includes('16 "AI slop"'), rel).toBeFalsy();
+  }
+});

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -1,6 +1,6 @@
 # Slop Detect Action
 
-> Score a landing page against the 16-rule **AI-design-slop fingerprint** and gate your PRs.
+> Score a landing page against the versioned **AI-design-slop fingerprint** and gate your PRs.
 
 A [composite GitHub Action](https://docs.github.com/actions/creating-actions/creating-a-composite-action)
 that scans a URL (typically a **deploy-preview**), posts a **sticky PR comment**

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -16,7 +16,7 @@
 #   body/title/branch content. Treat `url` as untrusted user input. Grant least
 #   privilege: `permissions: pull-requests: write` (plus `contents: read` if needed).
 name: 'Slop Detect'
-description: 'Score a landing page against the 16-rule AI-design-slop fingerprint and gate PRs.'
+description: 'Score a landing page against the AI-design-slop fingerprint and gate PRs.'
 author: 'Ravindra Kumar'
 
 branding:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # slop-detect
 
-> Score any landing page against the 16-rule AI-design-slop fingerprint, from your terminal.
+> Score any landing page against the versioned AI-design-slop fingerprint, from your terminal.
 
 Playwright-based, deterministic, zero-config. Perfect for CI, batch scans, and air-gapped audits.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > MCP server that lets AI coding agents scan landing pages for **AI-design-slop** and pull a ready-to-paste fix prompt — straight from the chat.
 
-Part of [slop-detect](https://slop-detect.com): the 16-rule fingerprint that catches Cursor / v0 / Lovable template slop in the wild. This package wraps the live `slop-detect.com` API as a [Model Context Protocol](https://modelcontextprotocol.io) server, so **Claude Code, Cursor, and Windsurf** can audit and de-slop pages without a browser or API key.
+Part of [slop-detect](https://slop-detect.com): the versioned fingerprint that catches Cursor / v0 / Lovable template slop in the wild (live catalogue: [`/api/patterns`](https://slop-detect.com/api/patterns)). This package wraps the live `slop-detect.com` API as a [Model Context Protocol](https://modelcontextprotocol.io) server, so **Claude Code, Cursor, and Windsurf** can audit and de-slop pages without a browser or API key.
 
 ## Tools
 


### PR DESCRIPTION
Closes #84

## What
Removes the stale "16-rule" / `16 "AI slop"` count from the five published surfaces listed in the issue. Copy now refers to the versioned fingerprint and the live catalogue at `https://slop-detect.com/api/patterns`.

## Why
The engine has 27 design patterns. AGENTS.md forbids hardcoding the count. These files still said 16.

## How verified
- tests: `apps/web/test/seo-version.test.js` — `published surfaces do not hardcode a 16-rule pattern count`
- manual: grep of the five files has no `16-rule` / `16 "AI slop"`
- greptile: 2 rounds, confidence 5/5, 2 findings fixed (absolute catalogue URL; regression test)

## Notes for review
Did not change `skills/README.md` (not in the issue file list). Follow-up: leftover hardcoded counts elsewhere.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces stale hardcoded “16-rule” references with count-independent wording tied to the versioned fingerprint and live pattern catalogue.

- Updates five published API, CLI, MCP, and GitHub Action surfaces.
- Adds a regression test preventing the two removed stale count phrases from returning.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it makes documentation-only wording corrections and adds a matching regression test without altering runtime behavior.

The changed documentation consistently removes the targeted stale count, the catalogue references use a stable absolute URL where needed, and no actionable failure was identified.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/API.md | Replaces the stale API pattern count with count-independent wording and an absolute live-catalogue link. |
| apps/web/test/seo-version.test.js | Adds focused coverage ensuring the five targeted published surfaces do not restore either stale 16-pattern phrase. |
| packages/action/README.md | Describes the Action as using a versioned fingerprint rather than a fixed-size rule set. |
| packages/action/action.yml | Removes the stale count from the GitHub Action marketplace description without changing Action behavior. |
| packages/cli/README.md | Updates the CLI introduction to refer to the versioned fingerprint without hardcoding its size. |
| packages/mcp/README.md | Replaces the stale count with versioned-fingerprint wording and links readers to the live catalogue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: use absolute /api/patterns URL and..."](https://github.com/ravidsrk/slop-detect/commit/2848cb0d9be0c01c794c50b793a50036461924bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58190050)</sub>

<!-- /greptile_comment -->