### PR TITLE
fix: address leftover Greptile P1s from #113 and #117

### DIFF
--- a/apps/web/test/seo-version.test.js
+++ b/apps/web/test/seo-version.test.js
@@ -63,9 +63,8 @@ test('publishable packages share one version and a changesets fixed group', () =
   const core = JSON.parse(read('../../../packages/core/package.json'));
   const cli = JSON.parse(read('../../../packages/cli/package.json'));
   const mcp = JSON.parse(read('../../../packages/mcp/package.json'));
-  expect(core.version).toBe(pkg.version);
-  expect(cli.version).toBe(pkg.version);
-  expect(mcp.version).toBe(pkg.version);
+  expect(cli.version).toBe(core.version);
+  expect(mcp.version).toBe(core.version);
   const changesets = JSON.parse(read('../../../.changeset/config.json'));
   expect(changesets.fixed).toEqual([['@slop-detect/core', 'slop-detect', 'slop-detect-mcp']]);
 });

--- a/packages/cli/src/detector.ts
+++ b/packages/cli/src/detector.ts
@@ -35,6 +35,10 @@ export interface ScanOptions {
   includeSystem?: boolean;
 }
 
+export function shouldIncludeSystem(opts: ScanOptions = {}) {
+  return !!(opts.designMd || opts.includeSystem);
+}
+
 // Playwright is heavy (pulls in a ~150 MB browser) and is ONLY needed for an
 // actual scan. Import it lazily so `--help`, flag validation, error paths, and
 // the `--remote` API mode all work without it installed. A top-level import here
@@ -218,7 +222,7 @@ export async function scanUrl(url, opts: ScanOptions = {}) {
     await page.evaluate(waitFontsReadyInPage, SCAN_PAGE_WAIT.fontsReadyTimeoutMs);
 
     const data = await page.evaluate(
-      buildPageScript({ includeSystem: !!(opts.designMd || opts.includeSystem) })
+      buildPageScript({ includeSystem: shouldIncludeSystem(opts) })
     );
 
     // Anti-bot / dead-page detection — don't silently return Clean 0.

--- a/packages/cli/src/detector.ts
+++ b/packages/cli/src/detector.ts
@@ -29,6 +29,10 @@ export interface ScanOptions {
   designMd?: string;
   api?: string;
   apiKey?: string;
+  // Kept on the public options object so existing TS call sites that pass
+  // includeSystem: true keep typechecking. Runtime equivalent: inject the
+  // system extractor (also implied by designMd).
+  includeSystem?: boolean;
 }
 
 // Playwright is heavy (pulls in a ~150 MB browser) and is ONLY needed for an
@@ -213,7 +217,9 @@ export async function scanUrl(url, opts: ScanOptions = {}) {
     await page.waitForTimeout(SCAN_PAGE_WAIT.postNetworkSettleMs);
     await page.evaluate(waitFontsReadyInPage, SCAN_PAGE_WAIT.fontsReadyTimeoutMs);
 
-    const data = await page.evaluate(buildPageScript({ includeSystem: !!opts.designMd }));
+    const data = await page.evaluate(
+      buildPageScript({ includeSystem: !!(opts.designMd || opts.includeSystem) })
+    );
 
     // Anti-bot / dead-page detection — don't silently return Clean 0.
     const blocked = detectBlocked(data);

--- a/packages/cli/src/detector.ts
+++ b/packages/cli/src/detector.ts
@@ -221,9 +221,7 @@ export async function scanUrl(url, opts: ScanOptions = {}) {
     await page.waitForTimeout(SCAN_PAGE_WAIT.postNetworkSettleMs);
     await page.evaluate(waitFontsReadyInPage, SCAN_PAGE_WAIT.fontsReadyTimeoutMs);
 
-    const data = await page.evaluate(
-      buildPageScript({ includeSystem: shouldIncludeSystem(opts) })
-    );
+    const data = await page.evaluate(buildPageScript({ includeSystem: shouldIncludeSystem(opts) }));
 
     // Anti-bot / dead-page detection — don't silently return Clean 0.
     const blocked = detectBlocked(data);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,8 @@
-export { scanUrl, scanRemote, aeoRemote, loadDesignMd, type ScanOptions } from './detector.js';
+export {
+  scanUrl,
+  scanRemote,
+  aeoRemote,
+  loadDesignMd,
+  shouldIncludeSystem,
+  type ScanOptions,
+} from './detector.js';

--- a/packages/cli/test/scan-options.test.js
+++ b/packages/cli/test/scan-options.test.js
@@ -1,0 +1,13 @@
+import { test, expect } from 'vitest';
+import { shouldIncludeSystem } from '../src/index.ts';
+
+test('includeSystem remains a public ScanOptions field and enables extraction', () => {
+  expect(shouldIncludeSystem({})).toBe(false);
+  expect(shouldIncludeSystem({ includeSystem: true })).toBe(true);
+  expect(shouldIncludeSystem({ includeSystem: false })).toBe(false);
+});
+
+test('designMd still implies system extraction', () => {
+  expect(shouldIncludeSystem({ designMd: 'tokens: {}' })).toBe(true);
+  expect(shouldIncludeSystem({ designMd: 'tokens: {}', includeSystem: false })).toBe(true);
+});


### PR DESCRIPTION
## What
Addresses two unanswered Greptile P1s on already-merged PRs:

- #113: restore `ScanOptions.includeSystem` on the public CLI options type and honor it (`designMd` still implies it). `shouldIncludeSystem` is tested without a browser.
- #117: pin publishable package versions to each other, not to the private root `package.json`.

## Why
Those threads were merged without a reply. The findings are valid.

## How verified
- tests: `packages/cli/test/scan-options.test.js`; `seo-version.test.js` (8); `slop-detect` typecheck
- greptile: 2 rounds, confidence 5/5, 1 finding fixed (option coverage)

## Notes for review
Does not reopen #94/#89.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes two previously requested fixes: it restores the CLI’s public `includeSystem` scan option and makes package-version consistency independent of the private monorepo root.
- Adds and exports `shouldIncludeSystem`, using it when constructing the browser-side extraction script.
- Adds focused coverage for explicit `includeSystem` values and the existing `designMd` implication.
- Verifies that the three publishable packages share a version and remain in one Changesets fixed group.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/detector.ts | Restores `ScanOptions.includeSystem` and consistently enables system-context extraction when it or `designMd` is provided. |
| packages/cli/src/index.ts | Exposes the new option helper alongside the existing public scan API and options type. |
| packages/cli/test/scan-options.test.js | Covers explicit option values and confirms that `designMd` continues to imply system extraction. |
| apps/web/test/seo-version.test.js | Correctly compares the publishable fixed-group package versions to one another instead of the private root package. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style: let prettier collapse the page.ev..."](https://github.com/ravidsrk/slop-detect/commit/04f729edd86b54ba2557047ae25978848e6704d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58196349)</sub>

<!-- /greptile_comment -->