### PR TITLE
test: cover MCP dispatch and Action fail-under gate (#93)

### DIFF
--- a/packages/action/scan.mjs
+++ b/packages/action/scan.mjs
@@ -114,12 +114,22 @@ async function scan(apiBase, url) {
 // ---------------------------------------------------------------------------
 // Threshold gate. Returns { passed, reason } given the result + fail-under.
 // ---------------------------------------------------------------------------
-function evaluateThreshold(result, failUnder) {
+export function evaluateThreshold(result, failUnder) {
   const raw = String(failUnder ?? '').trim();
 
   // Empty → report-only, always passes.
   if (raw === '') {
     return { passed: true, mode: 'report-only', reason: 'No threshold set — report only.' };
+  }
+
+  if (result?.error || result?.blocked) {
+    return {
+      passed: false,
+      mode: 'failed-scan',
+      reason: result.error
+        ? `Scan error: ${result.error}`
+        : `Scan blocked (${result.code || 'blocked'}).`,
+    };
   }
 
   if (isLetterGrade(raw)) {

--- a/packages/action/test/threshold.test.js
+++ b/packages/action/test/threshold.test.js
@@ -1,0 +1,37 @@
+import { test, expect } from 'vitest';
+import { evaluateThreshold } from '../scan.mjs';
+
+test('empty fail-under is report-only and always passes', () => {
+  const r = evaluateThreshold({ score: 99, grade: 'F', blocked: true, error: 'nope' }, '');
+  expect(r.passed).toBe(true);
+  expect(r.mode).toBe('report-only');
+});
+
+test('numeric fail-under fails when score exceeds the limit (lower is better)', () => {
+  expect(evaluateThreshold({ score: 10, grade: 'B' }, '9').passed).toBe(false);
+  expect(evaluateThreshold({ score: 9, grade: 'A-' }, '9').passed).toBe(true);
+  expect(evaluateThreshold({ score: 0, grade: 'A+' }, '0').passed).toBe(true);
+});
+
+test('letter-grade fail-under fails when the page grades worse', () => {
+  expect(evaluateThreshold({ score: 12, grade: 'B-' }, 'B').passed).toBe(false);
+  expect(evaluateThreshold({ score: 8, grade: 'A' }, 'B').passed).toBe(true);
+  expect(evaluateThreshold({ score: 22, grade: 'C' }, 'B').mode).toBe('grade');
+});
+
+test('invalid fail-under fails closed', () => {
+  const r = evaluateThreshold({ score: 0, grade: 'A+' }, 'bogus');
+  expect(r.passed).toBe(false);
+  expect(r.mode).toBe('invalid');
+});
+
+test('error and blocked scans fail the gate when a threshold is set', () => {
+  expect(evaluateThreshold({ error: 'timeout' }, '27').passed).toBe(false);
+  expect(evaluateThreshold({ error: 'timeout' }, '27').mode).toBe('failed-scan');
+  expect(evaluateThreshold({ blocked: true, code: 'cloudflare_challenge' }, 'heavy').passed).toBe(
+    false
+  );
+  expect(evaluateThreshold({ blocked: true, code: 'cloudflare_challenge' }, 'B').passed).toBe(
+    false
+  );
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -27,7 +27,7 @@ function readVersion() {
 }
 const VERSION = readVersion();
 
-const TOOLS = [
+export const TOOLS = [
   {
     name: 'scan_page',
     description:
@@ -105,7 +105,7 @@ function asToolResult(text, isError = false) {
   return { content: [{ type: 'text', text }], isError };
 }
 
-async function handleCall(name, args) {
+export async function handleCall(name, args) {
   const url = args && typeof args.url === 'string' ? args.url.trim() : '';
   if (!url) {
     return asToolResult('Missing required argument "url" (a string).', true);

--- a/packages/mcp/test/server.test.js
+++ b/packages/mcp/test/server.test.js
@@ -1,0 +1,114 @@
+import { test, expect, afterEach } from 'vitest';
+import { handleCall, TOOLS } from '../src/server.ts';
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+});
+
+function jsonRes(body, { ok = true, status = 200, text } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (text != null ? text : JSON.stringify(body)),
+  };
+}
+
+test('TOOLS lists all four tool names with url required', () => {
+  expect(TOOLS.map((t) => t.name)).toEqual([
+    'scan_page',
+    'check_aeo',
+    'check_design_system',
+    'fix_prompt',
+  ]);
+  for (const t of TOOLS) {
+    expect(t.inputSchema.required).toContain('url');
+  }
+  const system = TOOLS.find((t) => t.name === 'check_design_system');
+  expect(system.inputSchema.properties.design_md_url).toBeTruthy();
+});
+
+test('missing url is a tool error, not a crash', async () => {
+  let called = false;
+  global.fetch = async () => {
+    called = true;
+    return jsonRes({});
+  };
+  const r = await handleCall('scan_page', {});
+  expect(r.isError).toBe(true);
+  expect(r.content[0].text).toMatch(/Missing required argument "url"/);
+  expect(called).toBe(false);
+});
+
+test('scan_page POSTs /api/scan and formats the result', async () => {
+  const calls = [];
+  global.fetch = async (url, opts) => {
+    calls.push({ url: String(url), body: JSON.parse(opts.body) });
+    return jsonRes({
+      grade: 'A',
+      score: 4,
+      tier: 'Clean',
+      patternsFlagged: 0,
+      patternsTotal: 27,
+      patterns: [],
+    });
+  };
+  const r = await handleCall('scan_page', { url: ' https://example.com ' });
+  expect(r.isError).toBeFalsy();
+  expect(calls[0].url).toMatch(/\/api\/scan$/);
+  expect(calls[0].body).toEqual({ url: 'https://example.com' });
+  expect(r.content[0].text).toMatch(/Score: 4\/100/);
+});
+
+test('check_aeo POSTs /api/aeo; check_design_system forwards design_md_url', async () => {
+  const calls = [];
+  global.fetch = async (url, opts) => {
+    calls.push({ url: String(url), body: JSON.parse(opts.body) });
+    if (String(url).includes('/api/aeo')) {
+      return jsonRes({
+        url: 'https://example.com',
+        score: 80,
+        maxScore: 100,
+        tier: 'AI-Ready',
+        requiredFailed: 0,
+        recommendedFailed: 0,
+        failed: [],
+        passed: [],
+      });
+    }
+    return jsonRes({
+      system: {
+        declared: true,
+        score: 90,
+        tier: 'Aligned',
+        name: 'Heritage',
+        checksEvaluated: 5,
+        checksSkipped: 0,
+        drift: [],
+      },
+    });
+  };
+  const aeo = await handleCall('check_aeo', { url: 'https://example.com' });
+  const sys = await handleCall('check_design_system', {
+    url: 'https://example.com',
+    design_md_url: 'https://example.com/DESIGN.md',
+  });
+  expect(calls[0].url).toMatch(/\/api\/aeo$/);
+  expect(calls[1].body).toEqual({
+    url: 'https://example.com',
+    designMd: 'https://example.com/DESIGN.md',
+    share: false,
+  });
+  expect(aeo.content[0].text).toMatch(/AI-Ready/);
+  expect(sys.content[0].text).toMatch(/Aligned/);
+});
+
+test('fix_prompt returns prompt text; unknown tools error', async () => {
+  global.fetch = async () => jsonRes(null, { text: 'de-slop this page' });
+  const ok = await handleCall('fix_prompt', { url: 'https://example.com' });
+  expect(ok.content[0].text).toBe('de-slop this page');
+  const bad = await handleCall('nope', { url: 'https://example.com' });
+  expect(bad.isError).toBe(true);
+  expect(bad.content[0].text).toMatch(/Unknown tool/);
+});


### PR DESCRIPTION
Closes #93

## What
Exports `evaluateThreshold` from the GitHub Action and `handleCall`/`TOOLS` from the MCP server. Adds unit tests for numeric and letter-grade gates, error/blocked always-fail when a threshold is set, and MCP dispatch of all four tools with a stubbed fetch client.

## Why
Those two user-facing contracts had no tests (Action gate only had pull_request_target notice coverage; MCP only api/formatters).

## How verified
- tests: `packages/action/test/threshold.test.js` (5); `packages/mcp/test/server.test.js` (5); existing action/mcp tests still pass
- greptile: 1 round, confidence 4/5, 2 P2 rebutted

## Notes for review
CLI golden scan path remains `RUN_GOLDEN=1`-gated (#92). Empty `fail-under` stays report-only even on error, matching "no threshold set".

Greptile P2: production `scan()` `die()`s on HTTP errors before the gate — the exported `evaluateThreshold` is the unit under test; error/blocked objects are the contract if a result ever reaches it. MCP `createServer` is a try/catch around `handleCall`; dispatch tests stub `fetch` and call `handleCall`, which is the tool-name switch the issue asked for.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR exposes internal Action and MCP dispatch helpers for direct unit testing and adds coverage for threshold gating and all four MCP tools.
- Exports `evaluateThreshold`, `handleCall`, and `TOOLS` for test access.
- Makes configured thresholds fail closed for error or blocked result objects.
- Adds numeric, letter-grade, invalid-input, report-only, and MCP dispatch tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The production behavior remains intact, imports are side-effect safe, and the added tests exercise the intended Action threshold and MCP dispatch contracts.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/action/scan.mjs | Exports threshold evaluation and adds fail-closed handling for error or blocked result objects without affecting the guarded Action entrypoint. |
| packages/action/test/threshold.test.js | Adds focused coverage for report-only, numeric, grade, invalid, and failed-scan threshold outcomes. |
| packages/mcp/src/server.ts | Exports the existing tool definitions and dispatch helper for direct testing without changing server dispatch behavior. |
| packages/mcp/test/server.test.js | Adds stubbed-fetch tests covering tool metadata, argument validation, dispatch, request payloads, formatting, and unknown tools. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover MCP tool dispatch and Action..."](https://github.com/ravidsrk/slop-detect/commit/abdb3bebcff2b5ab4396fdb09e014a51b8280b6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58194915)</sub>

<!-- /greptile_comment -->