### PR TITLE
docs: drop 16-rule count from skills README (#112)

### DIFF
--- a/apps/web/test/seo-version.test.js
+++ b/apps/web/test/seo-version.test.js
@@ -95,6 +95,7 @@ test('published surfaces do not hardcode a 16-rule pattern count', () => {
     '../../../packages/action/README.md',
     '../../../packages/action/action.yml',
     '../API.md',
+    '../../../skills/README.md',
   ];
   for (const rel of files) {
     const txt = read(rel);

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,7 +4,7 @@ This directory ships [Agent Skills](https://agentskills.io) — portable, agent-
 
 | Skill | What it does |
 |---|---|
-| [`slop-detect/`](./slop-detect/) | Scan any URL for the 16-rule AI-design-slop fingerprint and generate a fix prompt |
+| [`slop-detect/`](./slop-detect/) | Scan any URL for the versioned AI-design-slop fingerprint and generate a fix prompt |
 
 ## Install
 


### PR DESCRIPTION
Closes #112

## What
Replaces the leftover `16-rule` wording in `skills/README.md` with "versioned AI-design-slop fingerprint". Extends the existing seo-version pin to include that file.

## Why
Follow-up from #84: that PR intentionally skipped `skills/README.md` because it was not in the original file list.

## How verified
- tests: `published surfaces do not hardcode a 16-rule pattern count` now includes `skills/README.md`
- greptile: 2 rounds (CLI JSON dump timed out; `greptile review status --json` on HEAD: completed, confidence 4/5, 0 comments)

## Notes for review
None.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the skills README to describe the AI-design-slop fingerprint as versioned rather than hardcoding a 16-rule count.
- Adds `skills/README.md` to the existing test that prevents published surfaces from hardcoding the old rule count.
- Keeps public documentation accurate as the fingerprint evolves.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the documentation update and corresponding regression coverage aligned.

The new test path resolves to the intended skills README, and the revised wording removes the stale hardcoded count without changing runtime behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/test/seo-version.test.js | Correctly extends the published-surface assertion to cover the skills README using the established relative-path convention. |
| skills/README.md | Replaces the stale fixed rule count with accurate version-independent wording. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: drop hardcoded 16-rule count from ..."](https://github.com/ravidsrk/slop-detect/commit/4648f50ec91f2471d8483d47595da1b5abd8b9eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58192203)</sub>

<!-- /greptile_comment -->